### PR TITLE
feat: Add design-epic workflow with DAG units and fan-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ __marimo__/
 # autocode runtime state (only meaningful when this repo is checked out at ~/.autocode/)
 .last-fetch
 .update-available
+.DS_Store

--- a/autocode/_config/conventions/issue-lifecycle.md
+++ b/autocode/_config/conventions/issue-lifecycle.md
@@ -15,9 +15,10 @@ Autocode reasons about issues using four states, regardless of provider:
 
 | Issue kind | todo -> in-progress | in-progress -> in-review | in-review -> done |
 |---|---|---|---|
-| Proposal | Worktree / branch created for the proposal document | Proposal document PR opened | Proposal document PR merged |
-| Epic | First sub-issue starts | Final epic-level PR opened | Epic-level PR merged |
-| Sub-issue | Sub-issue work scheduled on a worktree | Sub-issue PR review created | Sub-issue PR merged into the epic branch |
+| Epic | First unit starts (`impl-start`) | n/a (no aggregate epic PR) | All units done; `impl-archive` closes the epic |
+| Sub-issue (unit) | `impl-start` picks the unit | `impl-push` opens the unit PR | Unit PR merges (auto-closes via `Closes #`) |
+
+The epic has no `in-review` state: there is no aggregate epic PR. Each unit has its own PR that merges to the default branch; a unit's dependencies being `done` means their code is already on the default branch.
 
 ## Inspect
 

--- a/autocode/_config/conventions/issue-types.md
+++ b/autocode/_config/conventions/issue-types.md
@@ -17,7 +17,7 @@ Capture what issue categories this repo uses, what each means, and which commit 
 
 ## Default
 
-Five types: `epic`, `story`, `task`, `bug`, `proposal`. Each maps to one provider concept (label, issue-type, or whatever the tracker offers). The `proposal` type is registered by the `design-plan` flow for design proposals tracked as their own tickets; its `commit_type` is `docs` so design docs commit as `docs:` rather than `feat:`.
+Four types: `epic`, `story`, `task`, `bug`. Each maps to one provider concept (label, issue-type, or whatever the tracker offers). Design fan-out creates an `epic` for a multi-unit design; the units (sub-issues) take `story`, `task`, or `bug` from each unit file's `type:` frontmatter. Design folders themselves are pushed as `docs:`-typed branches and are not tracked by an issue.
 
 ## Output format
 
@@ -34,5 +34,5 @@ Five types: `epic`, `story`, `task`, `bug`, `proposal`. Each maps to one provide
 
 ## Selection rules
 
-<when to use which type; e.g. epic vs story boundaries, when to file a proposal>
+<when to use which type; e.g. epic vs story boundaries, story vs task>
 ```

--- a/autocode/_config/settings-schema.md
+++ b/autocode/_config/settings-schema.md
@@ -9,7 +9,7 @@ Each key has exactly one home. No merging, no precedence rules. Scope is determi
 
 | Namespace | Scope | File |
 |---|---|---|
-| `provider.*`, `workflow.*` | shared | `settings.json` |
+| `provider.*` | shared | `settings.json` |
 | `paths.*` | local | `settings.local.json` |
 
 `/autocode-setup` writes `AUTOCODE_CONFIG_DIR` into a Claude Code settings file (`.claude/settings.json` for the in-repo default, `.claude/settings.local.json` otherwise) so readers can locate the config dir from any session.
@@ -21,7 +21,6 @@ Each key has exactly one home. No merging, no precedence rules. Scope is determi
 | `provider.issue-tracker` | string | (required) | Which issue-tracker provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/issue-tracker/<value>/<feature>.sh`. Supported values: `github`. |
 | `provider.git-remote` | string | (required) | Which git-remote provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/git-remote/<value>/<feature>.sh`. Supported values: `github`. |
 | `provider.ci` | string | value of `provider.git-remote` | Which ci provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/ci/<value>/<feature>.sh`. When unset or empty, the dispatcher falls back to `provider.git-remote`. Supported values: `github`. |
-| `workflow.auto-merge-sub-issues` | bool | `false` | If true, sub-issue PRs auto-merge once required checks pass. Honored by workflow-phase skills (when they land). |
 
 ## Local keys (`settings.local.json`)
 

--- a/autocode/design/CLAUDE.md
+++ b/autocode/design/CLAUDE.md
@@ -1,3 +1,5 @@
 # design/
 
-Planning and research before code lands. Skills that plan, critique, push, and iterate on design docs live here. The `codebase-researcher` and `web-researcher` agents are read-only helpers spawned by those skills.
+Planning and research before code lands. Skills that plan, critique, push, iterate on, and fan out design docs live here (`design-plan`, `design-plan-critique`, `design-plan-push`, `design-plan-iterate`, `design-fanout`). The `codebase-researcher` and `web-researcher` agents are read-only helpers spawned by those skills.
+
+`design-folder.md` is the canonical layout for a design epic (folder, units DAG, fan-out to issues, progress log, archive). It is a fixed spec, not a scaffolded convention; design and impl skills `@`-import it.

