### PR TITLE
fix: Native issue type without org read, plus autocode-update hardening

### DIFF
--- a/autocode/_config/conventions/issue-lifecycle.md
+++ b/autocode/_config/conventions/issue-lifecycle.md
@@ -34,7 +34,7 @@ The epic has no `in-review` state: there is no aggregate epic PR. Each unit has 
 
 ## Default
 
-- GitHub: `todo`, `in-progress`, `in-review` all map to `open` with an `autocode:<state>` label distinguishing them; `done` maps to `closed`.
+- GitHub: `in-progress` and `in-review` map to `open` with an `autocode:<state>` label; `todo` is `open` with no state label (the absence of a label is the default state); `done` maps to `closed`.
 - Jira: 1-to-1 mapping with `To Do`, `In Progress`, `In Review`, `Done`.
 
 ## Output format

--- a/autocode/design/design-folder.md
+++ b/autocode/design/design-folder.md
@@ -50,7 +50,7 @@ When the work is one PR's worth, the epic and the unit are the same thing. The d
 
 The rule everything keys on: `units/` present -> multi-unit epic; `units/` absent -> flat single issue. Use flat when the plan would otherwise produce a single unit; use multi-unit when the work splits into independently mergeable pieces.
 
-All four are committed. Only the transient state files `.autocode/.impl-context` and `.autocode/.progress-last-sha` (written by `impl-start` and the progress hook) are gitignored.
+All four are committed. Only the transient state files `.autocode/.impl-context` and `.autocode/.progress-last-sha` (written by `impl-start` and the progress hook) are gitignored; this list is canonical. `/autocode-setup` and `/autocode-update` scaffold `<repo-root>/.autocode/.gitignore` to ignore them, with `impl-start` as a backstop. The repo-root `.autocode/` always holds these artifacts, independent of where `AUTOCODE_CONFIG_DIR` points.
 
 ## DESIGN.md
 

--- a/autocode/impl/skills/impl-start/SKILL.md
+++ b/autocode/impl/skills/impl-start/SKILL.md
@@ -46,6 +46,6 @@ One of:
 - Never branch from a dirty working tree on the default branch.
 - Delegate branch creation to `git-create-branch`; never duplicate that logic.
 - Pick exactly one ready unit per invocation. Re-run the skill to start another.
-- The state files (`.autocode/.impl-context`, `.autocode/.progress-last-sha`) are gitignored; ensure `$repo_root/.autocode/.gitignore` ignores them (create if missing).
+- The state files (`.autocode/.impl-context`, `.autocode/.progress-last-sha`) are gitignored. `/autocode-setup` and `/autocode-update` are the primary owners of `$repo_root/.autocode/.gitignore`; as a backstop (relocated config dir, or a repo set up before this was added), ensure it ignores them here (create if missing, append if absent).
 
 $ARGUMENTS

--- a/plugins/autocode/skills/autocode-setup/SKILL.md
+++ b/plugins/autocode/skills/autocode-setup/SKILL.md
@@ -67,7 +67,10 @@ For each invocation, capture stdout and:
 
 Use the Write tool to persist. The script already pretty-prints with two-space indent.
 
-After writing, ensure `$AUTOCODE_CONFIG_DIR/.gitignore` contains a `settings.local.json` line. Create the file with that single line if missing; if present, append the line only when absent.
+After writing, reconcile two ignore rules. Each is idempotent: create the file with the line if missing, append only when absent.
+
+- `settings.local.json` in `$AUTOCODE_CONFIG_DIR/.gitignore` (the config dir).
+- the transient impl state files (`.impl-context`, `.progress-last-sha`; canonical list in the design-folder spec, `~/.autocode/autocode/design/design-folder.md`) in `<repo-root>/.autocode/.gitignore`, the repo-root artifact dir the impl hook and design skills key on (always there, not via `AUTOCODE_CONFIG_DIR`). When the config dir is the default `<repo-root>/.autocode/`, this is the same file and both rules land in it. When it is relocated, only reconcile `<repo-root>/.autocode/.gitignore` if that dir already exists; otherwise leave it to the `impl-start` backstop, which creates the dir on first use.
 
 ## Step 4: Scaffold conventions
 

