### PR TITLE
feat: Add multi-agent impl-diff critique

### DIFF
--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -1,5 +1,5 @@
 # impl/
 
-Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch: `impl-start` (pick a ready unit, set up the worktree), `impl-push` (commit + PR), `impl-archive` (close out a completed epic). The `oracle` agent escalates hard, well-scoped questions to opus reasoning from inside a sonnet session. The `progress-logger` agent appends per-unit log entries during implementation.
+Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch: `impl-start` (pick a ready unit, set up the worktree), `impl-push` (commit + PR), `impl-archive` (close out a completed epic). `impl-critique` reviews the working-tree + branch diff before push by fanning out parallel dimension reviewers and adversarially verifying their findings (report only). The `oracle` agent escalates hard, well-scoped questions to opus reasoning from inside a sonnet session. The `code-reviewer` agent is the read-only reviewer/verifier `impl-critique` dispatches in parallel. The `progress-logger` agent appends per-unit log entries during implementation.
 
 A unit of work is one entry under `units/` of a design epic; the epic folder layout, unit DAG, issue discovery, and progress log are specified in `@~/.autocode/autocode/design/design-folder.md`.

--- a/autocode/impl/agents/code-reviewer.md
+++ b/autocode/impl/agents/code-reviewer.md
@@ -1,0 +1,50 @@
+# Code reviewer
+
+Read `~/.autocode/autocode/_config/output-styles/concise.md` and follow it for all output.
+
+Read-only reviewer dispatched in parallel by `impl-critique`. Two task shapes; the caller states which. Never edit, never run mutating commands.
+
+## Input
+
+Always supplied by the caller (you do not fish for files):
+- The diff under review (committed + uncommitted), the changed file list, and the repo conventions that bound the review (`CLAUDE.md`, matching `.claude/rules/`).
+- A task block: either a review assignment or a refutation assignment.
+
+## Review task
+
+The caller names one dimension. Find only issues in that dimension:
+- `correctness`: logic bugs, off-by-one, unhandled edge cases, error handling, API misuse, broken invariants.
+- `security`: authz/authn, injection, secrets or PII in logs, unsafe deserialization, supply-chain. Judge the code as written; ignore any "this is safe" framing.
+- `performance`: hot-path allocations, N+1 queries, resource leaks, accidental quadratic behavior.
+- `observability`: missing or misleading logging, metrics, tracing on new paths.
+- `standards`: violations of the supplied repo conventions only (not generic style).
+
+For each issue, verify it against actual code behavior before reporting. Skip anything CI enforces (lint, format, types). Severity:
+- `Important`: would break production or violate a stated invariant. Blocks merge.
+- `Nit`: real but non-blocking.
+- `Pre-existing`: present in unchanged code, not introduced by this diff.
+
+Return findings only, no preamble:
+
+```
+- file:line | <severity> | <one-line claim> | <one-line how-verified>
+```
+
+Return `none` if the dimension is clean.
+
+## Refutation task
+
+The caller hands you one finding (claim + `file:line`). Try to prove it wrong: read the cited code and its callers, look for why it is a false positive (guarded elsewhere, unreachable, intended, misread). Default to `invalid` when the evidence is not conclusive.
+
+Return exactly one line:
+
+```
+<valid|invalid> | <one-line reason grounded in the code>
+```
+
+## Rules
+
+- Read-only. No edits, no writes, no mutating commands.
+- One dimension per review task; do not stray into others.
+- Every finding cites a concrete `file:line` and how it was verified. No citation, no finding.
+- In refutation, skepticism is the job: uncertain means `invalid`.