--- a/autocode/design/design-folder.md
+++ b/autocode/design/design-folder.md
@@ -1,0 +1,149 @@
+# Design folder layout
+
+Canonical structure for a design epic: one folder holding the epic plan, its independent units of work (a DAG), and the living progress log. Fixed across all autocode repos. `design-plan` creates it; the design-PR fan-out turns it into issues; `impl-start` consumes it; the progress log tracks it. Skills `@`-import this file rather than restating the layout.
+
+## Location and naming
+
+```
+.autocode/design/<id>-<shortname>/
+```
+
+- `<id>`: UTC timestamp, `date -u +%Y%m%dT%H%M%SZ` (e.g. `20260601T143022Z`). Lexicographically sortable so `ls` orders epics by creation. Generated once at `design-plan` time and used as the folder name immediately (it depends on nothing external).
+- `<shortname>`: kebab-case, 2-4 words, human label.
+- The folder is never renamed. No issue number is ever encoded in the path; issues do not exist until the design PR merges, and the link runs issue -> folder (see Fan-out).
+
+## Contents
+
+```
+.autocode/design/<id>-<shortname>/
+  DESIGN.md             # epic plan; immutable after the design PR merges
+  units/<slug>.md       # one per unit of work; immutable after merge
+  PROGRESS.md           # epic rollup, one block per merged unit; living
+  progress/<slug>.md    # per-unit detailed log; living
+```
+
+Immutable vs living: `DESIGN.md` and `units/*.md` are the spec; once the design PR merges they are not edited (corrections go through a new design PR). `PROGRESS.md` and `progress/*.md` are living, written during implementation. This split is what makes the immutable spec safe to fan out to issues while progress accrues independently.
+
+### Single-unit (flat) designs
+
+When the work is one PR's worth, the epic and the unit are the same thing. The design is flat: no `units/` directory. `DESIGN.md` carries the unit frontmatter (`type:`) and an `## Implementation` section, and is its own unit (slug = `<shortname>`). Fan-out then creates exactly one issue (no epic/sub-issue split), still tagged `autocode-epic:<id>` so discovery is identical. `progress/<shortname>.md` is the only per-unit log.
+
+The rule everything keys on: `units/` present -> multi-unit epic; `units/` absent -> flat single issue. Use flat when the plan would otherwise produce a single unit; use multi-unit when the work splits into independently mergeable pieces.
+
+All four are committed. Only the transient state files `.autocode/.impl-context` and `.autocode/.progress-last-sha` (written by `impl-start` and the progress hook) are gitignored.
+
+## DESIGN.md
+
+The epic plan. Sections:
+
+- `## Summary`: one paragraph. Verbatim source for the epic issue body at fan-out, so it must stand alone.
+- `## Architecture impact`, `## Edge cases and error handling`, `## Testing strategy`, `## Sources`: as in the `design-plan` flow.
+- `## Units`: the DAG overview. One row per unit: slug, one-line deliverable, `depends-on`. This is the human-readable index; the authoritative dependency data lives in each unit file's frontmatter.
+
+## units/<slug>.md
+
+One independent unit of work. The filename stem is the unit `<slug>` (kebab-case, unique within the folder). Frontmatter:
+
+```yaml
+---
+depends-on: [<slug>, ...]   # other unit slugs in this folder; [] if none
+type: <issue-type>          # one of the repo's issue types, e.g. task, story, bug
+---
+```
+
+Body sections:
+
+- `## Summary`: one paragraph. Verbatim source for the sub-issue body at fan-out.
+- `## Implementation`: deliverable, files to create/modify, public interfaces, tests that prove it. High-level; the implementer owns logic.
+
+A unit is a single PR's worth of work. Dependencies between units in the same folder are expected and fine; a unit with `depends-on: []` is immediately workable. The DAG must be acyclic.
+
+## Fan-out to issues
+
+On design-PR merge (mechanically by the GH Action, or via the `design-fanout` skill), each design folder becomes:
+
+- One epic issue: title from `<shortname>`, body = `DESIGN.md` `## Summary` + a link to `DESIGN.md` at the merge commit + the epic marker. Issue type `epic`.
+- One sub-issue per unit: title from the unit, body = the unit's `## Summary` + a link to `units/<slug>.md` at the merge commit + the unit marker. Issue type from the unit's `type` frontmatter. Linked as a sub-issue of the epic.
+
+No issue number is written back into any file. The link is one-directional (issue -> folder) via the body link and the markers below.
+
+### Tags and markers
+
+Every issue of an epic carries:
+
+- Epic tag `autocode-epic:<id>` (a tracker label or equivalent). Applied to the epic issue and every unit sub-issue. List-filterable in one live call, so discovery never depends on a search index.
+- Body marker, in an HTML comment so it survives rendering and is never shown:
+  - epic: `<!-- autocode:epic=<id> -->`
+  - unit: `<!-- autocode:unit=<id>/<slug> -->`
+
+### Discovery
+
+To find the issue for a given unit, or to read the state of an epic's units, list issues by the epic tag and match markers:
+
+```
+list issues with tag autocode-epic:<id>, state=all   # one live provider call
+-> epic = the body with autocode:epic=<id>
+-> unit = the body with autocode:unit=<id>/<slug>
+-> each unit's done-state = that issue's state (see issue-lifecycle)
+```
+
+`impl-start` uses this to compute the DAG-ready set (a unit is workable when every slug in its `depends-on` has a closed/done sub-issue) and to find the sub-issue to link a unit PR to.
+
+## PROGRESS.md
+
+Epic-level rollup, one block appended per merged unit. Written by the unit's PR at merge time (the `impl-push` path appends in-PR; the optional GH Action appends post-merge). Format:
+
+```markdown
+# Progress: <shortname>
+
+## <slug> — <merge date>
+
+PR: <url>  Unit: <sub-issue ref>
+<one-paragraph what-shipped>
+Notes: <issues hit, follow-ups, gotchas worth knowing> (omit if none)
+```
+
+A new session that finds an in-flight block from an abandoned session marks it with a `---` rule and starts a fresh block below; no concurrency coordination beyond that.
+
+## progress/<slug>.md
+
+Per-unit detailed log, owned solely by that unit's worktree (no cross-file writes, so parallel units never contend). `impl-start` seeds the header; the `progress-logger` agent appends entries as work proceeds. Format:
+
+```markdown
+# <slug>
+
+Epic: <id>-<shortname>  Branch: <branch>  Started: <date>
+
+## <entry timestamp>
+<what was attempted, what worked, what failed, troubleshooting steps>
+```
+
+Entries capture lessons for any agent that later continues this unit or a sibling unit in the same epic. Written for both completed and abandoned units.
+
+## Lifecycle
+
+States are the four-state model from the `issue-lifecycle` convention (`todo`, `in-progress`, `in-review`, `done`); the convention maps them to the tracker (GitHub: open + `autocode:<state>` label for the open states, `closed` for `done`).
+
+Unit sub-issue:
+
+| Transition | Trigger |
+|---|---|
+| (created) -> `todo` | fan-out creates the sub-issue |
+| `todo` -> `in-progress` | `impl-start` picks the unit (`issue-transition <unit> in-progress`) |
+| `in-progress` -> `in-review` | `impl-push` opens the unit PR (`issue-transition <unit> in-review`); PR body carries `Closes #<unit>` |
+| `in-review` -> `done` | the unit PR merges; the tracker auto-closes the sub-issue via the `Closes` link |
+
+Epic issue (multi-unit only): no aggregate epic PR exists, so the epic has no `in-review`.
+
+| Transition | Trigger |
+|---|---|
+| (created) -> `todo` | fan-out creates the epic |
+| `todo` -> `in-progress` | the first unit moves to `in-progress` (`impl-start` flips the epic if still `todo`) |
+| `in-progress` -> `done` | every unit is `done`; `impl-archive` (or the GH Action) closes the epic |
+
+Flat single-unit design: one issue, no epic/unit split. It runs the unit row directly (`todo` -> `in-progress` -> `in-review` -> `done`).
+
+Done semantics:
+
+- Unit done: its sub-issue is closed (and a `PROGRESS.md` block exists). Read from the discovery call; low-level, per-unit visibility.
+- Epic done: the whole folder is moved to `.autocode/archive/<id>-<shortname>/`. Location is the epic-level source of truth. `impl-archive` (manual) or the GH Action moves it once every unit is done and closes the epic.

--- a/autocode/design/skills/design-fanout/SKILL.md
+++ b/autocode/design/skills/design-fanout/SKILL.md
@@ -1,0 +1,40 @@
+# Design fanout
+
+Turn a merged design folder into tracker issues: an epic plus one sub-issue per unit (or a single issue for a flat design). The manual, Claude-driven counterpart of the optional GitHub Action. Run after the design PR merges.
+
+Layout, markers, and labels: `@~/.autocode/autocode/design/design-folder.md`. This skill produces exactly the tags and markers it specifies, so `impl-start` discovery works identically whether issues were created here or by the Action.
+
+## Args
+
+`<id | shortname>` (the design folder prefix or suffix). Default: the most recent folder under `.autocode/design/`. On ambiguity, ask via `AskUserQuestion`.
+
+## Discovery
+
+- Glob `.autocode/design/<id>-*` or `*-<shortname>`. Resolve to one folder; read its `DESIGN.md` and any `units/*.md`.
+- Derive `<id>` and `<shortname>` from the folder name.
+- Multi-unit if `units/` exists and is non-empty; flat otherwise.
+
+## Workflow
+
+1. Build the permalink base. `sha=$(git log -1 --format=%H -- <folder>)` (the commit that last touched the folder, i.e. the merge). `repo_url=$(gh repo view --json url --jq .url)`. A file's link is `<repo_url>/blob/<sha>/<repo-relative-path>`. (Permalink shape is GitHub-specific; acceptable while `git-remote` is GitHub.)
+2. Ensure the epic tag exists: `provider/run.sh issue-tracker issue-label-ensure "autocode-epic:<id>" --description "autocode design epic <id>"`.
+3. Idempotency check. `provider/run.sh issue-tracker issue-list --label "autocode-epic:<id>" --state all`. Parse the returned `description` of each issue for existing markers (`autocode:epic=<id>`, `autocode:unit=<id>/<slug>`). Skip creating anything whose marker is already present; report it as existing.
+4. Create issues. For each issue, build a body temp file: the source file's `## Summary` paragraph, then a blank line, then `Design: <permalink>`, then a blank line, then the HTML-comment marker. Write it with the Write tool, then call the provider.
+
+   Multi-unit:
+   - Epic (if its marker is absent): body from `DESIGN.md` `## Summary` + `DESIGN.md` permalink + `<!-- autocode:epic=<id> -->`. `provider/run.sh issue-tracker issue-create -t epic -s "<shortname>" -b "<body>" -l "autocode-epic:<id>"`. Capture the epic number.
+   - Each unit `units/<slug>.md` (if its marker is absent): body from the unit's `## Summary` + the unit file permalink + `<!-- autocode:unit=<id>/<slug> -->`. `provider/run.sh issue-tracker issue-create -t <unit.type> -s "<slug>" -b "<body>" -l "autocode-epic:<id>" -P <epic-number>`.
+
+   Flat (no `units/`):
+   - One issue (if `autocode:epic=<id>` marker absent): body from `DESIGN.md` `## Summary` + permalink + `<!-- autocode:epic=<id> -->`. `provider/run.sh issue-tracker issue-create -t <DESIGN.type> -s "<shortname>" -b "<body>" -l "autocode-epic:<id>"`. No parent. This issue is both epic and unit.
+5. Report a table: each issue's role (epic / unit slug), number, and created-or-existing.
+
+## Rules
+
+- All tracker writes go through `provider/run.sh issue-tracker ...`. Never call `gh issue` directly. (`gh repo view` for the permalink base is the only direct `gh` read.)
+- Idempotent. Re-running creates only the issues whose markers are missing; never duplicates.
+- The unit issue `type` comes from the unit file's `type:` frontmatter; the epic is always type `epic`; a flat design's single issue takes `DESIGN.md`'s `type:` frontmatter.
+- Do not write issue numbers back into any file. The link runs issue -> folder via the permalink and markers.
+- Run only after the design PR merged; the permalink must point at a commit on the default branch.
+
+$ARGUMENTS

--- a/autocode/design/skills/design-plan-critique/SKILL.md
+++ b/autocode/design/skills/design-plan-critique/SKILL.md
@@ -5,28 +5,28 @@ Iteratively interrogate a written plan: generate follow-up questions, resolve th
 ## Args
 
 One of:
-- `<path>`: the temp path returned by `design-plan --temp`.
-- `<ticket-num>` (e.g. `42`, `BA-1234`).
+- `<path>`: the temp folder returned by `design-plan --temp`.
+- `<id>` (the design folder timestamp prefix).
 - `<feature-shortname>` (the kebab-case suffix of a `.autocode/design/*/` directory).
 - nothing: defaults to the most recent `.autocode/design/*` dir. On ambiguity, ask via `AskUserQuestion`.
 
 ## Discovery
 
-- If arg looks like a path and the file exists, use it.
-- Else glob `.autocode/design/<ticket-num>-*` or `*-<shortname>`.
+- If arg looks like a path to a folder, use it.
+- Else glob `.autocode/design/<id>-*` or `*-<shortname>`.
 - On no match, ask the user via `AskUserQuestion`.
 
 ## Workflow
 