--- a/plugins/autocode/skills/autocode-update/SKILL.md
+++ b/plugins/autocode/skills/autocode-update/SKILL.md
@@ -27,6 +27,21 @@ Behavior:
 
 The script exits non-zero on any failure; surface its stderr to the user verbatim.
 
+## Step 1b: Plugin staleness check
+
+The pull refreshes `~/.autocode/` only. This skill, all skill/agent frontmatter, and the inline bootstrap files (`autocode-setup`, `autocode-update` itself, the hooks) are served from the installed plugin, which updates through Claude Code's plugin channel, not this pull. So an updated `/autocode-update` description, or any other frontmatter change, now sits in the freshly-pulled `~/.autocode/` but not in the running plugin.
+
+Detect that drift:
+
+```
+bash ${CLAUDE_SKILL_DIR}/scripts/check-plugin-drift.sh
+```
+
+It compares the installed plugin's `skills/`, `agents/`, and `hooks/` against `~/.autocode/plugins/autocode/` and prints `{"stale": <bool>, "files": [...]}`.
+
+- `stale: false`: nothing to do.
+- `stale: true`: the installed plugin is behind the pulled checkout (this includes `/autocode-update`'s own description). Name the differing files and tell the user to update the plugin through Claude Code's plugin manager, then restart the session for the changes to load. Re-reading the new body in this run does not help: the running skill and all frontmatter were parsed at session start, so the update only takes effect next session.
+
 ## Step 2: Reconcile settings
 
 After the pull succeeds, read `~/.autocode/autocode/_config/settings-schema.md`. It declares which top-level namespaces are shared (`provider.*`, `workflow.*` -> `settings.json`) and which are local (`paths.*` -> `settings.local.json`), plus which keys are required.
@@ -35,7 +50,9 @@ Check each file under `$AUTOCODE_CONFIG_DIR/`:
 
 1. **Required-key drift.** For every key the schema marks required, verify it exists in the file matching its scope. Report any missing required key. Offer to scaffold it now using the same prompt logic as `/autocode-setup` step 3 (ask the user, then call `write-settings.sh --scope=<scope>` and merge into the existing file via `jq` rather than overwriting).
 2. **Scope migration.** Read both files; for any key whose namespace does not match the file it sits in (e.g. a `paths.*` key found in `settings.json`, or a `provider.*` key found in `settings.local.json`), move it to the correct file. Report each move. Use `jq` to delete from the wrong file and add to the right one in one pass; never lose values.
-3. **Gitignore.** Verify `$AUTOCODE_CONFIG_DIR/.gitignore` exists and contains a `settings.local.json` line. If missing or absent, append it. Report only when changed.
+3. **Gitignore.** Verify two ignore rules, each idempotent (append the line if missing). Report only when changed.
+   - `settings.local.json` in `$AUTOCODE_CONFIG_DIR/.gitignore`.
+   - the transient impl state files (`.impl-context`, `.progress-last-sha`; canonical list in the design-folder spec) in `<repo-root>/.autocode/.gitignore`. Default config dir: same file. Relocated: reconcile only if `<repo-root>/.autocode/` exists; the `impl-start` backstop covers the not-yet-created case.
 
 If `settings.local.json` does not exist and no local keys are required, leave it absent (a fresh repo with no local wiring is valid).
 
@@ -59,6 +76,6 @@ For each existing convention file:
 
 ## Done
 
-One terse line: commits pulled, settings keys migrated/scaffolded, conventions missing/scaffolded, drift flagged. Skip the "next run" note; the `SessionStart` hook handles nudging. No narration of skipped steps (e.g. do not mention that `--force` was absent).
+One terse line: commits pulled, plugin staleness flagged, settings keys migrated/scaffolded, conventions missing/scaffolded, drift flagged. Skip the "next run" note; the `SessionStart` hook handles nudging. No narration of skipped steps (e.g. do not mention that `--force` was absent).
 
 `$ARGUMENTS`

--- a/plugins/autocode/skills/autocode-update/scripts/check-plugin-drift.sh
+++ b/plugins/autocode/skills/autocode-update/scripts/check-plugin-drift.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compare the installed plugin's session-start-parsed surface (skill/agent
+# frontmatter shims plus the inline bootstrap skills and hooks) against the
+# freshly-pulled ~/.autocode/ checkout.
+#
+# autocode-update's git pull refreshes ~/.autocode/ only; the installed plugin
+# updates through Claude Code's plugin channel, not this pull. When the two
+# diverge the running plugin is stale: frontmatter and bootstrap changes (this
+# skill's own description included) sit in ~/.autocode/ but will not load until
+# the plugin is updated and the session restarts.
+#
+# Output (stdout, JSON): {"stale": <bool>, "files": [<diff lines>]}.
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+plugin_root=$(cd "${script_dir}/../../.." && pwd)   # scripts -> autocode-update -> skills -> plugin root
+canonical="${HOME}/.autocode/plugins/autocode"
+
+emit() { jq -n --argjson stale "$1" --argjson files "$2" '{stale: $stale, files: $files}'; }
+
+if [[ ! -d "${canonical}" ]]; then
+  echo "warning: ${canonical} not found; skipping plugin drift check" >&2
+  emit false '[]'
+  exit 0
+fi
+
+# Symlinked dev checkout: the installed plugin is the canonical tree, so there
+# is no separate channel to drift.
+if [[ "${plugin_root}" -ef "${canonical}" ]]; then
+  emit false '[]'
+  exit 0
+fi
+
+diffs=""
+for sub in skills agents hooks; do
+  out=$(diff -rq "${plugin_root}/${sub}" "${canonical}/${sub}" 2>/dev/null || true)
+  [[ -n "${out}" ]] && diffs+="${out}"$'\n'
+done
+
+if [[ -z "${diffs}" ]]; then
+  emit false '[]'
+else
+  files=$(printf '%s' "${diffs}" | sed '/^$/d' | jq -R . | jq -s .)
+  emit true "${files}"
+fi
+exit 0

--- a/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/action.yml
+++ b/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/action.yml
@@ -18,18 +18,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Resolve org issue types
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
-        REPO: ${{ inputs.repo }}
-      run: |
-        set -euo pipefail
-        owner="${REPO%%/*}"
-        gh api "/orgs/${owner}/issue-types" 2>/dev/null \
-          | jq -r '.[] | "\(.name | ascii_downcase)\t\(.name)"' > "${RUNNER_TEMP}/org-types.tsv" || true
-        touch "${RUNNER_TEMP}/org-types.tsv"
-
     - name: Render issue bodies
       id: render
       shell: bash
@@ -61,7 +49,7 @@ runs:
         if [[ -n "${num}" ]]; then
           echo "epic already exists: #${num}"
         else
-          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}" "${RUNNER_TEMP}/org-types.tsv")
+          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}")
           echo "created epic #${num}"
         fi
         node=$(gh api graphql -H "GraphQL-Features:sub_issues" \
@@ -87,7 +75,7 @@ runs:
             echo "unit ${slug} already linked; skip"
             continue
           fi
-          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}" "${RUNNER_TEMP}/org-types.tsv" "${EPIC_NODE}")
+          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}" "${EPIC_NODE}")
           echo "created and linked unit ${slug} as #${num}"
           sleep 1
         done < <(awk -F'\t' '$1=="unit"' "${manifest}")