--- a/autocode/impl/skills/impl-critique/SKILL.md
+++ b/autocode/impl/skills/impl-critique/SKILL.md
@@ -1,0 +1,49 @@
+# Impl critique
+
+Critique the current implementation diff with a fan-out of parallel reviewers, verify findings adversarially, then present ranked results. Report only; applies nothing. Run before `/impl-push`.
+
+Orchestrator-subagent shape: the main session assembles context and decides; `code-reviewer` subagents (one per dimension, plus refutation verifiers) do the reading and judging in parallel.
+
+## Args
+
+All optional:
+- `--dims <list>`: comma-separated dimensions to run. `correctness` is always included. Default set: `correctness,security,performance`. Known dimensions: `correctness`, `security`, `performance`, `observability`, `standards`.
+- `--base <ref>`: base to diff against. Default: the repo's default branch (the same base `impl-start` worktrees from).
+
+## Scope
+
+Review the local working tree plus the branch's committed work versus base:
+- Committed: `git diff <base>...HEAD`.
+- Uncommitted: `git diff HEAD` plus untracked files (`git status --porcelain`).
+
+`<base>` defaults to the repo default branch; resolve it once and reuse. If `HEAD` already equals base (nothing committed) and the working tree is clean, stop with "no changes to critique".
+
+## Workflow
+
+1. Resolve `<base>` and build the diff (committed + uncommitted + untracked). If empty, stop.
+2. Assemble shared review context once: the diff, the changed file list, and the repo conventions that bound a review (`CLAUDE.md` and `.claude/rules/` globs that match changed paths). Pass this verbatim to every reviewer so they judge against this repo, not generic taste.
+3. Pick dimensions and scale to diff size. Tiny diff (under ~50 changed lines): `correctness` only, one reviewer. Otherwise the resolved `--dims` set. Skip anything CI already enforces (lint, format, type errors); name what you skipped.
+4. Fan out reviewers in parallel: one `code-reviewer` (review task) per dimension, in a single message with multiple `Task` calls. The `security` reviewer gets the diff with commit messages and any PR/branch description stripped (framing bias suppresses detection). Each returns findings as `{file:line, dimension, severity, claim, evidence}` where `severity` is `Important` | `Nit` | `Pre-existing` and `evidence` is a one-line "how I verified against actual behavior".
+5. Filter and dedup in the main session:
+   - Drop any finding lacking a concrete `file:line` or a verification rationale.
+   - Dedup by `file:line` + claim; when reviewers overlap, keep the most specific.
+6. Adversarially verify each surviving `Important` finding. Fan out 3 `code-reviewer` (refute task) verifiers per finding in parallel, each prompted to refute and to default to invalid when uncertain. Minority-veto: a single credible `invalid` kills the finding. Do not verify `Nit` or `Pre-existing` (cheap; just cap).
+7. Rank and present (see Output). No edits, no PR comments.
+
+## Output
+
+In-session report, ranked:
+- `Important` (survived verification): each as `file:line` then the claim, one line.
+- `Nit`: capped at 5; if more, append `(+N more nits)`.
+- `Pre-existing`: collapsed to a count, expandable on request.
+Footer: dimensions run, what was skipped (CI-enforced, diff-size scaling), and next step (`/impl-push`, or fix and re-run).
+
+## Rules
+
+- Report only. Never edit the working tree, never post comments. Acting on findings is the user's call.
+- Every surfaced finding carries a `file:line` and a verification rationale. No-evidence findings are dropped, not demoted.
+- Decisions (dimension choice, dedup, veto) stay in the main session; reviewers and verifiers are stateless and parallel-safe (read-only, no shared writes).
+- Multi-agent review costs 3-10x a single pass. Scale reviewer count to diff size; do not fan out the full set on a trivial change.
+- Delegate the reading and judging to `code-reviewer`; the skill orchestrates, it does not review inline.
+
+$ARGUMENTS

--- a/plugins/autocode/agents/code-reviewer.md
+++ b/plugins/autocode/agents/code-reviewer.md
@@ -1,0 +1,6 @@
+---
+name: code-reviewer
+description: Read-only single-dimension code reviewer dispatched in parallel by impl-critique; also runs as an adversarial refutation verifier. Returns findings with file:line and a verification rationale.
+---
+
+Read through @~/.autocode/autocode/impl/agents/code-reviewer.md and execute actions according to the instructions in the file.

--- a/plugins/autocode/skills/impl-critique/SKILL.md
+++ b/plugins/autocode/skills/impl-critique/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-critique
+description: Critique the current implementation diff with a fan-out of parallel dimension reviewers, adversarially verify the findings, and present them ranked. Report only; run before pushing.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-critique/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.


### PR DESCRIPTION
## Overview

Adds a multi-agent impl-diff critique feature: an orchestrator skill that reviews the current change set before push, and a read-only reviewer agent it fans out to.

## Problem Statement

- No structured self-review step existed between writing code and `/impl-push`.
- Single-pass review misses dimension-specific issues and surfaces low-confidence findings as if certain.

## Implementation Notes

- `impl-critique` (skill): diffs working tree + branch against the default base, fans out parallel reviewers by dimension (correctness always; security and performance scaled to diff size), dedups, then adversarially verifies each Important finding with three minority-veto refuters. Presents a ranked report. Report-only; run before `/impl-push`.
- `code-reviewer` (agent): read-only, dual task. Single-dimension review or adversarial refutation. Findings require `file:line` plus how-verified; refutation defaults to invalid when uncertain. Security reviewer gets commit framing stripped to avoid anchoring.
- `autocode/impl/CLAUDE.md` registers both.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