-1. Read the plan.
-2. Generate follow-up questions per section. Bias toward: untested assumptions, interface shapes, error modes, concurrency, security, data shape, ordering invariants.
+1. Read the design: `DESIGN.md` and every `units/*.md` (multi-unit) or just `DESIGN.md` (flat).
+2. Generate follow-up questions per section and per unit. Bias toward: untested assumptions, interface shapes, error modes, concurrency, security, data shape, ordering invariants, and whether the unit decomposition and `depends-on` edges are right.
 3. For each question, decide: ask the user, dispatch a researcher, or both (parallel where possible).
-4. Apply resolutions to the plan file in place. Preserve existing structure; add a `## Critique log` at the bottom that lists each iteration's questions and resolutions (one line each).
+4. Apply resolutions in place to the relevant file (`DESIGN.md` or the unit file). Preserve existing structure; add a `## Critique log` at the bottom of `DESIGN.md` that lists each iteration's questions and resolutions (one line each).
 5. Repeat steps 2-4 until a pass produces no new questions. Cap iterations at 5. On cap, ask the user via `AskUserQuestion` whether to continue.
 
 ## Output
 
-Updates the plan file in place. Final report is a summary of iterations and what changed (the critique log already captures detail; the report is a 2-3 line summary).
+Updates the design files in place. Final report is a summary of iterations and what changed (the critique log already captures detail; the report is a 2-3 line summary).
 
 ## Rules
 

--- a/autocode/design/skills/design-plan-iterate/SKILL.md
+++ b/autocode/design/skills/design-plan-iterate/SKILL.md
@@ -9,9 +9,9 @@ Triage and apply review comments on a design-doc PR.
 ## Differences vs pr-review
 
 - Triage rubric weighs design clarity, scope alignment, and assumption auditing over code correctness.
-- Disagreement responses cite specific plan sections (architecture impact, edge cases, testing strategy).
-- Edits land in `DESIGN.md`, not in source code.
-- No build verify step (the PR contains a markdown file, not code).
+- Disagreement responses cite specific plan sections (architecture impact, edge cases, testing strategy) or specific units.
+- Edits land in the design folder (`DESIGN.md` or `units/*.md`), not in source code.
+- No build verify step (the PR contains markdown, not code).
 - Commits go through `git-commit`.
 
 ## Workflow
@@ -36,7 +36,7 @@ Triage and apply review comments on a design-doc PR.
    | 30-69 | Optional; update if trivial, else resolve with explanation |
    | 0-29 | Resolve as spurious |
 
-4. Apply valid edits to the `DESIGN.md` file. Group related edits.
+4. Apply valid edits to `DESIGN.md` or the relevant `units/*.md`. Group related edits.
 5. Delegate commit to `git-commit`.
 6. Reply and resolve threads:
    - `provider/run.sh git-remote pr-comment-reply <pr> <comment-id> "<text>"` for each thread that needs a reply.
@@ -46,8 +46,8 @@ Triage and apply review comments on a design-doc PR.
 
 ## Rules
 
-- Disagreement is direct but respectful. Cite specific plan sections.
-- Edits land in `DESIGN.md` only. Never edit source code from this skill.
+- Disagreement is direct but respectful. Cite specific plan sections or units.
+- Edits land in the design folder only (`DESIGN.md` or `units/*.md`). Never edit source code from this skill.
 - No verify step (the PR is markdown).
 - Never `--no-verify` on commits; delegated `git-commit` handles hook failures.
 - Never resolve a thread without an explanation comment.

--- a/autocode/design/skills/design-plan-push/SKILL.md
+++ b/autocode/design/skills/design-plan-push/SKILL.md
@@ -1,37 +1,38 @@
 # Design plan push
 
-Open a PR for a written design doc.
+Open a PR for a design folder (the epic plan plus its units). Merging it is what triggers fan-out into issues.
+
+Layout: `@~/.autocode/autocode/design/design-folder.md`.
 
 ## Args
 
-`<ticket-num>` or `<feature-shortname>` (same discovery as `design-plan-critique`).
+`<id>` or `<shortname>` (the design folder prefix or suffix).
 
-`--temp` plans are refused. The user must promote the temp plan to a tracked `.autocode/design/` directory first.
+`--temp` plans are refused. The user must promote the temp folder into `.autocode/design/` first.
 
 ## Discovery
 
-- If arg looks like a path: refuse (temp plans not supported here).
-- Else glob `.autocode/design/<ticket-num>-*` or `*-<shortname>`.
+- If the arg looks like a path: refuse (temp plans not supported here).
+- Else glob `.autocode/design/<id>-*` or `*-<shortname>`. Resolve to one folder.
 - On no match, ask the user via `AskUserQuestion`.
 
 ## Workflow
 
-1. Locate `.autocode/design/<ticket-num>-<shortname>/DESIGN.md`. Stop on no match.
-2. Verify a worktree + feature branch exist for this ticket:
-   - Check `git rev-parse --abbrev-ref HEAD` and confirm the branch encodes this ticket.
-   - If not, delegate to `impl-start <ticket-num>` and continue inside the new worktree.
-3. Stage the design directory: `git add .autocode/design/<ticket-num>-<shortname>/`.
-4. Delegate to `git-commit` (forwards a context note describing the design proposal).
+1. Locate `.autocode/design/<id>-<shortname>/`. Confirm `DESIGN.md` exists. Stop on no match.
+2. Ensure a worktree + docs branch. If the current branch is the default branch, use `EnterWorktree` based on the default branch, then delegate to `git-create-branch "docs: design <shortname>"` inside it.
+3. Stage the design folder: `git add .autocode/design/<id>-<shortname>/`.
+4. Delegate to `git-commit` (forward a context note describing the design).
 5. Delegate to `pr-create --lightweight`. The lightweight flag:
    - Skips PR-template sectioning.