--- a/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/create-design-issue.sh
+++ b/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/create-design-issue.sh
@@ -5,14 +5,15 @@
 # this once per epic and once per unit, passing the rendered body and (for units)
 # the epic's GraphQL node id.
 #
-# Type: when the owning org defines a matching native Issue Type (case-insensitive)
-# it is set via PATCH; otherwise a `type:<x>` label is applied as a fallback.
+# Type: set as a native Issue Type by name via a repo-scoped REST write, then
+# confirmed by reading it back. If the type did not take (the org defines no such
+# type, or none at all), a `type:<x>` label is applied as a fallback. Avoids the
+# org-scoped issue-types read, which the workflow GITHUB_TOKEN cannot perform.
 #
 # Usage:
-#   create-design-issue.sh <repo> <title> <type> <body-file> <org-types-file> [parent-node-id]
+#   create-design-issue.sh <repo> <title> <type> <body-file> [parent-node-id]
 #
-# <org-types-file> is a TSV of `lowercased-name<TAB>native-name`, empty when the
-# owner defines no native types. Prints the created issue number on stdout.
+# Prints the created issue number on stdout.
 
 set -euo pipefail
 
@@ -20,8 +21,7 @@ repo="$1"
 title="$2"
 type="$3"
 body_file="$4"
-org_types_file="$5"
-parent_node="${6:-}"
+parent_node="${5:-}"
 
 owner="${repo%%/*}"
 name="${repo##*/}"
