### PR TITLE
fix: Correct gh field set and exit handling in provider scripts

### DIFF
--- a/autocode/pr/skills/pr-fix-ci/SKILL.md
+++ b/autocode/pr/skills/pr-fix-ci/SKILL.md
@@ -9,7 +9,7 @@ Diagnose failing CI checks and apply minimal fixes.
 ## Workflow
 
 1. Resolve PR (arg or `provider/run.sh git-remote pr-view --json number`).
-2. List checks: `provider/run.sh ci pr-check-list <pr>`. If all green, report and stop.
+2. List checks: `provider/run.sh ci pr-check-list <pr>`. Green when every check's `bucket` is `pass` or `skipping`; if so, report and stop. A `pending` bucket means CI is still running, not failing.
 3. For each failing check:
    - Fetch the failure log: `provider/run.sh ci run-view-failed <run-id>`. The script already caps to the last 200 lines of the failing step.
    - Diagnose: classify as lint / build / test / workflow. Read the source or config files referenced in the failure.

--- a/provider/ci/contract.md
+++ b/provider/ci/contract.md
@@ -35,12 +35,14 @@ Workflow-run inspection: list PR-level checks, list recent runs for a branch, an
 ```json
 {
   "name": "<string>",
-  "status": "<string>",
-  "conclusion": "<string|empty>",
+  "bucket": "pass|fail|pending|skipping|cancel",
+  "state": "<string>",
   "link": "<string>",
   "workflow": "<string>"
 }
 ```
+
+`bucket` is the normalized outcome callers branch on (a PR is green when every check is `pass` or `skipping`). `state` is the raw provider state (e.g. `SUCCESS`, `FAILURE`, `IN_PROGRESS`). A provider that lacks a native rollup must derive `bucket` itself.
 
 ## Required scripts
 
@@ -52,7 +54,7 @@ Workflow-run inspection: list PR-level checks, list recent runs for a branch, an
 
 ### Notes
 
-- `pr-check-list.sh` returns `[]` when no checks have run.
+- `pr-check-list.sh` returns `[]` when no checks have run, and still returns the `Check[]` array (exit `0`) when checks are failing or pending.
 - `run-list.sh` default limit is `10`. Most-recent first.
 - `run-view-failed.sh` returns plain text, not JSON. The cap is 200 lines from the tail of the failed step's log.
 - The `provider.ci` setting falls back to `provider.git-remote` when unset; `provider/run.sh` performs the fallback so callers always invoke `provider/run.sh ci <feature>`.

--- a/provider/ci/github/pr-check-list.sh
+++ b/provider/ci/github/pr-check-list.sh
@@ -3,8 +3,18 @@ set -euo pipefail
 
 # List CI check status for a PR.
 # Usage: pr-check-list.sh <pr-number>
-# Stdout: JSON array of { name, status, conclusion, link, workflow }.
+# Stdout: JSON array of { name, bucket, state, link, workflow }.
 
 pr_number="${1:?Usage: pr-check-list.sh <pr-number>}"
 
-gh pr checks "${pr_number}" --json name,status,conclusion,link,workflow
+# `gh pr checks` exits non-zero when checks are failing (1) or pending (8), and
+# emits "no checks reported" with empty stdout when none exist. The JSON still
+# lands on stdout in the failing/pending cases, so tolerate the exit code and
+# treat empty output as the no-checks case.
+checks=$(gh pr checks "${pr_number}" --json name,bucket,state,link,workflow 2>/dev/null) || true
+
+if [[ -z "${checks}" ]]; then
+  printf '[]\n'
+else
+  printf '%s\n' "${checks}"
+fi

--- a/provider/git-remote/contract.md
+++ b/provider/git-remote/contract.md
@@ -73,7 +73,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 ### Notes
 
 - `pr-view.sh` defaults to the PR for the current branch when `<pr>` is omitted. With `--json`, stdout is JSON containing the requested fields.
-- `pr-create.sh` `--no-review` suppresses auto-requesting reviewers from CODEOWNERS or branch protection.
+- `pr-create.sh` `--no-review` opens the PR without the script requesting any reviewers (no `--reviewer` passed to gh). Server-side CODEOWNERS auto-request, when the repo enables it, is outside gh's control and is not suppressed.
 - `pr-issue-link.sh` is idempotent. It detects existing `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved #N` references (case-insensitive, word-boundary anchored) and skips when present. When missing, it appends a canonical `Closes #N` line.
 - `pr-review-request.sh` tolerates reviewers already on the PR without error.
 - `pr-comment-list.sh` default `--kind` is `all`. The merged list discriminates via `.kind`.

--- a/provider/git-remote/github/pr-create.sh
+++ b/provider/git-remote/github/pr-create.sh
@@ -61,9 +61,11 @@ if [[ -n "${assignee}" ]]; then
   args+=(--assignee "${assignee}")
 fi
 if [[ "${no_review}" -eq 1 ]]; then
-  # `gh pr create` does not auto-request reviewers unless asked, but some
-  # repos rely on CODEOWNERS. Pass an empty --reviewer list explicitly.
-  args+=(--reviewer "")
+  # gh requests reviewers only when --reviewer is passed, so omitting it is how
+  # a PR opens without requesting reviews. Passing --reviewer "" instead sends
+  # an empty handle that gh rejects. Server-side CODEOWNERS auto-request, when
+  # the repo enables it, is not controllable from gh.
+  :
 fi
 
 gh "${args[@]}"


### PR DESCRIPTION
## Overview

Fixes two bugs in the GitHub provider scripts: a wrong field set plus an exit-code abort in `pr-check-list.sh`, and an invalid empty `--reviewer` in `pr-create.sh --no-review`.

## Problem Statement

- `pr-check-list.sh` queried `gh pr checks --json name,status,conclusion`, but `status`/`conclusion` are not valid fields, so the call errored.
- The same script ran under `set -euo pipefail`; `gh pr checks` exits `8` when checks are pending and non-zero when failing, aborting the script exactly when `pr-fix-ci` needs it.
- `pr-create.sh --no-review` appended `--reviewer ""`, an empty handle `gh` rejects, and it never suppressed CODEOWNERS anyway.

## Implementation Notes

- `pr-check-list.sh`: switch to `name,bucket,state,link,workflow`; tolerate the non-zero exit (JSON still prints) and map empty output to `[]`.
- `pr-fix-ci/SKILL.md`: branch on `bucket` (`pass`/`skipping` green, `pending` still running).
- `pr-create.sh`: pass no `--reviewer` under `--no-review`.
- `provider/ci/contract.md` and `provider/git-remote/contract.md`: update the `Check` type and the `--no-review` note. Remaining audited scripts verified clean; shellcheck clean.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