-   - Body becomes the plan's executive summary verbatim plus a bullet list of the plan's section headings.
-   - Skips background `pr-hygiene` dispatch (the PR is text, not code, so hygiene assessments don't apply).
-6. Report PR URL. Suggest `/design-plan-iterate` once reviews land.
+   - Body is the `DESIGN.md` `## Summary` verbatim plus a bullet list of the design's section headings (and unit slugs, if multi-unit).
+   - Skips issue linking and background `pr-hygiene` (the PR is text, and the issues do not exist yet).
+6. Report the PR URL. Suggest `/design-plan-iterate` once reviews land, and note that merging this PR triggers fan-out (the `design-fanout` skill or the optional Action).
 
 ## Rules
 
-- Refuse `--temp` plans. Tell the user to promote to a tracked path first.
-- Delegate aggressively. Do not inline commit logic, do not inline PR-body generation.
+- Refuse `--temp` plans. Tell the user to promote to `.autocode/design/` first.
+- Delegate aggressively. Do not inline commit logic or PR-body generation.
 - The PR is text-only; never run a verify step.
+- No issue is created or linked here; fan-out happens at merge.
 
 $ARGUMENTS

--- a/autocode/design/skills/design-plan/SKILL.md
+++ b/autocode/design/skills/design-plan/SKILL.md
@@ -1,49 +1,54 @@
 # Design plan
 
-Plan a non-trivial implementation: rough sketch, gap identification, parallel research, then a written plan.
+Plan a non-trivial implementation as an epic: rough sketch, gap identification, parallel research, then a written plan decomposed into independent units of work (a DAG). Output is a design folder, not a single document.
+
+Layout authority: `@~/.autocode/autocode/design/design-folder.md`. Read it; this skill produces exactly that structure.
 
 ## Args
 
 - Freeform user description (typical), or
-- `--temp` (or `--temporary`): write the plan to a temp directory and skip proposal ticket creation.
+- `--temp` (or `--temporary`): write the folder to a temp directory instead of the repo. Same structure; for throwaway critique only.
 
 ## Workflow
 
 1. Treat `$ARGUMENTS` as the seed. If empty, ask via `AskUserQuestion` for a one-paragraph description.
-2. Rough sketch from conversation context only. No research yet. The point is to surface what the model already thinks so gaps are easier to identify.
+2. Rough sketch from conversation context only. No research yet. Surface what the model already thinks so gaps are easier to identify.
 3. Gap identification. List every assumption, every unknown library/API, every "I'm guessing X". Decide per gap:
    - dispatch `codebase-researcher` (current repo) in background,
    - dispatch `codebase-researcher` (cross-project) in background,
    - dispatch `web-researcher` in background,
    - ask the user.
-   Launch researchers in parallel (single message, multiple Task tool calls). The researchers return verbatim findings; you fold them into the plan.
-4. Compose plan once research returns. Sections:
-   - `## Executive summary` (one paragraph).
-   - `## Architecture impact` (packages, interfaces, new deps; or "no architecture impact" explicitly).
-   - `## Implementation steps`. Each step: deliverable, files to create/modify, public interfaces (signatures, struct types), tests that prove it. High-level. No inline code, no pseudo-code. The implementer owns logic.
-   - `## Edge cases and error handling`.
-   - `## Testing strategy` (categories, fakes, minimum coverage).
-   - `## Sources`. Every claim cited. Unsubstantiated claims are discarded.
-5. Branch on `--temp`:
+   Launch researchers in parallel (single message, multiple Task tool calls). They return verbatim findings; fold them into the plan.
+4. Compose the epic plan and decompose it into units once research returns.
+   - Decide multi-unit vs flat. If the work is one PR's worth, produce a flat single-unit design: `DESIGN.md` only, no `units/` (see "Flat designs" below). Otherwise decompose into independent units of work, each one PR's worth with a single clear deliverable; identify dependencies between units and confirm the graph is acyclic. A unit that depends on nothing is immediately workable.
+   - `DESIGN.md` sections (multi-unit):
+     - `## Summary` (one paragraph; this is the verbatim epic issue body at fan-out, so it must stand alone).
+     - `## Architecture impact` (packages, interfaces, new deps; or "no architecture impact" explicitly).
+     - `## Edge cases and error handling`.
+     - `## Testing strategy` (categories, fakes, minimum coverage).
+     - `## Sources`. Every claim cited. Unsubstantiated claims are discarded.
+     - `## Units`. Table: `slug`, one-line deliverable, `depends-on`. The human-readable DAG index.
+   - For each unit, `units/<slug>.md`:
+     - Frontmatter: `depends-on: [<slug>...]` (other slugs in this folder; `[]` if none) and `type: <issue-type>` (an issue type from the repo's `issue-types` convention at `$AUTOCODE_CONFIG_DIR/conventions/issue-types.md`, typically `task`, `story`, or `bug`).
+     - `## Summary` (one paragraph; verbatim sub-issue body at fan-out).
+     - `## Implementation`: deliverable, files to create/modify, public interfaces (signatures, struct types), tests that prove it. High-level. No inline code, no pseudo-code. The implementer owns logic.
+   - Flat designs (single unit): omit the `## Units` section and the `units/` directory. `DESIGN.md` instead carries frontmatter `type: <issue-type>` and its own `## Implementation` section (same shape as a unit). It is its own unit, slug `<shortname>`.
+5. Write the folder.
+   - `id=$(date -u +%Y%m%dT%H%M%SZ)`.
+   - Ask the user for `<shortname>` via `AskUserQuestion`. Kebab-case, lowercase, 2-4 words.
+   - Multi-unit: write `DESIGN.md` plus each `units/<slug>.md`. Flat: write `DESIGN.md` only (no `units/`).
+   - With `--temp`: `dir=$(mktemp -d -t autocode-design)`. Write the files under `$dir`. Stop. Final report: print `$dir`. Suggest `/design-plan-critique $dir`.
+   - Without `--temp`: `repo_root=$(git rev-parse --show-toplevel)`. Create `$repo_root/.autocode/design/<id>-<shortname>/` (plus `units/` when multi-unit) and write the files. Final report: folder path and `<id>`. Suggest `/design-plan-critique <id>` or `/design-plan-push <id>`.
 
-   With `--temp`:
-   - `dir=$(mktemp -d -t autocode-design); plan_path="$dir/DESIGN.md"`. Write plan to that file.
-   - Stop. No proposal issue. No design directory in the repo.
-   - Final report: print `<plan_path>`. Suggest `/design-plan-critique <plan_path>`.
-
-   Without `--temp`:
-   - Ask the user for `<feature-shortname>` via `AskUserQuestion`. Kebab-case, lowercase, 2-4 words.
-   - `repo_root=$(git rev-parse --show-toplevel)`. Create `$repo_root/.autocode/design/unsubmitted-<shortname>/` and write `DESIGN.md` there.
-   - Delegate to `issue-create` with type `proposal`. Capture the issue number.
-   - Rename `unsubmitted-<shortname>/` to `<ticket-num>-<shortname>/`.
-   - Final report: plan path and proposal ticket id. Suggest `/design-plan-critique <ticket-num>` or `/design-plan-push <ticket-num>`.
+No issue is created here. The epic issue and per-unit sub-issues are created only when the design PR merges, by `design-fanout` or the optional GitHub Action.
 
 ## Rules
 
-- The proposal issue is for SUBMITTING the proposal itself. The implementation issue is created later (manually or by `impl-start`).
-- No phase numbers in commits, code, or PR titles.
+- Every unit lists the files it touches; if you cannot list files, the unit is not specific enough.
+- `DESIGN.md` and every unit carry a `## Summary`; these are the verbatim issue bodies at fan-out.
+- `depends-on` forms an acyclic DAG. Each unit must be independently mergeable once its dependencies are merged.
 - Prefer "I don't know" over a guess. Send the gap to a researcher or the user; do not paper over it.
-- Every implementation step lists files; if you cannot list files, the plan is not specific enough.
 - Sources section is mandatory. Each claim has a citation (codebase path, URL, or user statement).
+- No phase numbers in commits, code, or PR titles.
 
 $ARGUMENTS

--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -1,3 +1,5 @@
 # impl/
 
-Implementation phase. Worktree-bound skills (`impl-start`, `impl-push`) drive code from an approved design to a pushed branch. The `oracle` agent escalates hard, well-scoped questions to opus reasoning from inside a sonnet session.
+Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch: `impl-start` (pick a ready unit, set up the worktree), `impl-push` (commit + PR), `impl-archive` (close out a completed epic). The `oracle` agent escalates hard, well-scoped questions to opus reasoning from inside a sonnet session. The `progress-logger` agent appends per-unit log entries during implementation.
+
+A unit of work is one entry under `units/` of a design epic; the epic folder layout, unit DAG, issue discovery, and progress log are specified in `@~/.autocode/autocode/design/design-folder.md`.

--- a/autocode/impl/agents/progress-logger.md
+++ b/autocode/impl/agents/progress-logger.md
@@ -1,0 +1,45 @@
+Read `~/.autocode/autocode/_config/output-styles/concise.md` and follow it for all output.
+
+# Progress logger
+
+Append one entry to a unit's progress log so the next agent that touches this unit, or a sibling unit in the same epic, learns from what just happened. You write one file and nothing else.
+
+## Invocation
+
+Background-only. Spawned by the main implementation agent after meaningful work (typically a new commit), usually in response to the progress-log hook. Not user-callable.
+
+## Inputs
+
+The spawning prompt provides:
+
+- `progress_log`: path to `.autocode/design/<id>-<short>/progress/<slug>.md`.
+- `slug` and the unit's branch.
+- A short description of what was attempted this stretch, plus the new commit SHA(s).
+
+If any is missing, derive it: read `progress_log` for the last entry, then `git log` / `git diff` on the current branch for what changed since.
+
+## Workflow
+
+1. Read `progress_log` to see what is already recorded (and the last commit it covered).
+2. Inspect what changed since: `git log` and `git diff` for the new commits.
+3. Append one entry (never edit earlier ones):
+
+   ```
+   ## <UTC timestamp>
+   <what was attempted; what worked; what failed and why; troubleshooting steps and their outcome; anything a future implementer should know>
+   ```
+
+4. Report a one-line confirmation of what you logged, or that you skipped.
+
+## What makes a good entry
+
+- Lessons, not a commit echo. "X failed because Y; fixed by Z" beats "added X".
+- Record dead ends, gotchas, and non-obvious fixes; they save the next agent time.
+- A few sentences or terse bullets. No filler.
+- If nothing meaningful happened, append nothing and say you skipped.
+
+## Rules
+
+- Append only. Never modify or delete prior entries; a new session continues below a `---` rule rather than rewriting.
+- Touch only `progress_log`. No code edits, no other files, no issue or PR calls.
+- The entry is for humans and future agents reading the log, not a message back to the spawner.

--- a/autocode/impl/skills/impl-archive/SKILL.md
+++ b/autocode/impl/skills/impl-archive/SKILL.md
@@ -1,0 +1,33 @@
+# Impl archive
+
+Close out a completed design epic: verify every unit is done, close the epic issue, and move the folder to `.autocode/archive/`. The folder location is the epic-level source of truth for done.
+
+Layout, discovery, and lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
+
+## Args
+
+`<id | shortname>` (the design folder prefix or suffix). Default: ask via `AskUserQuestion` if more than one active epic exists.
+
+## Workflow
+
+1. Locate `.autocode/design/<id>-<short>/` (glob on either half). Derive `<id>`, `<short>`. Multi-unit if `units/` exists; flat otherwise.
+2. Discover issues: `provider/run.sh issue-tracker issue-list --label "autocode-epic:<id>" --state all`. Map markers to `{slug, key, status}` and the epic issue.
+3. Verify completion:
+   - Multi-unit: every unit's status must be `done`. Flat: the single issue must be `done`.
+   - If any unit is not `done`, report the outstanding units (slug + status) and stop. Do not archive a partially-done epic.
+4. Close the epic (multi-unit only): `provider/run.sh issue-tracker issue-transition <epic-key> done`. (Flat designs have no separate epic; the single issue is already closed.)
+5. Move the folder. If on the default branch, use `EnterWorktree` + `git-create-branch "chore: archive design <short>"` first. Then:
+   - `mkdir -p .autocode/archive`
+   - `git mv .autocode/design/<id>-<short> .autocode/archive/<id>-<short>` (if the source no longer exists, it is already archived; report and stop).
+6. Delegate to `git-commit` (a `chore` commit; note that the epic is complete).
+7. Delegate to `pr-create --lightweight` (the change is a folder move, not code).
+8. Report the PR URL and that merging it archives the folder; note the epic issue is closed.
+
+## Rules
+
+- Never archive an epic with outstanding units. Completion is read from the discovery call, not assumed.
+- All tracker writes go through `provider/run.sh issue-tracker ...`.
+- Idempotent: re-running on an already-archived epic detects the missing source folder and stops cleanly; `issue-transition` tolerates an already-closed epic.
+- Delegate commit and PR creation; do not inline them.
+
+$ARGUMENTS

--- a/autocode/impl/skills/impl-push/SKILL.md
+++ b/autocode/impl/skills/impl-push/SKILL.md
@@ -1,6 +1,8 @@
 # Impl push
 
-Commit local changes and open a PR.
+Commit local changes and open a PR for the unit of work in progress.
+
+When the worktree carries a unit context (`.autocode/.impl-context`, written by `impl-start`), this also records the unit in the epic rollup and advances the sub-issue. Layout and lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
 
 ## Args
 
@@ -12,20 +14,25 @@ Optional context note (rationale or extra detail). Forwarded to `git-commit` as 
    - `git rev-parse --abbrev-ref HEAD` should NOT match the default branch.
    - If on default, delegate to `impl-start` to create a worktree+branch, then continue.
 2. Run `git status` and `git diff` to confirm uncommitted changes exist. If clean, stop with a note: "no changes to push".
-3. Delegate to `git-commit` skill. Verification is owned by the repo's pre-commit hooks; this skill does not run a verify step.
-4. Delegate to `pr-create` skill.
-5. Final report. No autonomous post-PR loop. Print:
+3. If `.autocode/.impl-context` exists, read it for `design_id`, `shortname`, `slug`, `unit_key`. Append one block to the epic rollup `.autocode/design/<design_id>-<shortname>/PROGRESS.md` in the format from the design-folder spec: `## <slug> — <today>`, then `Unit: #<unit_key>`, a one-paragraph what-shipped summary, and a `Notes:` line for anything worth knowing (drawn from `progress/<slug>.md`; omit if none). Create `PROGRESS.md` with a `# Progress: <shortname>` heading if it does not exist. This block is committed with the unit, so it lands on merge.
+4. Delegate to `git-commit` (stages the code plus `PROGRESS.md` and `progress/<slug>.md`). Verification is owned by the repo's pre-commit hooks; this skill does not run a verify step.
+5. Delegate to `pr-create`. Its generated body includes `Closes #<unit_key>`, so the merge will close the sub-issue (advancing the unit to `done`).
+6. If a unit context was present, advance the sub-issue: `provider/run.sh issue-tracker issue-transition <unit_key> in-review`.
+7. Final report. No autonomous post-PR loop. Print:
    - PR URL.
    - Branch.
+   - Unit slug + sub-issue key (when in a unit context).
    - Static next-step suggestions:
      - `/pr-fix-ci` if CI fails.
      - `/pr-review` when reviews land.
      - `/pr-rebase` if base advances.
+     - `/impl-start --from-design <design_id>` to pick the next ready unit.
 
 ## Rules
 
 - Delegate. Don't inline commit logic, don't inline PR-body generation, don't run a verify step.
 - Never push with `--force` or `--force-with-lease`. Plain `git push` only (handled by `git-commit`).
 - No autonomous loops after the PR opens; user dispatches the next skill.
+- Outside a unit context (no `.autocode/.impl-context`), steps 3 and 6 are skipped; the skill behaves as a plain commit-and-PR.
 
 $ARGUMENTS

--- a/autocode/impl/skills/impl-start/SKILL.md
+++ b/autocode/impl/skills/impl-start/SKILL.md
@@ -1,33 +1,51 @@
 # Impl start
 
-Set up a worktree + feature branch for implementation work.
+Set up a worktree + feature branch for one unit of work. From a design epic, this picks a single DAG-ready unit; it also supports a bare ticket or a freeform description.
+
+Design-epic discovery, markers, the DAG, and the lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
 
 ## Args
 
 One of:
-- `--from-design <ticket-num | shortname>`: seed from a design doc.
+- `--from-design <id | shortname>`: pick a ready unit from a fanned-out design epic.
 - `<ticket-id>` (e.g. `42`, `BA-1234`): ticket mode.
 - `<type>: <description>` (e.g. `feat: add login flow`): description mode.
 
-## Workflow
+## Workflow (from-design)
 
-1. If `--from-design`:
-   - Locate `.autocode/design/<ticket>-<short>/DESIGN.md` (glob if only one of ticket/short is provided).
-   - Read the design doc into context.
-   - Derive the implementation ticket from the doc body. If absent, ask the user via `AskUserQuestion` whether to delegate to `issue-create` to open one.
-2. Otherwise, treat the arg as a ticket id (ticket mode) or `<type>: <description>` (description mode).
-3. Use Claude Code's `EnterWorktree` tool to create a new worktree. Name follows the branch naming convention (delegate the actual branch creation to step 4). Base the worktree on the repo's default branch (commonly `main`).
-4. Inside the worktree, delegate to the `git-create-branch` skill to produce the feature branch.
-5. Report:
-   - Worktree path.
-   - Branch name.
-   - Ticket id (if any).
-   - Next step: hand control back to the user; they (or `impl-push` once changes exist) take over.
+1. Locate `.autocode/design/<id>-<short>/` (glob on either half). Read `DESIGN.md` and any `units/*.md`. Multi-unit if `units/` exists; flat otherwise.
+2. Discover issues: `provider/run.sh issue-tracker issue-list --label "autocode-epic:<id>" --state all`. If it returns `[]`, the design has not been fanned out; tell the user to run `/design-fanout <id>` (or wait for the Action) and stop.
+3. Map markers to issues. For each returned issue, read its `description` for a marker:
+   - `<!-- autocode:epic=<id> -->` -> the epic issue (also the single unit in a flat design).
+   - `<!-- autocode:unit=<id>/<slug> -->` -> that unit's sub-issue.
+   Record each unit's `{slug, key, status}`.
+4. Compute the ready set:
+   - Flat design: the one issue is the unit; ready iff its status is `todo`.
+   - Multi-unit: a unit is ready iff its status is `todo` and every slug in its `depends-on` (from the unit file frontmatter) maps to a unit whose status is `done`. Units already `in-progress`/`in-review`/`done` are excluded.
+   - If the ready set is empty, report why (all done, or all remaining are blocked on unfinished deps) and stop.
+5. Present the ready units via `AskUserQuestion` (slug + one-line deliverable). The user picks one. Its sub-issue `key` is the ticket for the rest of the flow.
+6. Use `EnterWorktree` to create a worktree based on the repo's default branch (deps are already merged there). Inside it, delegate to `git-create-branch <key>` for the feature branch.
+7. Transition state:
+   - `provider/run.sh issue-tracker issue-transition <key> in-progress`.
+   - Multi-unit: if the epic issue status is still `todo`, `provider/run.sh issue-tracker issue-transition <epic-key> in-progress`.
+8. Seed the per-unit log. In the worktree, create `.autocode/design/<id>-<short>/progress/<slug>.md` with the header from the design-folder spec (slug, epic, branch, started date). Multi-unit only writes under the existing folder; flat uses slug `<short>`.
+9. Seed the worktree state files (both gitignored; the Stop progress hook reads them):
+   - `.autocode/.impl-context`: a JSON object with keys `design_id`, `shortname`, `slug`, `unit_key`, `epic_key` (empty string for flat), `progress_log` (absolute path to the per-unit log). The hook parses this with `jq`, so it must be valid JSON.
+   - `.autocode/.progress-last-sha`: current `git rev-parse HEAD`.
+10. Report: worktree path, branch, unit slug, sub-issue key, and next step (implement, then `/impl-push`).
+
+## Workflow (ticket / description mode)
+
+1. Treat the arg as a ticket id (ticket mode) or `<type>: <description>` (description mode). No design epic, no unit selection, no progress log.
+2. `EnterWorktree` based on the default branch; inside it, delegate to `git-create-branch`.
+3. Report worktree path, branch, ticket id (if any), and next step.
 
 ## Rules
 
-- Worktree base is the repo's default branch. Epic-base detection is intentionally out of scope.
-- Never branch from a dirty working tree on `main`.
+- Worktree base is the repo's default branch. Units merge to the default branch directly; there is no epic integration branch. A unit's dependencies being `done` (closed) means their code is already on the default branch the worktree is based on.
+- Never branch from a dirty working tree on the default branch.
 - Delegate branch creation to `git-create-branch`; never duplicate that logic.
+- Pick exactly one ready unit per invocation. Re-run the skill to start another.
+- The state files (`.autocode/.impl-context`, `.autocode/.progress-last-sha`) are gitignored; ensure `$repo_root/.autocode/.gitignore` ignores them (create if missing).
 
 $ARGUMENTS

--- a/autocode/pr/skills/pr-create/SKILL.md
+++ b/autocode/pr/skills/pr-create/SKILL.md
@@ -21,6 +21,7 @@ Open a pull request for the current branch.
      - Inspect changes: `git diff <base>...HEAD` and `git log <base>..HEAD --oneline`. Read source files when needed for accurate section text.
      - Fill every section of the template. Empty sections get a placeholder (`(none)` or `_n/a_`); never drop a section.
      - Strip HTML comments (template instructions, not content). Copy checklist items character-for-character; only flip `[ ]` to `[x]` when satisfied.
+     - When a ticket id is parseable from the branch (per `branch-naming`), add a `Closes #<ticket-id>` line so the merge auto-closes the linked issue. This is what advances a unit sub-issue to `done`.
      - Write to `body="$(mktemp -d -t autocode-pr)/body.md"`.
    - `--lightweight`:
      - Skip template. Body is a one-paragraph summary derived from commit subjects via `git log <base>..HEAD --pretty='- %s'`.

--- a/plugins/autocode/agents/progress-logger.md
+++ b/plugins/autocode/agents/progress-logger.md
@@ -1,0 +1,9 @@
+---
+name: progress-logger
+description: Background-only. Appends one lessons-learned entry to a design unit's progress log after meaningful work; sonnet.
+model: sonnet
+tools: Read, Write, Edit, Bash
+disable-model-invocation: true
+---
+
+Read through @~/.autocode/autocode/impl/agents/progress-logger.md and execute actions according to the instructions in the file.

--- a/plugins/autocode/hooks/check-progress-log.sh
+++ b/plugins/autocode/hooks/check-progress-log.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hook. After each turn, if a unit of work is in progress and a new commit
+# landed since the last logged entry, nudge the main agent to spawn the
+# progress-logger. Mechanical: it detects commits only, writes no log, and
+# mutates no code (only its own gitignored state file). Loop-safe via
+# stop_hook_active and by recording the SHA on each nudge (one nudge per commit).
+#
+# Output: exit 0 with `{"decision":"block","reason":...}` to nudge, or exit 0
+# with no output to stay silent. Never exit 2 (plugin Stop hooks mishandle it).
+
+input=$(cat)
+
+# Re-entry guard: if we already forced a continuation, let the agent stop.
+if [[ "$(printf '%s' "${input}" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)" == "true" ]]; then
+  exit 0
+fi
+
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "${project_dir}" ]]; then
+  project_dir="$(printf '%s' "${input}" | jq -r '.cwd // empty' 2>/dev/null || echo "")"
+fi
+if [[ -z "${project_dir}" ]]; then
+  project_dir="${PWD}"
+fi
+
+context="${project_dir}/.autocode/.impl-context"
+[[ -f "${context}" ]] || exit 0   # not a unit-of-work session
+
+git -C "${project_dir}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+cur=$(git -C "${project_dir}" rev-parse HEAD 2>/dev/null || echo "")
+[[ -n "${cur}" ]] || exit 0
+
+state="${project_dir}/.autocode/.progress-last-sha"
+last=$(cat "${state}" 2>/dev/null || echo "")
+
+if [[ "${cur}" == "${last}" ]]; then
+  exit 0   # no new commit since the last nudge/log
+fi
+
+# Record now so each new commit nudges exactly once.
+printf '%s\n' "${cur}" > "${state}"
+
+slug=$(jq -r '.slug // empty' "${context}" 2>/dev/null || echo "")
+log=$(jq -r '.progress_log // empty' "${context}" 2>/dev/null || echo "")
+
+reason="New commit ${cur:0:8} on unit '${slug}' since the last progress entry. Spawn the progress-logger agent in the background (progress_log=${log}, slug=${slug}) with a short note on what this stretch attempted, then stop. If nothing log-worthy happened, skip and stop."
+
+jq -n --arg r "${reason}" '{decision: "block", reason: $r}'
+exit 0