@@ -35,20 +35,19 @@ node_id() {  # $1=issue number
     -f o="${owner}" -f n="${name}" -F num="$1" --jq '.data.repository.issue.id'
 }
 
-native=$(awk -F'\t' -v w="$(printf '%s' "${type}" | tr '[:upper:]' '[:lower:]')" '$1==w{print $2; exit}' "${org_types_file}")
+type_lower=$(printf '%s' "${type}" | tr '[:upper:]' '[:lower:]')
+# Issue Types are named in Title case (Bug, Task, ...); match that when setting.
+type_name=$(printf '%s' "${type_lower}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
 
-args=(issue create --repo "${repo}" --title "${title}" --body-file "${body_file}")
-if [[ -z "${native}" ]]; then
-  tl=$(printf '%s' "${type}" | tr '[:upper:]' '[:lower:]')
-  gh label create "type:${tl}" --force >/dev/null 2>&1 || true
-  args+=(--label "type:${tl}")
-fi
+num=$(gh issue create --repo "${repo}" --title "${title}" --body-file "${body_file}" | grep -oE '[0-9]+$')
 
-num=$(gh "${args[@]}" | grep -oE '[0-9]+$')
-
-if [[ -n "${native}" ]]; then
-  gh api -X PATCH "/repos/${repo}/issues/${num}" -f type="${native}" >/dev/null 2>&1 \
-    || echo "warning: created #${num} but could not set native type ${native}" >&2
+# Set the native Issue Type by name (repo-scoped); an unknown name is silently
+# dropped, so confirm by reading it back and fall back to a type:<x> label.
+gh api -X PATCH "/repos/${repo}/issues/${num}" -f type="${type_name}" >/dev/null 2>&1 || true
+applied=$(gh api "/repos/${repo}/issues/${num}" --jq '.type.name // empty' 2>/dev/null || true)
+if [[ -z "${applied}" ]]; then
+  gh label create "type:${type_lower}" --repo "${repo}" --force >/dev/null 2>&1 || true
+  gh issue edit "${num}" --repo "${repo}" --add-label "type:${type_lower}" >/dev/null
 fi
 
 if [[ -n "${parent_node}" ]]; then

--- a/provider/issue-tracker/contract.md
+++ b/provider/issue-tracker/contract.md
@@ -55,7 +55,7 @@ Tracker-side issue operations: view, create, identity, and future label / commen
 
 `issue-epic-list.sh` powers design-epic discovery: given an autocode epic `<id>`, return that epic's issue plus every unit sub-issue (`Issue[]`), in one live call (no search index). The caller matches body markers client-side (`autocode:epic=<id>`, `autocode:unit=<id>/<slug>`) to assign roles and read each unit's state. Each provider resolves the set natively: GitHub finds the epic by its body marker and reads units from the sub-issue relationship (no per-epic label); a provider without a native parent/child relationship may instead carry an `autocode-epic:<id>` label on every issue of the epic and list by it. Unit rows carry `parent` = the epic key; the epic row carries `parent: ""`. Default state is `all`, so a closed (done) epic or unit is included.
 
-`issue-transition.sh` accepts only the four-state enum values (`todo`, `in-progress`, `in-review`, `done`); the provider maps them to native state (GitHub: `autocode:<state>` label for open states, `closed` for done). Idempotent.
+`issue-transition.sh` accepts only the four-state enum values (`todo`, `in-progress`, `in-review`, `done`); the provider maps them to native state (GitHub: `autocode:in-progress` / `autocode:in-review` label for those two states, `todo` is open with no state label, `closed` for done). Idempotent.
 
 ## Optional scripts
 

--- a/provider/issue-tracker/github/issue-create.sh
+++ b/provider/issue-tracker/github/issue-create.sh
@@ -6,10 +6,11 @@ set -euo pipefail
 #                  [-a <assignee>] [-S <points>] [-g <owner/repo>] [-l <label>]...
 # Depends on: gh, jq.
 #
-# Issue type: materialized as a native GitHub Issue Type when the owning org
-# exposes a matching one (case-insensitive, e.g. autocode `bug` -> GitHub `Bug`);
-# otherwise falls back to a `type:<x>` label. Issue Types are org-scoped, so user
-# repos and orgs lacking the type always take the label path.
+# Issue type: set as a native GitHub Issue Type by name (e.g. autocode `bug` ->
+# GitHub `Bug`) via a repo-scoped REST write, then confirmed by reading it back.
+# If the type did not take (the org defines no such type, or none at all as on
+# user repos) it falls back to a `type:<x>` label. Avoids the org-scoped
+# issue-types read, which a workflow GITHUB_TOKEN cannot perform.
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "issue-create.sh: gh CLI not on PATH; install GitHub CLI and run 'gh auth login'" >&2
@@ -63,22 +64,12 @@ else
 fi
 
 type_lower=$(printf '%s' "${type}" | tr '[:upper:]' '[:lower:]')
-
-# Resolve the native Issue Type name when the org exposes a match; empty -> label.
-native_type=""
-if org_types=$(gh api "/orgs/${owner}/issue-types" 2>/dev/null); then
-  native_type=$(printf '%s' "${org_types}" \
-    | jq -r --arg w "${type_lower}" 'map(select((.name | ascii_downcase) == $w))[0].name // empty')
-fi
+# Issue Types are named in Title case (Bug, Task, ...); match that when setting.
+type_name=$(printf '%s' "${type_lower}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
 
 args=(issue create --title "${summary}")
 if [[ -n "${repo_override}" ]]; then
   args+=(--repo "${repo_override}")
-fi
-
-if [[ -z "${native_type}" ]]; then
-  gh label create "type:${type_lower}" --force >/dev/null 2>&1 || true
-  args+=(--label "type:${type_lower}")
 fi
 
 if [[ -n "${body_file}" ]]; then
@@ -103,10 +94,18 @@ if [[ -z "${child_number}" ]]; then
   exit 2
 fi
 
-# gh issue create has no native-type flag; set it via REST after creation.
-if [[ -n "${native_type}" ]]; then
-  gh api -X PATCH "/repos/${owner}/${name}/issues/${child_number}" -f type="${native_type}" >/dev/null \
-    || echo "issue-create.sh: warning: created #${child_number} but could not set native issue type '${native_type}'" >&2
+# Set the native Issue Type by name (repo-scoped issues:write; no org read). An
+# unknown type name is silently dropped, so confirm by reading it back; apply a
+# type:<x> label only when the type did not take.
+gh api -X PATCH "/repos/${owner}/${name}/issues/${child_number}" -f type="${type_name}" >/dev/null 2>&1 || true
+applied_type=$(gh api "/repos/${owner}/${name}/issues/${child_number}" --jq '.type.name // empty' 2>/dev/null || true)
+if [[ -z "${applied_type}" ]]; then
+  gh label create "type:${type_lower}" --force >/dev/null 2>&1 || true
+  edit_args=(issue edit "${child_number}" --add-label "type:${type_lower}")
+  if [[ -n "${repo_override}" ]]; then
+    edit_args+=(--repo "${repo_override}")
+  fi
+  gh "${edit_args[@]}" >/dev/null
 fi
 
 # Link as sub-issue when a parent was requested.

--- a/provider/issue-tracker/github/issue-epic-list.sh
+++ b/provider/issue-tracker/github/issue-epic-list.sh
@@ -75,7 +75,6 @@ issue_filter='
           [.labels[].name] as $names |
           if ($names | any(. == "autocode:in-review")) then "in-review"
           elif ($names | any(. == "autocode:in-progress")) then "in-progress"
-          elif ($names | any(. == "autocode:todo")) then "todo"
           else "todo"
           end
         )

--- a/provider/issue-tracker/github/issue-transition.sh
+++ b/provider/issue-tracker/github/issue-transition.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Move an issue to one of the four contract states. Open states are distinguished
-# by an autocode:<state> label; `done` closes the issue. Idempotent.
+# Move an issue to one of the four contract states. `in-progress` and `in-review`
+# carry an autocode:<state> label; `todo` is open with no state label; `done`
+# closes the issue. Idempotent.
 # Usage: issue-transition.sh <key> <status>
 #   status: todo | in-progress | in-review | done
 # Depends on: gh, jq.
@@ -25,13 +26,15 @@ case "${status}" in
   *) echo "issue-transition.sh: status must be one of todo, in-progress, in-review, done (got: ${status})" >&2; exit 1 ;;
 esac
 