--- a/plugins/autocode/hooks/hooks.json
+++ b/plugins/autocode/hooks/hooks.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-progress-log.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/autocode/skills/autocode-setup/SKILL.md
+++ b/plugins/autocode/skills/autocode-setup/SKILL.md
@@ -37,7 +37,7 @@ The script creates the directory and writes `AUTOCODE_CONFIG_DIR` into the corre
 
 Read `~/.autocode/autocode/_config/settings-schema.md` first; it is the source of truth for which keys exist, which namespace each belongs to, and the shared-vs-local split. Each key lands in exactly one file:
 
-- Shared keys (`provider.*`, `workflow.*`) -> `$AUTOCODE_CONFIG_DIR/settings.json` (committed).
+- Shared keys (`provider.*`) -> `$AUTOCODE_CONFIG_DIR/settings.json` (committed).
 - Local keys (`paths.*`) -> `$AUTOCODE_CONFIG_DIR/settings.local.json` (gitignored).
 
 Collect a value for every required key, plus any optional key whose default the user should override. Currently that means asking via `AskUserQuestion`:
@@ -45,7 +45,6 @@ Collect a value for every required key, plus any optional key whose default the 
 - `provider.issue-tracker` (required, shared): default `github`.
 - `provider.git-remote` (required, shared): default `github`.
 - `provider.ci` (optional, shared): default is the same value as `provider.git-remote`. When the user accepts the default, omit `--ci=` from the script invocation so `provider/run.sh` falls back to `provider.git-remote` at dispatch time.