-state_labels=("autocode:todo" "autocode:in-progress" "autocode:in-review")
+# Only in-progress and in-review carry a state label; todo is open with no
+# state label, done is closed.
+state_labels=("autocode:in-progress" "autocode:in-review")
 
 current=$(gh issue view "${key}" --json state,labels --jq '{state: .state, labels: [.labels[].name]}')
 gh_state=$(printf '%s' "${current}" | jq -r '.state')
 
 desired_label=""
-if [[ "${status}" != "done" ]]; then
+if [[ "${status}" == "in-progress" || "${status}" == "in-review" ]]; then
   desired_label="autocode:${status}"
 fi
 
@@ -48,21 +51,22 @@ if [[ "${#remove[@]}" -gt 0 ]]; then
   remove_csv=$(IFS=,; printf '%s' "${remove[*]}")
 fi
 
+edit_args=(issue edit "${key}")
+if [[ -n "${desired_label}" ]]; then
+  gh label create "${desired_label}" --force >/dev/null 2>&1 || true
+  edit_args+=(--add-label "${desired_label}")
+fi
+if [[ -n "${remove_csv}" ]]; then
+  edit_args+=(--remove-label "${remove_csv}")
+fi
+if [[ -n "${desired_label}" || -n "${remove_csv}" ]]; then
+  gh "${edit_args[@]}" >/dev/null
+fi
+
 if [[ "${status}" == "done" ]]; then
-  if [[ -n "${remove_csv}" ]]; then
-    gh issue edit "${key}" --remove-label "${remove_csv}" >/dev/null
-  fi
   if [[ "${gh_state}" != "CLOSED" ]]; then
     gh issue close "${key}" >/dev/null
   fi
-else
-  gh label create "${desired_label}" --force >/dev/null 2>&1 || true
-  edit_args=(issue edit "${key}" --add-label "${desired_label}")
-  if [[ -n "${remove_csv}" ]]; then
-    edit_args+=(--remove-label "${remove_csv}")
-  fi
-  gh "${edit_args[@]}" >/dev/null
-  if [[ "${gh_state}" == "CLOSED" ]]; then
-    gh issue reopen "${key}" >/dev/null
-  fi
+elif [[ "${gh_state}" == "CLOSED" ]]; then
+  gh issue reopen "${key}" >/dev/null
 fi

--- a/provider/issue-tracker/github/issue-view.sh
+++ b/provider/issue-tracker/github/issue-view.sh
@@ -67,7 +67,6 @@ gh api "/repos/${owner}/${name}/issues/${issue_number}" \
           [.labels[].name] as $names |
           if ($names | any(. == "autocode:in-review")) then "in-review"
           elif ($names | any(. == "autocode:in-progress")) then "in-progress"
-          elif ($names | any(. == "autocode:todo")) then "todo"
           else "todo"
           end
         )


### PR DESCRIPTION
## Overview

Set GitHub issues' native Issue Type by name (with a label fallback) so the design-fanout Action stops mislabeling issues as `type:bug`, and harden `autocode-update` with state-file gitignore ownership plus a plugin-staleness check.

## Problem Statement

- The fanout Action read `/orgs/{org}/issue-types` with the repo-scoped workflow `GITHUB_TOKEN`, which cannot read org endpoints; the empty result forced every issue onto a `type:<x>` label instead of the native Issue Type.
- `autocode:todo` was dead: nothing transitions an issue to `todo`, so the label was never applied, only carried defensively.
- Setup/update did not own the repo-root `.autocode/.gitignore` for the transient state files, and `autocode-update` could not detect when the installed plugin was stale relative to its freshly-pulled checkout.

## Implementation Notes

- Issue type: set by name via the repo-scoped REST write the token already has, confirmed by reading `.type.name` back; `type:<x>` label only when the type did not take. The `/orgs/{org}/issue-types` lookup is removed from `issue-create.sh`, `create-design-issue.sh`, and the Action.
- Lifecycle: `todo` is now an explicit no-label open state; the redundant read branches and the strip-set entry are gone; `contract.md` and the `issue-lifecycle` convention are aligned.
- `autocode-update`/`autocode-setup`: scaffold `<repo-root>/.autocode/.gitignore` for the state files (with `impl-start` demoted to a backstop); new `check-plugin-drift.sh` and Step 1b flag a stale installed plugin and tell the user to update and restart.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