-- `workflow.auto-merge-sub-issues` (shared): leave unset unless the user asks for it.
 - `paths.projects-dir` (required, local): default is the parent of the repo root (`dirname "$repo_root"`); surface that default in the prompt. Accept absolute paths or `~/`-prefixed paths; resolve `~` to the user's home before writing.
 
 Build each file's JSON via the helper, one scope at a time:
@@ -54,8 +53,7 @@ Build each file's JSON via the helper, one scope at a time:
 bash ${CLAUDE_SKILL_DIR}/scripts/write-settings.sh --scope=shared \
   --issue-tracker=<value> \
   --git-remote=<value> \
-  [--ci=<value>] \
-  [--auto-merge-sub-issues=true]
+  [--ci=<value>]
 
 bash ${CLAUDE_SKILL_DIR}/scripts/write-settings.sh --scope=local \
   --projects-dir=<resolved-path>
@@ -107,9 +105,19 @@ Rules:
 
 Use Read + Edit (or Write for the create-from-scratch case). Do not call out to a script.
 
+## Step 6: Optional design fan-out Action
+
+Ask the user (via `AskUserQuestion`, default no) whether to install the mechanical design fan-out GitHub Action. Frame: "For repos that fully adopt autocode. On merge to the default branch, it turns a merged design folder into an epic issue plus per-unit sub-issues, with no Claude involved. Without it, run the `/design-fanout` skill manually after a design PR merges." If the user declines, skip.
+
+If the user agrees:
+
+- Copy `~/.autocode/plugins/autocode/templates/autocode-design-fanout.yml` to `<repo-root>/.github/workflows/autocode-design-fanout.yml` (`mkdir -p` the workflows dir).
+- If the repo's default branch is not `main`, edit the `branches:` line in the copied file to match.
+- If the destination already exists, show a diff and ask before overwriting.
+
 ## Done
 
-After all five steps, summarize what was written and what was skipped, and tell the user:
+After these steps, summarize what was written and what was skipped, and tell the user:
 
 - They can run `/autocode-update` periodically to pull the latest autocode and reconcile conventions.
 - They can re-run `/autocode-setup` safely; each step skips when already complete.

--- a/plugins/autocode/skills/autocode-setup/scripts/write-settings.sh
+++ b/plugins/autocode/skills/autocode-setup/scripts/write-settings.sh
@@ -9,8 +9,7 @@ set -euo pipefail
 #   write-settings.sh --scope=shared \
 #     --issue-tracker=<value> \
 #     --git-remote=<value> \
-#     [--ci=<value>] \
-#     [--auto-merge-sub-issues=<true|false>]
+#     [--ci=<value>]
 #
 #   write-settings.sh --scope=local \
 #     --projects-dir=<path>
@@ -25,7 +24,6 @@ issue_tracker=""
 git_remote=""
 ci=""
 ci_provided=0
-auto_merge="false"
 projects_dir=""
 
 for arg in "$@"; do
@@ -34,7 +32,6 @@ for arg in "$@"; do
     --issue-tracker=*) issue_tracker="${arg#*=}" ;;
     --git-remote=*)    git_remote="${arg#*=}" ;;
     --ci=*)            ci="${arg#*=}"; ci_provided=1 ;;
-    --auto-merge-sub-issues=*) auto_merge="${arg#*=}" ;;
     --projects-dir=*)  projects_dir="${arg#*=}" ;;
     *) echo "write-settings.sh: unknown arg: ${arg}" >&2; exit 1 ;;
   esac
@@ -55,10 +52,6 @@ if [[ "${scope}" == "shared" ]]; then
     echo "write-settings.sh: --git-remote=<value> required for --scope=shared" >&2
     exit 1
   fi
-  case "${auto_merge}" in
-    true|false) ;;
-    *) echo "write-settings.sh: --auto-merge-sub-issues must be true or false" >&2; exit 1 ;;
-  esac
 
   provider_json=$(jq -n \
     --arg it "${issue_tracker}" \
@@ -71,11 +64,7 @@ if [[ "${scope}" == "shared" ]]; then
 
   jq -n \
     --argjson provider "${provider_json}" \
-    --argjson auto_merge "${auto_merge}" \
-    '{
-      provider: $provider,
-      workflow: {"auto-merge-sub-issues": $auto_merge}
-    }'
+    '{ provider: $provider }'
 else
   if [[ -z "${projects_dir}" ]]; then
     echo "write-settings.sh: --projects-dir=<path> required for --scope=local" >&2

--- a/plugins/autocode/skills/design-fanout/SKILL.md
+++ b/plugins/autocode/skills/design-fanout/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: design-fanout
+description: Turn a merged design folder into tracker issues (an epic plus one sub-issue per unit, or a single issue for a flat design). Run after the design PR merges. The manual counterpart of the optional fan-out GitHub Action.
+---
+
+Read through @~/.autocode/autocode/design/skills/design-fanout/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-archive/SKILL.md
+++ b/plugins/autocode/skills/impl-archive/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-archive
+description: Close out a completed design epic. Verifies every unit is done, closes the epic issue, and moves the design folder to .autocode/archive/ via a lightweight PR.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-archive/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-start/SKILL.md
+++ b/plugins/autocode/skills/impl-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl-start
-description: Create a worktree + feature branch for implementation work. Seeds from a design doc, a ticket id, or a freeform type+description.
+description: Create a worktree + feature branch for one unit of work. Picks a DAG-ready unit from a fanned-out design epic, or seeds from a bare ticket id or a freeform type+description.
 ---
 
 Read through @~/.autocode/autocode/impl/skills/impl-start/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/templates/autocode-design-fanout.yml
+++ b/plugins/autocode/templates/autocode-design-fanout.yml
@@ -1,0 +1,114 @@
+# autocode design fan-out (optional, full-adopt path).
+#
+# On merge to the default branch touching .autocode/design/**, mechanically
+# create one epic issue plus one sub-issue per unit (or a single issue for a
+# flat design). No Claude, no AI. The body, tags, and markers match
+# autocode/design/design-folder.md so `impl-start` discovery works the same as
+# the manual `design-fanout` skill. Idempotent: re-runs create only issues whose
+# marker is missing.
+#
+# Install: copy to .github/workflows/ in the target repo. Adjust the branch name
+# below if the default branch is not `main`. Requires the default GITHUB_TOKEN
+# (issues: write); no extra secrets.
+
+name: autocode design fan-out
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.autocode/design/**'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fanout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fan out merged design folders
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${BEFORE}" =~ ^0+$ ]]; then
+            range="${SHA}^..${SHA}"
+          else
+            range="${BEFORE}..${SHA}"
+          fi
+
+          mapfile -t dirs < <(git diff --name-only "${range}" -- '.autocode/design/' \
+            | sed -nE 's#^(\.autocode/design/[^/]+)/.*#\1#p' | sort -u)
+
+          summary() { awk '/^## Summary[[:space:]]*$/{f=1;next} /^## /{f=0} f' "$1"; }
+          fm_type() { awk 'NR==1 && $0=="---"{i=1;next} i && $0=="---"{exit} i && /^type:/{sub(/^type:[[:space:]]*/,"");print;exit}' "$1"; }
+          make_body() {  # $1=file $2=marker
+            summary "$1"
+            printf '\nDesign: https://github.com/%s/blob/%s/%s\n\n%s\n' "${REPO}" "${SHA}" "$1" "$2"
+          }
+          rest_id() { gh api "/repos/${REPO}/issues/$1" --jq '.id'; }
+          create_issue() {  # $1=title $2=epic-label $3=type $4=body-file -> prints number
+            gh label create "type:$3" --force >/dev/null 2>&1 || true
+            gh issue create --repo "${REPO}" --title "$1" --label "$2" --label "type:$3" \
+              --body-file "$4" | grep -oE '[0-9]+$'
+          }
+
+          for dir in "${dirs[@]+"${dirs[@]}"}"; do
+            [[ -d "${dir}" ]] || continue   # deleted or archived; nothing to fan out
+            base=$(basename "${dir}")
+            id="${base%%-*}"
+            short="${base#*-}"
+            label="autocode-epic:${id}"
+            gh label create "${label}" --force --description "autocode design epic ${id}" >/dev/null 2>&1 || true
+
+            existing=$(gh issue list --repo "${REPO}" --label "${label}" --state all --limit 200 \
+              --json body --jq '[.[].body] | join("\n")' || echo "")
+            has() { printf '%s' "${existing}" | grep -qF "$1"; }
+
+            tmp=$(mktemp)
+
+            if [[ -d "${dir}/units" ]]; then
+              epic_marker="<!-- autocode:epic=${id} -->"
+              if has "${epic_marker}"; then
+                epic_num=$(gh issue list --repo "${REPO}" --label "${label}" --state all \
+                  --json number,body --jq ".[] | select(.body | contains(\"${epic_marker}\")) | .number" | head -n1)
+              else
+                make_body "${dir}/DESIGN.md" "${epic_marker}" > "${tmp}"
+                epic_num=$(create_issue "${short}" "${label}" "epic" "${tmp}")
+              fi
+              epic_id=$(rest_id "${epic_num}")
+
+              for unit in "${dir}"/units/*.md; do
+                [[ -f "${unit}" ]] || continue
+                slug=$(basename "${unit}" .md)
+                umarker="<!-- autocode:unit=${id}/${slug} -->"
+                has "${umarker}" && continue
+                utype=$(fm_type "${unit}"); utype="${utype:-task}"
+                make_body "${unit}" "${umarker}" > "${tmp}"
+                child_num=$(create_issue "${slug}" "${label}" "${utype}" "${tmp}")
+                child_id=$(rest_id "${child_num}")
+                gh api graphql -H "GraphQL-Features:sub_issues" \
+                  -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){subIssue{number}}}' \
+                  -f p="${epic_id}" -f c="${child_id}" >/dev/null 2>&1 \
+                  || echo "warning: could not link #${child_num} to epic #${epic_num}" >&2
+                sleep 1
+              done
+            else
+              emarker="<!-- autocode:epic=${id} -->"
+              if ! has "${emarker}"; then
+                ftype=$(fm_type "${dir}/DESIGN.md"); ftype="${ftype:-task}"
+                make_body "${dir}/DESIGN.md" "${emarker}" > "${tmp}"
+                create_issue "${short}" "${label}" "${ftype}" "${tmp}" >/dev/null
+              fi
+            fi
+
+            rm -f "${tmp}"
+          done

--- a/provider/issue-tracker/contract.md
+++ b/provider/issue-tracker/contract.md
@@ -47,9 +47,18 @@ Tracker-side issue operations: view, create, identity, and future label / commen
 |---|---|---|
 | `issue-view.sh` | `<key>` | `Issue` JSON |
 | `issue-create.sh` | `<flags>` | created key on a single line |
+| `issue-list.sh` | `--label <label> [--state all\|open\|closed]` | `Issue[]` JSON |
+| `issue-transition.sh` | `<key> <status>` | none |
+| `issue-label-ensure.sh` | `<name> [--color <hex>] [--description <text>]` | none |
 | `current-user.sh` | (none) | `User` JSON |
 
-`issue-create.sh` flag set is provider-defined but must accept at minimum a summary, an issue type, and an optional body file. Providers document their own flag surface inside the script.
+`issue-create.sh` flag set is provider-defined but must accept at minimum a summary (`-s`), an issue type (`-t`), an optional body file (`-b`), zero or more labels (`-l`, repeatable), and an optional parent for sub-issue linking (`-P`). Providers document their own flag surface inside the script.
+
+`issue-list.sh` powers design-epic discovery: list every issue carrying the epic tag in one live call (no search index), then match body markers client-side to resolve units and read their state. It emits the `Issue` shape per row, except `parent` is always `""` (bulk listing does not resolve per-row parents). Default `--state` is `all` so closed (done) issues are included.
+
+`issue-transition.sh` accepts only the four-state enum values (`todo`, `in-progress`, `in-review`, `done`); the provider maps them to native state (GitHub: `autocode:<state>` label for open states, `closed` for done). Idempotent.
+
+`issue-label-ensure.sh` creates or updates a label. Required before creating an issue with a dynamic label (e.g. an epic tag `autocode-epic:<id>`), since GitHub rejects `issue create --label X` when X does not exist. Idempotent.
 
 ## Optional scripts
 
@@ -63,9 +72,8 @@ Documented for future implementers. Not yet implemented. A skill that calls an o
 | `issue-comment-list.sh` | `<key>` | `Comment[]` JSON | reading tracker-side discussion |
 | `issue-label-list.sh` | `<key>` | `string[]` JSON | inspecting current labels |
 | `issue-label-add.sh` | `<key> <label>...` | none | applying labels (idempotent) |
-| `issue-transition.sh` | `<key> <status>` | none | `autocode:*` label moves on GitHub, Jira status transitions |
 
-`issue-transition.sh` accepts only the four-state enum values (`todo`, `in-progress`, `in-review`, `done`); the provider maps them to native state. `issue-label-add.sh` is idempotent: re-adding an existing label exits `0` with no error.
+`issue-label-add.sh` is idempotent: re-adding an existing label exits `0` with no error.
 
 The `Comment` shape for `issue-comment-list.sh` is provider-defined for now; pin it when the first caller lands.
 

--- a/provider/issue-tracker/github/issue-label-ensure.sh
+++ b/provider/issue-tracker/github/issue-label-ensure.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a label exists in the repo, creating or updating it. Idempotent.
+# Needed before creating issues with a dynamic label (e.g. an epic tag): GitHub
+# rejects `issue create --label X` when X does not yet exist.
+# Usage: issue-label-ensure.sh <name> [--color <hex>] [--description <text>] [-g <owner/repo>]
+# Depends on: gh.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "issue-label-ensure.sh: gh CLI not on PATH; install GitHub CLI and run 'gh auth login'" >&2
+  exit 2
+fi
+
+name=""
+color=""
+description=""
+repo_override=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --color) color="${2:-}"; shift 2 ;;
+    --description) description="${2:-}"; shift 2 ;;
+    -g) repo_override="${2:-}"; shift 2 ;;
+    -*) echo "issue-label-ensure.sh: unknown option: $1" >&2; exit 1 ;;
+    *)
+      if [[ -z "${name}" ]]; then
+        name="$1"; shift
+      else
+        echo "issue-label-ensure.sh: unexpected argument: $1" >&2; exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "${name}" ]]; then
+  echo "issue-label-ensure.sh: <name> is required" >&2
+  exit 1
+fi
+
+args=(label create "${name}" --force)
+if [[ -n "${color}" ]]; then args+=(--color "${color}"); fi
+if [[ -n "${description}" ]]; then args+=(--description "${description}"); fi
+if [[ -n "${repo_override}" ]]; then args+=(--repo "${repo_override}"); fi
+
+gh "${args[@]}" >/dev/null

--- a/provider/issue-tracker/github/issue-list.sh
+++ b/provider/issue-tracker/github/issue-list.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List issues filtered by a label, emitting Issue[] in contract shape. This is
+# the one live call that powers design-epic discovery (list by the epic tag,
+# then match body markers client-side). `parent` is always "" here: bulk listing
+# does not resolve the sub-issue parent (that would be one GraphQL call per row).
+# Usage: issue-list.sh --label <label> [--state all|open|closed] [-g <owner/repo>]
+# Depends on: gh, jq.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "issue-list.sh: gh CLI not on PATH; install GitHub CLI and run 'gh auth login'" >&2
+  exit 2
+fi
+
+label=""
+state="all"
+repo_override=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label) label="${2:-}"; shift 2 ;;
+    --state) state="${2:-}"; shift 2 ;;
+    -g) repo_override="${2:-}"; shift 2 ;;
+    *) echo "issue-list.sh: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "${label}" ]]; then
+  echo "issue-list.sh: --label <label> is required" >&2
+  exit 1
+fi
+case "${state}" in
+  all|open|closed) ;;
+  *) echo "issue-list.sh: --state must be all, open, or closed (got: ${state})" >&2; exit 1 ;;
+esac
+
+# the commas belong to gh's --json field list, not array separators
+# shellcheck disable=SC2054
+args=(issue list --label "${label}" --state "${state}" --limit 200 --json number,title,body,labels,state)
+if [[ -n "${repo_override}" ]]; then
+  args+=(--repo "${repo_override}")
+fi
+
+gh "${args[@]}" | jq '
+  map({
+    key: (.number | tostring),
+    summary: .title,
+    description: (.body // ""),
+    type: (
+      [.labels[].name] |
+      if any(. == "type:epic") then "Epic"
+      elif any(. == "type:story") then "Story"
+      elif any(. == "type:bug") then "Bug"
+      elif any(. == "type:task") then "Task"
+      else "Task"
+      end
+    ),
+    status: (
+      if .state == "CLOSED" then "done"
+      else (
+        [.labels[].name] as $names |
+        if ($names | any(. == "autocode:in-review")) then "in-review"
+        elif ($names | any(. == "autocode:in-progress")) then "in-progress"
+        elif ($names | any(. == "autocode:todo")) then "todo"
+        else "todo"
+        end
+      )
+      end
+    ),
+    parent: ""
+  })
+'

--- a/provider/issue-tracker/github/issue-transition.sh
+++ b/provider/issue-tracker/github/issue-transition.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move an issue to one of the four contract states. Open states are distinguished
+# by an autocode:<state> label; `done` closes the issue. Idempotent.
+# Usage: issue-transition.sh <key> <status>
+#   status: todo | in-progress | in-review | done
+# Depends on: gh, jq.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "issue-transition.sh: gh CLI not on PATH; install GitHub CLI and run 'gh auth login'" >&2
+  exit 2
+fi
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: issue-transition.sh <key> <status>" >&2
+  exit 1
+fi
+
+key="$1"
+status="$2"
+
+case "${status}" in
+  todo|in-progress|in-review|done) ;;
+  *) echo "issue-transition.sh: status must be one of todo, in-progress, in-review, done (got: ${status})" >&2; exit 1 ;;
+esac
+
+state_labels=("autocode:todo" "autocode:in-progress" "autocode:in-review")
+
+current=$(gh issue view "${key}" --json state,labels --jq '{state: .state, labels: [.labels[].name]}')
+gh_state=$(printf '%s' "${current}" | jq -r '.state')
+
+desired_label=""
+if [[ "${status}" != "done" ]]; then
+  desired_label="autocode:${status}"
+fi
+
+remove=()
+for lbl in "${state_labels[@]}"; do
+  if [[ "${lbl}" != "${desired_label}" ]] \
+    && printf '%s' "${current}" | jq -e --arg l "${lbl}" '.labels | any(. == $l)' >/dev/null; then
+    remove+=("${lbl}")
+  fi
+done
+
+remove_csv=""
+if [[ "${#remove[@]}" -gt 0 ]]; then
+  remove_csv=$(IFS=,; printf '%s' "${remove[*]}")
+fi
+
+if [[ "${status}" == "done" ]]; then
+  if [[ -n "${remove_csv}" ]]; then
+    gh issue edit "${key}" --remove-label "${remove_csv}" >/dev/null
+  fi
+  if [[ "${gh_state}" != "CLOSED" ]]; then
+    gh issue close "${key}" >/dev/null
+  fi
+else
+  gh label create "${desired_label}" --force >/dev/null 2>&1 || true
+  edit_args=(issue edit "${key}" --add-label "${desired_label}")
+  if [[ -n "${remove_csv}" ]]; then
+    edit_args+=(--remove-label "${remove_csv}")
+  fi
+  gh "${edit_args[@]}" >/dev/null
+  if [[ "${gh_state}" == "CLOSED" ]]; then
+    gh issue reopen "${key}" >/dev/null
+  fi
+fi


### PR DESCRIPTION
## Overview

Restructures design docs into epic folders that decompose work into a DAG of independently mergeable units, and wires issue creation, implementation, progress logging, and archival around that structure.

## Problem Statement

- A design was a single `DESIGN.md` with no way to split into independent, parallelizable units of work.
- Nothing turned a merged design into tracker issues, and there was no link back from an issue to its design.
- No per-epic progress log existed to carry lessons between sessions or units.
- `workflow.auto-merge-sub-issues` was a stub with no implementation.

## Architecture

- Epic folder `.autocode/design/<utc-id>-<shortname>/` holds `DESIGN.md`, `units/<slug>.md` (with `depends-on` DAG frontmatter), `PROGRESS.md` (epic rollup), and `progress/<slug>.md` (per-unit log). Flat single-unit designs omit `units/`.
- Fan-out at design-PR merge creates an epic issue plus per-unit sub-issues, tagged `autocode-epic:<id>` with HTML-comment markers. Two paths: the `design-fanout` skill (Claude) and an optional mechanical GitHub Action. No issue numbers are written back; the link runs issue to folder.
- Discovery is one live `issue-list --label` call (no search index); `impl-start` matches markers to compute the DAG-ready set.
- Lifecycle: unit `todo -> in-progress` (impl-start) `-> in-review` (impl-push) `-> done` (PR merge auto-closes via `Closes #`); epic `todo -> in-progress -> done` (impl-archive), no aggregate epic PR.
- A `Stop` hook nudges the main agent to spawn the `progress-logger` background agent once per new commit while a unit is active. The hook is mechanical and mutates no code.

## Implementation Notes

- New provider scripts: `issue-list.sh`, `issue-transition.sh`, `issue-label-ensure.sh`.
- `pr-create` adds a `Closes #<ticket>` line so unit PRs auto-close their sub-issue.
- The single source for layout, markers, and lifecycle is `autocode/design/design-folder.md`; skills `@`-import it.

## Testing Notes

- Plugin shape check passes; all shell scripts pass shellcheck; both workflow YAMLs parse and the Action's embedded bash is syntax-clean.
- The Stop hook was exercised against a temp repo (nudges per new commit, de-dups on unchanged HEAD).
- The live `gh`/GraphQL fan-out paths were not run against a real repo; first real fan-out is the thing to watch (sub-issue `addSubIssue` link, `## Summary`/frontmatter extraction).

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
