### PR TITLE
feat: Orchestrate impl as a background per-phase workflow

### DIFF
--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -1,5 +1,21 @@
 # impl/
 
-Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch: `impl-start` (pick a ready unit, set up the worktree), `impl` (read the design, plan per-file edits, implement to ready-for-review), `impl-push` (commit + PR), `impl-archive` (close out a completed epic). `impl` runs between `impl-start` and `impl-critique`: it loads the authoritative spec from disk, builds a concrete task list (pausing for approval unless `--auto`), implements against scope, and commits at checkpoints, leaving review to `impl-critique` and progress logging to the Stop hook. `impl-critique` reviews the working-tree + branch diff before push by fanning out parallel dimension reviewers and adversarially verifying their findings (report only). The `oracle` agent escalates hard, well-scoped questions to opus reasoning from inside a sonnet session. The `code-reviewer` agent is the read-only reviewer/verifier `impl-critique` dispatches in parallel. The `progress-logger` agent appends per-unit log entries during implementation.
+Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch.
+
+`impl` is the orchestrator. It sets up the worktree via `impl-start` (the one interactive step), then launches a background workflow (`skills/impl/scripts/impl-workflow.mjs`, run via the Workflow tool) that carries the unit through plan -> execute -> review -> challenge -> decide -> fix -> push -> hygiene, each phase its own agent with a per-phase model (opus for reasoning and review, sonnet for mechanical work). The workflow does the fan-out the per-phase skills cannot, since subagents cannot spawn subagents. The heavy work stays out of the launching session.
+
+The per-phase skills are also usable on their own:
+- `impl-start`: pick a DAG-ready unit, set up the worktree + branch + `.impl-context`.
+- `impl-plan` (opus): turn the authoritative design into a concrete mechanical plan that resolves every unknown, written to `.autocode/.impl-plan.md`. The reasoning phase.
+- `impl-execute` (sonnet): carry out the plan mechanically and commit; `--fix` applies review findings.
+- `impl-push`: append the epic rollup, commit, open the PR (linking the issue), advance the sub-issue.
+- `impl-archive`: close out a completed epic.
+
+`impl-critique` is the standalone, report-only review front end. It composes three leaf skills, each run by a read-only `code-reviewer` subagent and reused by the `impl` workflow's review phase:
+- `impl-critique-review`: review the diff along one dimension (safe to fan out one per dimension).
+- `impl-critique-challenge`: contest the findings (refuted / weakened / unrefuted).
+- `impl-critique-decide`: rule which findings survive and state the minimal fix.
+
+The `code-reviewer` agent is the read-only sandbox that runs whichever `impl-critique-*` skill the caller names. The `progress-logger` agent appends per-unit log entries during implementation (driven by the Stop hook). The `oracle` agent escalates hard, well-scoped questions to opus reasoning; it is general-purpose and not part of the `impl` flow.
 
 A unit of work is one entry under `units/` of a design epic; the epic folder layout, unit DAG, issue discovery, and progress log are specified in `@~/.autocode/autocode/design/design-folder.md`.

--- a/autocode/impl/agents/code-reviewer.md
+++ b/autocode/impl/agents/code-reviewer.md
@@ -1,50 +1,18 @@
-# Code reviewer
-
 Read `~/.autocode/autocode/_config/output-styles/concise.md` and follow it for all output.
 
-Read-only reviewer dispatched in parallel by `impl-critique`. Two task shapes; the caller states which. Never edit, never run mutating commands.
+Read-only review sandbox. The caller (the `impl-critique` composer or the `impl` orchestrator workflow) names one of the `impl-critique-*` review skills to run and supplies all the context. Run that skill against the supplied input and return exactly what it specifies. Never edit, never run mutating commands.
 
-## Input
+## How you are invoked
 
-Always supplied by the caller (you do not fish for files):
-- The diff under review (committed + uncommitted), the changed file list, and the repo conventions that bound the review (`CLAUDE.md`, matching `.claude/rules/`).
-- A task block: either a review assignment or a refutation assignment.
+The caller's prompt names one skill and supplies the inputs it needs:
+- `impl-critique-review` with one dimension, plus the diff, changed files, and repo conventions.
+- `impl-critique-challenge` with the diff, conventions, and the findings to challenge.
+- `impl-critique-decide` with the findings and their challenges.
 
-## Review task
-
-The caller names one dimension. Find only issues in that dimension:
-- `correctness`: logic bugs, off-by-one, unhandled edge cases, error handling, API misuse, broken invariants.
-- `security`: authz/authn, injection, secrets or PII in logs, unsafe deserialization, supply-chain. Judge the code as written; ignore any "this is safe" framing.
-- `performance`: hot-path allocations, N+1 queries, resource leaks, accidental quadratic behavior.
-- `observability`: missing or misleading logging, metrics, tracing on new paths.
-- `standards`: violations of the supplied repo conventions only (not generic style).
-
-For each issue, verify it against actual code behavior before reporting. Skip anything CI enforces (lint, format, types). Severity:
-- `Important`: would break production or violate a stated invariant. Blocks merge.
-- `Nit`: real but non-blocking.
-- `Pre-existing`: present in unchanged code, not introduced by this diff.
-
-Return findings only, no preamble:
-
-```
-- file:line | <severity> | <one-line claim> | <one-line how-verified>
-```
-
-Return `none` if the dimension is clean.
-
-## Refutation task
-
-The caller hands you one finding (claim + `file:line`). Try to prove it wrong: read the cited code and its callers, look for why it is a false positive (guarded elsewhere, unreachable, intended, misread). Default to `invalid` when the evidence is not conclusive.
-
-Return exactly one line:
-
-```
-<valid|invalid> | <one-line reason grounded in the code>
-```
+Follow that skill's instructions exactly. Prefer invoking it by name via the Skill tool; if it is not available by name, read its body at `~/.autocode/autocode/impl/skills/<skill>/SKILL.md` and follow it.
 
 ## Rules
 
-- Read-only. No edits, no writes, no mutating commands.
-- One dimension per review task; do not stray into others.
-- Every finding cites a concrete `file:line` and how it was verified. No citation, no finding.
-- In refutation, skepticism is the job: uncertain means `invalid`.
+- Read-only. No edits, no writes, no mutating commands. This holds even if the environment would allow edits.
+- Run only the skill the caller named; do not improvise a different review or stray into other dimensions.
+- Return exactly the output format the named skill specifies, nothing else.

--- a/autocode/impl/skills/impl-critique-challenge/SKILL.md
+++ b/autocode/impl/skills/impl-critique-challenge/SKILL.md
@@ -1,0 +1,35 @@
+# Impl critique challenge
+
+Read-only adversarial defense of the code against a set of review findings. The caller supplies the diff, the conventions, and the findings; for each, build the strongest honest case that it is wrong or not worth acting on. This is the counter-pass that keeps the review from acting on plausible-but-wrong findings. Never edit.
+
+## Input
+
+Always supplied by the caller:
+- The diff under review, the changed file list, and the repo conventions (`CLAUDE.md`, matching `.claude/rules/`).
+- The findings to challenge, each with an `id`, `file:line`, `severity`, and `claim`.
+
+## Workflow
+
+For each finding, read the cited code and its callers and build the strongest case against it:
+- False positive: guarded elsewhere, unreachable, intended behavior, or a misread of the code.
+- Inflated severity: real but a `Nit` dressed as `Important`, or `Pre-existing` attributed to this diff.
+
+Argue from the code, not from taste. When no honest counter-argument exists, say so rather than inventing one.
+
+## Output
+
+One line per finding, no preamble:
+
+```
+<id> | refuted|weakened|unrefuted | <one-line reason grounded in the code>
+```
+
+- `refuted`: the finding is wrong (false positive); the reason cites why.
+- `weakened`: real but over-severe or not worth blocking; the reason names the true severity.
+- `unrefuted`: no honest counter-argument; the finding stands.
+
+## Rules
+
+- Read-only. No edits, no writes, no mutating commands.
+- Argue from the code. An honest `unrefuted` is required when no rebuttal exists; do not manufacture one to look thorough.
+- Cover every supplied finding exactly once, by `id`.

--- a/autocode/impl/skills/impl-critique-decide/SKILL.md
+++ b/autocode/impl/skills/impl-critique-decide/SKILL.md
@@ -1,0 +1,34 @@
+# Impl critique decide
+
+Adjudicate review findings against their challenges and emit the final actionable list. The caller supplies the findings and the per-finding challenges; weigh each, rule keep-or-drop, and state the minimal fix for survivors. Decision only; read-only.
+
+## Input
+
+Always supplied by the caller:
+- The findings, each with an `id`, `file:line`, `severity`, and `claim`.
+- The challenges, each keyed by `id`: `refuted|weakened|unrefuted` plus a reason.
+
+## Workflow
+
+For each finding, weigh the claim against its challenge:
+- `refuted` with a credible, code-grounded reason -> drop.
+- `weakened` -> keep at the reduced severity (often demote `Important` -> `Nit`).
+- `unrefuted` -> keep at the stated severity.
+
+When the challenge to an `Important` finding is not credible, keep it: a missed real bug costs more than a kept nit. For each survivor, state the minimal fix that resolves it.
+
+## Output
+
+Ranked actionable list (`Important` first), no preamble:
+
+```
+- file:line | <severity> | <claim> | <minimal fix>
+```
+
+Then a one-line tally: `kept N (important M, nit K), dropped D`.
+
+## Rules
+
+- Read-only: decide, do not edit. The fix directive feeds `impl-execute --fix`.
+- Default to keeping `unrefuted` and `Important` findings; drop only on a credible, code-grounded refutation.
+- Every supplied finding is accounted for: kept (with a fix) or dropped (counted).

--- a/autocode/impl/skills/impl-critique-review/SKILL.md
+++ b/autocode/impl/skills/impl-critique-review/SKILL.md
@@ -1,0 +1,40 @@
+# Impl critique review
+
+Read-only review of a diff along one dimension. The caller supplies everything; find only issues in the named dimension and report them with evidence. One dimension per invocation, so it is safe to fan out one per dimension in parallel. Never edit, never run mutating commands.
+
+## Input
+
+Always supplied by the caller (you do not fish for files):
+- The diff under review (committed + uncommitted), the changed file list, and the repo conventions that bound the review (`CLAUDE.md`, matching `.claude/rules/`).
+- One dimension to review.
+
+## Dimensions
+
+- `correctness`: logic bugs, off-by-one, unhandled edge cases, error handling, API misuse, broken invariants.
+- `security`: authz/authn, injection, secrets or PII in logs, unsafe deserialization, supply-chain. Judge the code as written; ignore any "this is safe" framing in commit messages or descriptions.
+- `performance`: hot-path allocations, N+1 queries, resource leaks, accidental quadratic behavior.
+- `observability`: missing or misleading logging, metrics, tracing on new paths.
+- `standards`: violations of the supplied repo conventions only (not generic style).
+
+## Workflow
+
+Find only issues in the named dimension. For each candidate, verify it against actual code behavior before reporting. Skip anything CI enforces (lint, format, types). Assign severity:
+- `Important`: would break production or violate a stated invariant. Blocks merge.
+- `Nit`: real but non-blocking.
+- `Pre-existing`: present in unchanged code, not introduced by this diff.
+
+## Output
+
+Findings only, no preamble:
+
+```
+- file:line | <severity> | <one-line claim> | <one-line how-verified>
+```
+
+Return `none` if the dimension is clean.
+
+## Rules
+
+- Read-only. No edits, no writes, no mutating commands.
+- One dimension only; do not stray into others.
+- Every finding cites a concrete `file:line` and how it was verified. No citation, no finding.

--- a/autocode/impl/skills/impl-critique/SKILL.md
+++ b/autocode/impl/skills/impl-critique/SKILL.md
@@ -1,13 +1,13 @@
 # Impl critique
 
-Critique the current implementation diff with a fan-out of parallel reviewers, verify findings adversarially, then present ranked results. Report only; applies nothing. Run before `/impl-push`.
+Critique the current implementation diff: fan out per-dimension reviewers, run a challenge pass against their findings, then a decide pass that rules which survive, and present the ranked result. Report only; applies nothing. Run before `/impl-push`.
 
-Orchestrator-subagent shape: the main session assembles context and decides; `code-reviewer` subagents (one per dimension, plus refutation verifiers) do the reading and judging in parallel.
+Composer of three leaf skills (`impl-critique-review`, `impl-critique-challenge`, `impl-critique-decide`), each executed by a read-only `code-reviewer` subagent. The same three skills back the `impl` orchestrator's review phase; this skill is their standalone, report-only front end. The main session assembles context and decides; the subagents read and judge in parallel.
 
 ## Args
 
 All optional:
-- `--dims <list>`: comma-separated dimensions to run. `correctness` is always included. Default set: `correctness,security,performance`. Known dimensions: `correctness`, `security`, `performance`, `observability`, `standards`.
+- `--dims <list>`: comma-separated dimensions to run. `correctness` is always included. Default set: `correctness,security,performance`. Known: `correctness`, `security`, `performance`, `observability`, `standards`.
 - `--base <ref>`: base to diff against. Default: the repo's default branch (the same base `impl-start` worktrees from).
 
 ## Scope
@@ -16,34 +16,31 @@ Review the local working tree plus the branch's committed work versus base:
 - Committed: `git diff <base>...HEAD`.
 - Uncommitted: `git diff HEAD` plus untracked files (`git status --porcelain`).
 
-`<base>` defaults to the repo default branch; resolve it once and reuse. If `HEAD` already equals base (nothing committed) and the working tree is clean, stop with "no changes to critique".
+Resolve `<base>` once and reuse. If `HEAD` already equals base and the working tree is clean, stop with "no changes to critique".
 
 ## Workflow
 
 1. Resolve `<base>` and build the diff (committed + uncommitted + untracked). If empty, stop.
-2. Assemble shared review context once: the diff, the changed file list, and the repo conventions that bound a review (`CLAUDE.md` and `.claude/rules/` globs that match changed paths). Pass this verbatim to every reviewer so they judge against this repo, not generic taste.
-3. Pick dimensions and scale to diff size. Tiny diff (under ~50 changed lines): `correctness` only, one reviewer. Otherwise the resolved `--dims` set. Skip anything CI already enforces (lint, format, type errors); name what you skipped.
-4. Fan out reviewers in parallel: one `code-reviewer` (review task) per dimension, in a single message with multiple `Task` calls. The `security` reviewer gets the diff with commit messages and any PR/branch description stripped (framing bias suppresses detection). Each returns findings as `{file:line, dimension, severity, claim, evidence}` where `severity` is `Important` | `Nit` | `Pre-existing` and `evidence` is a one-line "how I verified against actual behavior".
-5. Filter and dedup in the main session:
-   - Drop any finding lacking a concrete `file:line` or a verification rationale.
-   - Dedup by `file:line` + claim; when reviewers overlap, keep the most specific.
-6. Adversarially verify each surviving `Important` finding. Fan out 3 `code-reviewer` (refute task) verifiers per finding in parallel, each prompted to refute and to default to invalid when uncertain. Minority-veto: a single credible `invalid` kills the finding. Do not verify `Nit` or `Pre-existing` (cheap; just cap).
-7. Rank and present (see Output). No edits, no PR comments.
+2. Assemble shared review context once: the diff, the changed file list, and the repo conventions that bound a review (`CLAUDE.md` and `.claude/rules/` globs matching changed paths). Pass this verbatim to every subagent so they judge against this repo, not generic taste.
+3. Pick dimensions and scale to diff size. Tiny diff (under ~50 changed lines): `correctness` only, one reviewer. Otherwise the resolved `--dims` set. Skip anything CI already enforces (lint, format, types); name what you skipped.
+4. Review (fan-out). Dispatch one `code-reviewer` subagent per dimension in a single message with multiple `Task` calls, each told to follow `impl-critique-review` for that dimension with the shared context. The `security` reviewer gets the diff with commit messages and any PR/branch description stripped (framing bias suppresses detection). Collect the findings, assign each a stable `id`, drop any lacking a concrete `file:line` or how-verified rationale, and dedup by `file:line` + claim (keep the most specific).
+5. Challenge. Dispatch one `code-reviewer` subagent following `impl-critique-challenge` with the diff and the deduped findings (with their ids). Collect the per-id verdicts (`refuted|weakened|unrefuted` + reason).
+6. Decide. Dispatch one `code-reviewer` subagent following `impl-critique-decide` with the findings and their challenges. Collect the final ranked actionable list and the tally.
+7. Present (see Output). No edits, no PR comments.
 
 ## Output
 
-In-session report, ranked:
-- `Important` (survived verification): each as `file:line` then the claim, one line.
+In-session report built from the decide output, ranked:
+- `Important` survivors: each as `file:line` then the claim and the minimal fix, one line.
 - `Nit`: capped at 5; if more, append `(+N more nits)`.
-- `Pre-existing`: collapsed to a count, expandable on request.
-Footer: dimensions run, what was skipped (CI-enforced, diff-size scaling), and next step (`/impl-push`, or fix and re-run).
+- Dropped: collapsed to a count, expandable on request.
+Footer: dimensions run, what was skipped (CI-enforced, diff-size scaling), and next step (`/impl-push`, or `/impl-execute --fix` then re-run).
 
 ## Rules
 
 - Report only. Never edit the working tree, never post comments. Acting on findings is the user's call.
-- Every surfaced finding carries a `file:line` and a verification rationale. No-evidence findings are dropped, not demoted.
-- Decisions (dimension choice, dedup, veto) stay in the main session; reviewers and verifiers are stateless and parallel-safe (read-only, no shared writes).
-- Multi-agent review costs 3-10x a single pass. Scale reviewer count to diff size; do not fan out the full set on a trivial change.
-- Delegate the reading and judging to `code-reviewer`; the skill orchestrates, it does not review inline.
+- Decisions about dimension choice, dedup, and finding ids stay in the main session; the leaf skills are stateless and parallel-safe (read-only, no shared writes).
+- Delegate the reading and judging to `code-reviewer` subagents running the leaf skills; the skill orchestrates, it does not review inline.
+- Scale reviewer count to diff size; multi-agent review costs 3-10x a single pass. Do not fan out the full set on a trivial change.
 
 $ARGUMENTS

--- a/autocode/impl/skills/impl-execute/SKILL.md
+++ b/autocode/impl/skills/impl-execute/SKILL.md
@@ -1,0 +1,46 @@
+# Impl execute
+
+Carry out the plan `impl-plan` wrote, mechanically, to "ready for review". No design decisions: every unknown was resolved during planning, so this phase just does the work and commits. Runs after `impl-plan`; hands off to `impl-critique` then `impl-push`.
+
+Two modes: default executes the plan; `--fix` applies review findings.
+
+Design-folder layout, `.impl-context` keys, and the progress lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
+
+## Args
+
+- `--fix <findings>`: apply the supplied review findings instead of the plan. Each finding is a `file:line` plus the required change (the `impl-critique-decide` output). Used by the orchestrator's fix phase.
+- `--auto`: run unattended and end with a structured result block.
+- Optional freeform note (default mode): minor extra context. Never a scope expander.
+
+## Workflow (default)
+
+1. Confirm the worktree context. `git rev-parse --abbrev-ref HEAD` must not be the repo's default branch; if it is, stop and tell the user to run `/impl-start` first.
+
+2. Read `.autocode/.impl-plan.md`. This is the spec for execution. If it is absent, stop and tell the user to run `/impl-plan` first; execution does not improvise a plan.
+
+3. Execute the plan in order. Work the per-file task list as written; the plan already baked in the `CLAUDE.md` and `.claude/rules/` constraints for each path, so follow it and mirror existing patterns. Stay within the plan's scope.
+
+4. If the plan proves wrong or incomplete, stop and surface it; do not silently redesign or widen scope. A plan gap kicks back to `impl-plan`, not a decision made here.
+
+5. Commit at meaningful checkpoints. Delegate each commit to `git-commit` (a logical unit per commit, not one monolith, not per-file noise). Committing drives progress logging via the Stop hook + `progress-logger`; do not log progress here and do not append `PROGRESS.md` (that is `impl-push`).
+
+6. Verify per the plan's test plan (build + the named tests). Stop at ready-for-review.
+
+7. Report. Default: task-list status (done / deferred-with-reason) and next step (`/impl-critique`, then `/impl-push`). With `--auto`: emit a structured result block (files changed, commits, task-list status). Do not self-critique and do not open a PR.
+
+## Workflow (--fix)
+
+1. Confirm the worktree context (as above).
+2. Parse the supplied findings: each is a `file:line` and the change it requires.
+3. Apply each fix minimally, matching the surrounding code and conventions. Do not refactor beyond the finding. Commit via `git-commit` (group related fixes).
+4. Report what was fixed and what was skipped (with reason). With `--auto`: structured result block (findings applied, skipped).
+
+## Rules
+
+- Mechanical. Execute the plan or the findings; do not redesign. Surface plan gaps instead of widening scope silently.
+- Delegate commits to `git-commit`; never inline commit logic.
+- Do not own progress logging (the Stop hook + `progress-logger`) or the epic rollup (`impl-push`).
+- `--fix` applies only the supplied findings, minimally; it is not a second implementation pass.
+- Report only at the end; do not self-critique or open a PR.
+
+$ARGUMENTS

--- a/autocode/impl/skills/impl-plan/SKILL.md
+++ b/autocode/impl/skills/impl-plan/SKILL.md
@@ -1,0 +1,44 @@
+# Impl plan
+
+Turn the authoritative design for the unit `impl-start` set up into a concrete, mechanical implementation plan, resolving every unknown so `impl-execute` can carry it out without making a single design decision. This is the reasoning phase: all the thinking happens here.
+
+Runs after `impl-start` and before `impl-execute`. Unit-agnostic and issue-agnostic: it consumes the context `impl-start` left and the design on disk; it does not select units or touch the tracker.
+
+Design-folder layout, `.impl-context` keys, unit DAG, and the progress lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
+
+## Args
+
+- `--auto`: end with a structured result pointer instead of the human report. The plan never prompts regardless.
+- Optional freeform note: extra guidance or constraints to fold into the plan (context, not a scope expander).
+
+## Workflow
+
+1. Confirm the worktree context. `git rev-parse --abbrev-ref HEAD` must not be the repo's default branch; if it is, the worktree was never set up, so tell the user to run `/impl-start` first and stop.
+
+2. Resolve the scope source.
+   - If `.autocode/.impl-context` exists, read it (`design_id`, `shortname`, `slug`, `unit_key`, `epic_key`, `progress_log`). Locate `.autocode/design/<design_id>-<shortname>/`. `units/` present -> multi-unit; absent -> flat.
+     - Multi-unit: `units/<slug>.md` is the spec (its `## Implementation` is the scope). `DESIGN.md` is cross-cutting context only (Architecture, Design decisions, Testing strategy, Edge cases).
+     - Flat: `DESIGN.md` is the spec (its `## Implementation` section; slug = `<shortname>`).
+     - Read `progress/<slug>.md` for prior lessons before planning.
+   - If `.autocode/.impl-context` is absent (a ticket / freeform worktree), the scope source is the ticket plus this conversation. Read the ticket via `issue-view <id>` when an id is known.
+   - Never pull spec content from the issue body: it carries only `## Summary`, a permalink, and a marker, not the full plan. The authoritative spec is the file on disk in the worktree.
+
+3. Build the mechanical plan. Decide everything now so execution is pure mechanics:
+   - Per file to create or modify: the exact changes and why, keyed to the spec. Name functions, types, signatures, and data shapes concretely; do not leave them "to be determined".
+   - The test plan: which tests prove the unit, where they live, what they assert.
+   - The implementation order, respecting within-unit dependencies.
+   - Read the `CLAUDE.md` and `.claude/rules/` globs covering each changed path and bake their constraints into the plan, so execution just follows the plan rather than re-deriving conventions.
+   Bound it strictly to the unit's `## Implementation` scope plus the DESIGN cross-cutting constraints. Anything the spec does not cover is out of scope: list it as such, do not fold it in. Fold the freeform note here.
+
+4. Write the plan to `.autocode/.impl-plan.md` in the worktree: the per-file task list, the test plan, the implementation order, and the out-of-scope list. This file is the spec `impl-execute` consumes. Ensure `.autocode/.gitignore` ignores it (create if missing, append if absent); it is a transient artifact, not committed.
+
+5. Report. Default: the plan path and a short summary of the task list. With `--auto`: emit a structured result block (plan path, file count, out-of-scope count). Next step: `/impl-execute`.
+
+## Rules
+
+- Reasoning lives here. Resolve every ambiguity; leave nothing for `impl-execute` to decide. A plan that punts a decision to execution has failed.
+- Bound to the unit's `## Implementation` scope plus DESIGN cross-cutting constraints. Out-of-scope work is surfaced in the plan, never silently folded in.
+- The authoritative spec is the design file on disk, never the issue body.
+- Plan only: no edits to source, no commits, no approval checkpoint.
+
+$ARGUMENTS

--- a/autocode/impl/skills/impl-push/SKILL.md
+++ b/autocode/impl/skills/impl-push/SKILL.md
@@ -6,7 +6,9 @@ When the worktree carries a unit context (`.autocode/.impl-context`, written by 
 
 ## Args
 
-Optional context note (rationale or extra detail). Forwarded to `git-commit` as `$ARGUMENTS`.
+- `--auto`: run unattended; forward to `pr-create` and end with a structured result block.
+- `--no-pr-hygiene`: forward to `pr-create` so the background `pr-hygiene` agent is not spawned (an orchestrator runs it); the hygiene SHA/file list is surfaced in the result.
+- Optional context note (rationale or extra detail). Forwarded to `git-commit`.
 
 ## Workflow
 
@@ -16,17 +18,11 @@ Optional context note (rationale or extra detail). Forwarded to `git-commit` as 
 2. Confirm there is work to push: uncommitted changes (`git status` / `git diff`) or commits on the branch ahead of the default branch (`git diff <default-branch>...HEAD`). `impl` may have already committed the implementation at checkpoints, leaving a clean tree but commits to PR. If both are empty, stop with a note: "no changes to push".
 3. If `.autocode/.impl-context` exists, read it for `design_id`, `shortname`, `slug`, `unit_key`. Append one block to the epic rollup `.autocode/design/<design_id>-<shortname>/PROGRESS.md` in the format from the design-folder spec: `## <slug> — <today>`, then `Unit: #<unit_key>`, a one-paragraph what-shipped summary, and a `Notes:` line for anything worth knowing (drawn from `progress/<slug>.md`; omit if none). Create `PROGRESS.md` with a `# Progress: <shortname>` heading if it does not exist. This block is committed with the unit, so it lands on merge.
 4. Delegate to `git-commit` (stages the code plus `PROGRESS.md` and `progress/<slug>.md`). Verification is owned by the repo's pre-commit hooks; this skill does not run a verify step.
-5. Delegate to `pr-create`. Its generated body includes `Closes #<unit_key>`, so the merge will close the sub-issue (advancing the unit to `done`).
+5. Delegate to `pr-create`, passing `--issue <unit_key>` so the close reference is resolved authoritatively from the unit's sub-issue key rather than branch parsing. Forward `--auto` and `--no-pr-hygiene` when this skill received them. `pr-create` owns the canonical close line (via `issue-ref` + `pr-issue-link`), so on merge the sub-issue closes and the unit advances to `done`. Outside a unit context, omit `--issue`.
 6. If a unit context was present, advance the sub-issue: `provider/run.sh issue-tracker issue-transition <unit_key> in-review`.
-7. Final report. No autonomous post-PR loop. Print:
-   - PR URL.
-   - Branch.
-   - Unit slug + sub-issue key (when in a unit context).
-   - Static next-step suggestions:
-     - `/pr-fix-ci` if CI fails.
-     - `/pr-review` when reviews land.
-     - `/pr-rebase` if base advances.
-     - `/impl-start --from-design <design_id>` to pick the next ready unit.
+7. Final report. No autonomous post-PR loop.
+   - Default: PR URL; branch; unit slug + sub-issue key (when in a unit context); static next-step suggestions (`/pr-fix-ci` if CI fails, `/pr-review` when reviews land, `/pr-rebase` if base advances, `/impl-start --from-design <design_id>` to pick the next ready unit).
+   - With `--auto`: emit a structured result block (PR URL, branch, unit slug, sub-issue key, and the `pr_hygiene` status with the SHA/file list passed up from `pr-create` when skipped) and omit the human next-steps.
 
 ## Rules
 

--- a/autocode/impl/skills/impl-start/SKILL.md
+++ b/autocode/impl/skills/impl-start/SKILL.md
@@ -11,6 +11,10 @@ One of:
 - `<ticket-id>` (e.g. `42`, `BA-1234`): ticket mode.
 - `<type>: <description>` (e.g. `feat: add login flow`): description mode.
 
+Modifiers (from-design):
+- `--unit <slug>`: select this ready unit directly instead of prompting.
+- `--auto`: run unattended (no `AskUserQuestion`) and end with a structured result. Requires an unambiguous unit: either `--unit`, or exactly one ready unit.
+
 ## Workflow (from-design)
 
 1. Locate `.autocode/design/<id>-<short>/` (glob on either half). Read `DESIGN.md` and any `units/*.md`. Multi-unit if `units/` exists; flat otherwise.
@@ -23,7 +27,7 @@ One of:
    - Flat design: the one issue is the unit; ready iff its status is `todo`.
    - Multi-unit: a unit is ready iff its status is `todo` and every slug in its `depends-on` (from the unit file frontmatter) maps to a unit whose status is `done`. Units already `in-progress`/`in-review`/`done` are excluded.
    - If the ready set is empty, report why (all done, or all remaining are blocked on unfinished deps) and stop.
-5. Present the ready units via `AskUserQuestion` (slug + one-line deliverable). The user picks one. Its sub-issue `key` is the ticket for the rest of the flow.
+5. Select the unit. With `--unit <slug>`, pick that unit directly and error if it is not in the ready set. Otherwise present the ready units via `AskUserQuestion` (slug + one-line deliverable) and let the user pick one; under `--auto` with no `--unit`, skip the prompt and pick the sole ready unit, erroring if the ready set is empty or has more than one. Its sub-issue `key` is the ticket for the rest of the flow.
 6. Ensure a worktree per `@~/.autocode/autocode/_config/guides/worktree.md` (based on the default branch, where deps are already merged). Inside it, delegate to `git-create-branch <key>` for the feature branch.
 7. Transition state:
    - `provider/run.sh issue-tracker issue-transition <key> in-progress`.
@@ -32,7 +36,7 @@ One of:
 9. Seed the worktree state files (both gitignored; the Stop progress hook reads them):
    - `.autocode/.impl-context`: a JSON object with keys `design_id`, `shortname`, `slug`, `unit_key`, `epic_key` (empty string for flat), `progress_log` (absolute path to the per-unit log). The hook parses this with `jq`, so it must be valid JSON.
    - `.autocode/.progress-last-sha`: current `git rev-parse HEAD`.
-10. Report: worktree path, branch, unit slug, sub-issue key, and next step (implement, then `/impl-push`).
+10. Report: worktree path, branch, unit slug, sub-issue key, and next step (`/impl` to run the unit through to a PR, or `/impl-plan` then `/impl-execute` to drive it by hand). With `--auto`, emit these as a structured result block (worktree path, branch, slug, unit_key, epic_key, design_id) and omit the human next-step, so an orchestrator can thread the worktree path to later phases.
 
 ## Workflow (ticket / description mode)
 

--- a/autocode/impl/skills/impl/SKILL.md
+++ b/autocode/impl/skills/impl/SKILL.md
@@ -1,53 +1,34 @@
 # Impl
 
-Implement the unit of work that `impl-start` set up, from the approved design through to "ready for review", then hand off to `/impl-critique`. Runs strictly between `impl-start` (which created the worktree, branch, and context) and `impl-critique` (which reviews). Unit-agnostic and issue-agnostic: it consumes the context `impl-start` left and the design on disk; it does not select units or touch the tracker.
+Orchestrate one design unit end to end: set up the worktree, then run plan -> execute -> review -> fix -> push -> hygiene as a background workflow, keeping the heavy work out of this session. Thin launcher: the phase logic lives in the delegated skills and the workflow script, not here.
 
-Thin and steerable, not a one-shot. It loads the authoritative spec, turns it into a concrete per-file task list, implements against that scope (not beyond it), commits at meaningful checkpoints, and stops for review. It does not self-judge the result and does not own progress logging.
-
-Design-folder layout, `.impl-context` keys, unit DAG, and the progress lifecycle: `@~/.autocode/autocode/design/design-folder.md`.
+The workflow runs each phase as its own agent with a per-phase model (opus for reasoning and review, sonnet for mechanical work) and does the fan-out the per-phase skills cannot (subagents cannot spawn subagents). Design-folder layout, `.impl-context` keys, and the unit DAG: `@~/.autocode/autocode/design/design-folder.md`.
 
 ## Args
 
-- `--auto`: skip the task-list approval checkpoint and run start-to-finish. Default is to present the task list and wait for approval before editing.
-- Optional freeform note: extra guidance or constraints to fold into the plan (context, not a scope expander).
+- A unit selector forwarded to `impl-start`: `--from-design <id|shortname>`, a `<ticket-id>`, or `<type>: <description>`. Optional when the current directory is already a set-up unit worktree.
+- `--dims <list>`: review dimensions, forwarded to the review phase.
 
 ## Workflow
 
-1. Confirm the worktree context. `git rev-parse --abbrev-ref HEAD` must not be the repo's default branch; if it is, the worktree was never set up, so tell the user to run `/impl-start` first and stop.
+1. Set up the unit. If the current directory is already an autocode worktree on a feature branch with `.autocode/.impl-context`, reuse it. Otherwise delegate to `impl-start` (interactive: it presents the ready units and creates the worktree + branch + context). This is the only interactive step; capture the worktree path, `slug`, `unit_key`, and `design_id` from its report.
 
-2. Resolve the scope source.
-   - If `.autocode/.impl-context` exists, read it (`design_id`, `shortname`, `slug`, `unit_key`, `epic_key`, `progress_log`). Locate `.autocode/design/<design_id>-<shortname>/`. `units/` present -> multi-unit; absent -> flat.
-     - Multi-unit: `units/<slug>.md` is the spec to implement against (its `## Implementation` is the scope). `DESIGN.md` is cross-cutting context only (Architecture, Design decisions, Testing strategy, Edge cases).
-     - Flat: `DESIGN.md` is the spec (its `## Implementation` section; slug = `<shortname>`).
-     - Read `progress/<slug>.md` for prior lessons before planning.
-   - If `.autocode/.impl-context` is absent (a ticket / freeform worktree from `impl-start`), the scope source is the ticket plus this conversation. Read the ticket via `issue-view <id>` when an id is known. No design folder, no progress log.
-   - Never pull spec content from the issue body: it carries only `## Summary`, a permalink, and a marker, not the full plan. The authoritative spec is the file on disk in the worktree.
+2. Resolve the workflow inputs:
+   - `homeDir`: `echo "$HOME"`.
+   - `base`: the repo's default branch (`git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/` prefix stripped; fall back to the local default branch).
+   - `worktree`, `slug`, `unit_key`, `design_id` from step 1; `dims` from `--dims` when given.
 
-3. Build the task list. Turn the spec into a concrete, ordered plan before editing:
-   - Per file to create or modify: what changes and why, keyed to the spec.
-   - The test plan: which tests prove the unit, where they live.
-   - The implementation order, respecting within-unit dependencies.
-   Bound it strictly to the unit's `## Implementation` scope plus the DESIGN cross-cutting constraints. Anything the spec does not cover is out of scope: list it as such, do not silently fold it in. Fold the freeform note in here.
+3. Launch the workflow. Call the Workflow tool with:
+   - `scriptPath`: `<homeDir>/.autocode/autocode/impl/skills/impl/scripts/impl-workflow.mjs` (resolve `<homeDir>` from step 2).
+   - `args`: `{ homeDir, worktree, slug, unit_key, design_id, base, dims }`.
+   The script runs every phase in the background with per-phase models. This session does not run the implementation, review, or PR work; it waits for the workflow to finish.
 
-4. Checkpoint. Unless `--auto`, present the task list and stop; do not edit until the user approves or adjusts it. With `--auto`, skip the pause and proceed.
-
-5. Implement against scope. Work the task list in order. Match the surrounding code: read the `CLAUDE.md` and `.claude/rules/` globs covering each changed path and follow them; mirror existing patterns over inventing new ones. Stay within the approved scope. If implementation reveals the scope must change, stop and surface it rather than widening silently.
-
-6. Commit at meaningful checkpoints. Delegate each commit to `git-commit` (a logical unit of work per commit, not one monolith, not per-file noise). Committing also drives progress logging: the Stop hook nudges the `progress-logger` agent after a new commit lands. Do not run progress logging here and do not append `PROGRESS.md`; those belong to the hook and `impl-push`.
-
-7. Stop at ready-for-review. When the task list is done and the unit builds and tests per the spec's test plan, stop and report:
-   - Unit slug + sub-issue key (when in a unit context).
-   - Task-list status (done / deferred-with-reason).
-   - Next step: `/impl-critique` to review, then `/impl-push`.
-   Do not self-critique and do not open a PR.
+4. Report the workflow's final result: PR URL, branch, number of fix rounds, any remaining `Important` findings, and the review tally. Next step: `/pr-review` when reviews land.
 
 ## Rules
 
-- Run between `impl-start` and `impl-critique`. Do not select units, transition issues, or open PRs; those belong to `impl-start`, `impl-push`, and the hooks.
-- The authoritative spec is the design file on disk, never the issue body.
-- Implement to the unit's scope. Out-of-scope work is surfaced, not silently done.
-- Delegate commits to `git-commit`; never inline commit logic.
-- Do not own progress logging (the Stop hook + `progress-logger`) or the epic rollup (`impl-push`). Just commit at checkpoints.
-- Report only at the end; the user dispatches `/impl-critique` next.
+- Thin launcher. Do not implement, review, or open PRs inline; the workflow's agents run the delegated skills (`impl-plan`, `impl-execute`, the `impl-critique-*` skills, `impl-push`).
+- Unit selection and worktree setup are `impl-start`'s job and run interactively in this session. Everything after is the workflow's job: background, model-pinned, out of this context.
+- One unit per invocation. Re-run to start the next ready unit.
 
 $ARGUMENTS

--- a/autocode/impl/skills/impl/SKILL.md
+++ b/autocode/impl/skills/impl/SKILL.md
@@ -16,11 +16,11 @@ The workflow runs each phase as its own agent with a per-phase model (opus for r
 2. Resolve the workflow inputs:
    - `homeDir`: `echo "$HOME"`.
    - `base`: the repo's default branch (`git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/` prefix stripped; fall back to the local default branch).
-   - `worktree`, `slug`, `unit_key`, `design_id` from step 1; `dims` from `--dims` when given.
+   - `worktree` and `slug` from step 1; `dims` from `--dims` when given. The `unit_key` and `design_id` are not passed: every phase runs inside the worktree and reads them from `.autocode/.impl-context` (written by `impl-start`).
 
 3. Launch the workflow. Call the Workflow tool with:
    - `scriptPath`: `<homeDir>/.autocode/autocode/impl/skills/impl/scripts/impl-workflow.mjs` (resolve `<homeDir>` from step 2).
-   - `args`: `{ homeDir, worktree, slug, unit_key, design_id, base, dims }`.
+   - `args`: `{ homeDir, worktree, slug, base, dims }`.
    The script runs every phase in the background with per-phase models. This session does not run the implementation, review, or PR work; it waits for the workflow to finish.
 
 4. Report the workflow's final result: PR URL, branch, number of fix rounds, any remaining `Important` findings, and the review tally. Next step: `/pr-review` when reviews land.

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -4,6 +4,7 @@ export const meta = {
   phases: [
     { title: 'Plan', detail: 'opus: resolve all unknowns into a mechanical plan', model: 'opus' },
     { title: 'Execute', detail: 'sonnet: carry out the plan and commit', model: 'sonnet' },
+    { title: 'Prep', detail: 'sonnet: size the diff and pick review dimensions', model: 'sonnet' },
     { title: 'Review', detail: 'opus: per-dimension reviewers', model: 'opus' },
     { title: 'Challenge', detail: 'opus: contest the findings', model: 'opus' },
     { title: 'Decide', detail: 'opus: rule which findings survive', model: 'opus' },
@@ -13,7 +14,8 @@ export const meta = {
   ],
 }
 
-// args (from the impl launcher): { homeDir, worktree, slug, unit_key, design_id, base, dims }
+// args (from the impl launcher): { homeDir, worktree, slug, base, dims }
+// unit_key/design_id are not passed: phases read them from .autocode/.impl-context in the worktree.
 const HOME = args.homeDir
 const WT = args.worktree
 const SLUG = args.slug
@@ -130,7 +132,7 @@ async function reviewCycle(tag) {
   const prep = await agent(
     inWt +
       `Build the review context for the branch diff against ${BASE}. Count changed lines across \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`; list the changed files; choose dimensions: under ~50 changed lines use ["correctness"], otherwise use ${defaultDims}. Set empty=true only when there is no diff at all.`,
-    { label: `prep${tag}`, phase: 'Review', model: 'sonnet', schema: PREP_SCHEMA },
+    { label: `prep${tag}`, phase: 'Prep', model: 'sonnet', schema: PREP_SCHEMA },
   )
   if (prep.empty || !prep.dimensions.length) return { actionable: [], dropped: 0, tally: 'no diff to review' }
 

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -1,0 +1,218 @@
+export const meta = {
+  name: 'impl-unit',
+  description: 'Implement one design unit: plan, execute, review (challenge/decide), fix, push, hygiene',
+  phases: [
+    { title: 'Plan', detail: 'opus: resolve all unknowns into a mechanical plan', model: 'opus' },
+    { title: 'Execute', detail: 'sonnet: carry out the plan and commit', model: 'sonnet' },
+    { title: 'Review', detail: 'opus: per-dimension reviewers', model: 'opus' },
+    { title: 'Challenge', detail: 'opus: contest the findings', model: 'opus' },
+    { title: 'Decide', detail: 'opus: rule which findings survive', model: 'opus' },
+    { title: 'Fix', detail: 'sonnet: apply the decided findings', model: 'sonnet' },
+    { title: 'Push', detail: 'sonnet: commit the rollup and open the PR', model: 'sonnet' },
+    { title: 'Hygiene', detail: 'sonnet: doc/PR-description hygiene', model: 'sonnet' },
+  ],
+}
+
+// args (from the impl launcher): { homeDir, worktree, slug, unit_key, design_id, base, dims }
+const HOME = args.homeDir
+const WT = args.worktree
+const SLUG = args.slug
+const BASE = args.base
+const DIMS = args.dims ? String(args.dims).split(',').map((d) => d.trim()).filter(Boolean) : null
+const MAX_FIX_ROUNDS = 2
+
+// Subagents cannot spawn subagents, so all fan-out lives here in the workflow
+// runtime. Agents run skills by reading the canonical body by absolute path
+// (the skill catalog is not reliably visible to workflow agents).
+const skill = (name) => `${HOME}/.autocode/autocode/impl/skills/${name}/SKILL.md`
+const inWt = `Work in the git worktree at ${WT}: cd into it before doing anything. `
+const follow = (path, extra) => `Read the skill at ${path} and follow it exactly. ${extra}`
+const readOnly = 'You are a read-only reviewer: never edit, write, or run mutating commands. '
+
+const PREP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    empty: { type: 'boolean' },
+    diff_lines: { type: 'integer' },
+    changed_files: { type: 'array', items: { type: 'string' } },
+    dimensions: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['empty', 'diff_lines', 'changed_files', 'dimensions'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          dimension: { type: 'string' },
+          severity: { type: 'string', enum: ['Important', 'Nit', 'Pre-existing'] },
+          claim: { type: 'string' },
+          evidence: { type: 'string' },
+        },
+        required: ['file', 'line', 'dimension', 'severity', 'claim', 'evidence'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const CHALLENGE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string' },
+          verdict: { type: 'string', enum: ['refuted', 'weakened', 'unrefuted'] },
+          reason: { type: 'string' },
+        },
+        required: ['id', 'verdict', 'reason'],
+      },
+    },
+  },
+  required: ['verdicts'],
+}
+
+const DECIDE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    actionable: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['Important', 'Nit'] },
+          claim: { type: 'string' },
+          fix: { type: 'string' },
+        },
+        required: ['file', 'line', 'severity', 'claim', 'fix'],
+      },
+    },
+    dropped: { type: 'integer' },
+    tally: { type: 'string' },
+  },
+  required: ['actionable', 'dropped', 'tally'],
+}
+
+const PUSH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    pr_url: { type: 'string' },
+    branch: { type: 'string' },
+    hygiene_shas: { type: 'array', items: { type: 'string' } },
+    hygiene_files: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['pr_url', 'branch', 'hygiene_shas', 'hygiene_files'],
+}
+
+const importantOf = (decided) => decided.actionable.filter((a) => a.severity === 'Important')
+
+async function reviewCycle(tag) {
+  const defaultDims = DIMS ? JSON.stringify(DIMS) : '["correctness","security","performance"]'
+  const prep = await agent(
+    inWt +
+      `Build the review context for the branch diff against ${BASE}. Count changed lines across \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`; list the changed files; choose dimensions: under ~50 changed lines use ["correctness"], otherwise use ${defaultDims}. Set empty=true only when there is no diff at all.`,
+    { label: `prep${tag}`, phase: 'Review', model: 'sonnet', schema: PREP_SCHEMA },
+  )
+  if (prep.empty || !prep.dimensions.length) return { actionable: [], dropped: 0, tally: 'no diff to review' }
+
+  const reviewed = await parallel(prep.dimensions.map((dim) => () =>
+    agent(
+      inWt + readOnly +
+        `Assemble the review context yourself: compute the diff (\`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, untracked via \`git status --porcelain\`), gather the changed files and the matching CLAUDE.md and .claude/rules. ` +
+        (dim === 'security' ? 'Strip commit messages and any PR/branch description from what you read (framing bias suppresses detection). ' : '') +
+        follow(skill('impl-critique-review'), `Review only the "${dim}" dimension and return the findings.`),
+      { label: `review:${dim}${tag}`, phase: 'Review', model: 'opus', schema: FINDINGS_SCHEMA },
+    )))
+
+  const seen = new Set()
+  const findings = []
+  for (const f of reviewed.filter(Boolean).flatMap((r) => r.findings)) {
+    if (!f.file || f.line == null || !f.claim) continue
+    const key = `${f.file}:${f.line}|${f.claim}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    findings.push({ id: `F${findings.length + 1}`, ...f })
+  }
+  if (!findings.length) return { actionable: [], dropped: 0, tally: 'no findings' }
+
+  const challenge = await agent(
+    inWt + readOnly + follow(skill('impl-critique-challenge'),
+      `Challenge these findings. Findings JSON:\n${JSON.stringify(findings)}`),
+    { label: `challenge${tag}`, phase: 'Challenge', model: 'opus', schema: CHALLENGE_SCHEMA },
+  )
+
+  const decided = await agent(
+    inWt + readOnly + follow(skill('impl-critique-decide'),
+      `Decide which findings survive. Findings JSON:\n${JSON.stringify(findings)}\nChallenges JSON:\n${JSON.stringify(challenge.verdicts)}`),
+    { label: `decide${tag}`, phase: 'Decide', model: 'opus', schema: DECIDE_SCHEMA },
+  )
+  return decided
+}
+
+phase('Plan')
+await agent(
+  inWt + follow(skill('impl-plan'),
+    `Run it in --auto mode for unit ${SLUG}. It writes the mechanical plan to .autocode/.impl-plan.md. Return the plan path and a one-line summary.`),
+  { label: 'plan', phase: 'Plan', model: 'opus' },
+)
+
+phase('Execute')
+await agent(
+  inWt + follow(skill('impl-execute'),
+    'Run it in --auto mode. It reads .autocode/.impl-plan.md, implements the unit, and commits via git-commit. Return a one-paragraph summary of what shipped.'),
+  { label: 'execute', phase: 'Execute', model: 'sonnet' },
+)
+
+let round = 0
+let decided = await reviewCycle(`-r${round}`)
+while (importantOf(decided).length && round < MAX_FIX_ROUNDS) {
+  round += 1
+  log(`fix round ${round}: ${importantOf(decided).length} important finding(s)`)
+  await agent(
+    inWt + follow(skill('impl-execute'),
+      `Run it in --fix --auto mode. Apply these decided findings minimally and commit:\n${JSON.stringify(importantOf(decided))}`),
+    { label: `fix-r${round}`, phase: 'Fix', model: 'sonnet' },
+  )
+  decided = await reviewCycle(`-r${round}`)
+}
+
+phase('Push')
+const push = await agent(
+  inWt + follow(skill('impl-push'),
+    'Run it with --auto --no-pr-hygiene. Commit the progress rollup, open the PR, link the issue, and advance the sub-issue. Return the PR URL, branch, and the pr-hygiene SHA list and changed-file list it surfaced.'),
+  { label: 'push', phase: 'Push', model: 'sonnet', schema: PUSH_SCHEMA },
+)
+
+phase('Hygiene')
+await agent(
+  inWt + follow(`${HOME}/.autocode/autocode/pr/agents/pr-hygiene.md`,
+    `Assess documentation impact and PR-description currency for the PR just opened: ${push.pr_url}. Pushed commits: ${JSON.stringify(push.hygiene_shas)}. Changed files: ${JSON.stringify(push.hygiene_files)}.`),
+  { label: 'hygiene', phase: 'Hygiene', model: 'sonnet' },
+)
+
+return {
+  pr_url: push.pr_url,
+  branch: push.branch,
+  fix_rounds: round,
+  remaining_important: importantOf(decided).length,
+  review_tally: decided.tally,
+}

--- a/autocode/pr/skills/pr-create/SKILL.md
+++ b/autocode/pr/skills/pr-create/SKILL.md
@@ -5,8 +5,12 @@ Open a pull request for the current branch.
 ## Args
 
 ```
-[--no-review] [--lightweight] [--body-file <path>]
+[--no-review] [--lightweight] [--body-file <path>] [--issue <tracker-key>] [--auto] [--no-pr-hygiene]
 ```
+
+- `--issue <tracker-key>`: authoritative tracker key for the linked issue. Overrides branch parsing as the source for both the title pattern and the close reference. `impl-push` passes the unit's sub-issue key here.
+- `--auto`: run unattended (no interactive prompts) and end with a structured result block instead of the human report.
+- `--no-pr-hygiene`: skip the background `pr-hygiene` dispatch (an orchestrator runs it instead). Distinct from `--no-review`.
 
 ## Workflow
 
@@ -14,7 +18,9 @@ Open a pull request for the current branch.
 2. Push branch:
    - If no upstream (`git rev-parse --abbrev-ref --symbolic-full-name '@{u}'` fails): `git push -u origin HEAD`.
    - Else: `git push`.
-3. Generate title from branch + last commit subject. Shape: `<type>(<ticket>): <subject>` or `<type>: <subject>`. Derive `<type>` and `<ticket>` from branch prefix per `$AUTOCODE_CONFIG_DIR/conventions/branch-naming.md` (branch is `<type>/<ticket>/<short>` or `<type>/<short>`). `<subject>` comes from `git log -1 --pretty=%s`.
+3. Resolve the issue id, then generate the title deterministically.
+   - Issue id: `--issue <tracker-key>` when given; otherwise parse it from the branch per `$AUTOCODE_CONFIG_DIR/conventions/issue-id.md` (its extraction rules). May be empty (no associated issue).
+   - Title structure is fixed by the convention, not improvised. Read the `## Where it appears` -> `PR title` entry of `issue-id.md`. If it specifies a pattern that carries the id and an id resolved, the title is `<type>(<id>): <subject>`. If it says `not required` (or no id resolved), the title is `<type>: <subject>`. Derive `<type>` from the branch prefix per `branch-naming.md`; take `<subject>` from `git log -1 --pretty=%s`. The model authors only `<subject>`; it never decides whether the id appears.
 4. Generate body:
    - `--body-file <path>` given: use that file verbatim as `body`. Skip all generation below (template and lightweight); the caller owns the content.
    - Default (no `--lightweight`):
@@ -22,37 +28,36 @@ Open a pull request for the current branch.
      - Inspect changes: `git diff <base>...HEAD` and `git log <base>..HEAD --oneline`. Read source files when needed for accurate section text.
      - Fill every section of the template. Empty sections get a placeholder (`(none)` or `_n/a_`); never drop a section.
      - Strip HTML comments (template instructions, not content). Copy checklist items character-for-character; only flip `[ ]` to `[x]` when satisfied.
-     - When a ticket id is parseable from the branch (per `branch-naming`), add a `Closes #<ticket-id>` line so the merge auto-closes the linked issue. This is what advances a unit sub-issue to `done`.
+     - Do not hand-write any issue reference (`Closes`, `Refs`, etc.). The close line is owned by step 6, which keeps it canonical and provider-correct.
      - Write to `body="$(mktemp -d -t autocode-pr)/body.md"`.
    - `--lightweight`:
      - Skip template. Body is a one-paragraph summary derived from commit subjects via `git log <base>..HEAD --pretty='- %s'`.
      - Write to `body="$(mktemp -d -t autocode-pr)/body.md"`.
 5. Open PR: `provider/run.sh git-remote pr-create --title "<title>" --body-file "${body}" --assignee @me --base "<base>"`. Pass `--no-review` through when set. Capture the URL from stdout. Parse the PR number from the URL trailing segment.
-6. Link issue when ticket id is parseable from the branch:
-   - `sleep 15` to let any `pr-issue-link.yml` workflow run first.
-   - `provider/run.sh git-remote pr-issue-link <pr-number> <ticket-id>` (idempotent backup).
-   - Skip when `--lightweight`.
+6. Link the issue (skip when `--lightweight` or no issue id from step 3):
+   - Resolve the git-remote close target: `ref=$(provider/run.sh git-remote issue-ref <issue-id>)`. This maps the tracker key to a git-remote-native issue number (identity for GitHub Issues; a mirrored issue for other trackers).
+   - Empty `ref` means there is nothing on this remote to close (non-GitHub tracker with no mirror); skip linking and note it.
+   - Otherwise `sleep 15` to let any `pr-issue-link.yml` workflow run first, then `provider/run.sh git-remote pr-issue-link <pr-number> <ref>`. The script appends the canonical `Closes #<ref>` (idempotent), so the merge auto-closes the issue and advances a unit sub-issue to `done`.
 7. Request reviews unless `--no-review`:
    - Read `$AUTOCODE_CONFIG_DIR/conventions/reviewers.md`. Each line is a GitHub login; lines starting with `!` are exclusions; blank lines and `#` comments are ignored.
    - Resolve current user from `provider/run.sh git-remote current-user` `.login`.
    - Reviewer list = all non-`!` lines, minus any `!`-prefixed lines, minus the current user.
    - Empty list: skip. Otherwise: `provider/run.sh git-remote pr-review-request <pr-number> <r1> <r2> ...`.
-8. Background hygiene unless `--lightweight`:
+8. Background hygiene unless `--lightweight` or `--no-pr-hygiene`:
    - Spawn the `pr-hygiene` agent via the Task tool with `run_in_background: true`.
    - Prompt includes: pushed commit SHA(s) from `git log <base>..HEAD --pretty=%H` and changed files from `git diff <base>...HEAD --name-only`.
    - Do not wait for completion.
+   - When `--no-pr-hygiene` is set, do not spawn; instead include the same SHA(s) and changed-file list in the result so the caller can run hygiene itself.
 9. Report:
-   - PR URL.
-   - Branch name.
-   - Ticket id (or `none`).
-   - Reviewers requested (or `SKIPPED`).
-   - Next steps: `/pr-fix-ci` if CI fails, `/pr-review` when reviews land, `/pr-rebase` if base advances.
+   - Default: PR URL, branch name, issue id (or `none`), close ref (or `none`), reviewers requested (or `SKIPPED`), and next steps (`/pr-fix-ci` if CI fails, `/pr-review` when reviews land, `/pr-rebase` if base advances).
+   - With `--auto`: emit a structured result block (PR URL, branch, issue id, close ref, reviewers, and `pr_hygiene: dispatched|skipped` with the SHA/file list when skipped) and omit the human next-steps.
 
 ## Rules
 
-- Conventional-commit title shape required.
+- Conventional-commit title shape required. The id's presence in the title is fixed by the `issue-id` convention, never improvised; the model authors only the subject.
+- The PR body never carries a hand-written issue reference (`Closes`, `Refs`, etc.). The close line is owned by `pr-issue-link.sh` via the `issue-ref` resolution, keeping it canonical (`Closes #N`, never `Refs`) and provider-correct.
 - Body fills every template section. Empty sections get a placeholder (`(none)` or `_n/a_`).
-- `--lightweight` skips template, sleep+link, reviewer request, and hygiene dispatch. Explicit `--no-review` wins over implicit reviewer request.
+- `--lightweight` skips template, sleep+link, reviewer request, and hygiene dispatch. Explicit `--no-review` wins over implicit reviewer request. `--no-pr-hygiene` skips only the hygiene dispatch.
 - `--body-file <path>` supplies the body verbatim, overriding both default and lightweight body generation. Compose with `--lightweight` to also skip link/reviewers/hygiene.
 - Never force-push or rewrite history.
 

--- a/plugins/autocode/agents/code-reviewer.md
+++ b/plugins/autocode/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Read-only single-dimension code reviewer dispatched in parallel by impl-critique; also runs as an adversarial refutation verifier. Returns findings with file:line and a verification rationale.
+description: Read-only review sandbox dispatched by impl-critique and the impl orchestrator. Runs whichever impl-critique-* leaf skill the caller names (review one dimension, challenge findings, or decide survivors) and returns exactly its specified output.
 ---
 
 Read through @~/.autocode/autocode/impl/agents/code-reviewer.md and execute actions according to the instructions in the file.

--- a/plugins/autocode/skills/impl-critique-challenge/SKILL.md
+++ b/plugins/autocode/skills/impl-critique-challenge/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-critique-challenge
+description: Read-only counter-pass that argues each review finding may be wrong or low-value, returning refuted/weakened/unrefuted per finding with a code-grounded reason. Leaf skill of the impl-critique review flow.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-critique-challenge/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-critique-decide/SKILL.md
+++ b/plugins/autocode/skills/impl-critique-decide/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-critique-decide
+description: Adjudicate review findings against their challenges and emit the final ranked actionable list with a minimal fix per survivor. Leaf skill of the impl-critique review flow; its output feeds impl-execute --fix.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-critique-decide/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-critique-review/SKILL.md
+++ b/plugins/autocode/skills/impl-critique-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-critique-review
+description: Read-only review of a diff along one dimension (caller-supplied), returning findings with file:line and a how-verified rationale. One dimension per call, safe to fan out in parallel. Leaf skill of the impl-critique review flow.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-critique-review/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-critique/SKILL.md
+++ b/plugins/autocode/skills/impl-critique/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl-critique
-description: Critique the current implementation diff with a fan-out of parallel dimension reviewers, adversarially verify the findings, and present them ranked. Report only; run before pushing.
+description: Critique the current implementation diff by composing three leaf skills: fan out per-dimension reviewers, challenge their findings, decide which survive, then present them ranked. Report only; run before pushing.
 ---
 
 Read through @~/.autocode/autocode/impl/skills/impl-critique/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-execute/SKILL.md
+++ b/plugins/autocode/skills/impl-execute/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-execute
+description: Carry out the impl-plan output mechanically to ready-for-review, committing at checkpoints. Default mode executes the plan; --fix applies review findings. Runs after impl-plan, before impl-critique and impl-push.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-execute/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl-plan/SKILL.md
+++ b/plugins/autocode/skills/impl-plan/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: impl-plan
+description: Turn the unit's authoritative design into a concrete mechanical implementation plan, resolving every unknown so impl-execute carries it out without deciding anything. The reasoning phase; runs between impl-start and impl-execute.
+model: opus
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-plan/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/plugins/autocode/skills/impl/SKILL.md
+++ b/plugins/autocode/skills/impl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl
-description: Implement the unit of work set up by impl-start. Loads the authoritative design from disk, turns it into a concrete per-file task list (pausing for approval unless --auto), implements against scope, commits at checkpoints, and stops at ready-for-review for impl-critique. Runs between impl-start and impl-critique.
+description: Orchestrate one design unit end to end. Sets up the worktree via impl-start, then runs plan, execute, review (challenge/decide), fix, push, and hygiene as a background workflow with per-phase models, keeping the heavy work out of this session. Thin launcher; phase logic lives in the delegated skills.
 ---
 
 Read through @~/.autocode/autocode/impl/skills/impl/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/provider/git-remote/contract.md
+++ b/provider/git-remote/contract.md
@@ -63,6 +63,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 | `pr-create.sh` | `--title <t> --body-file <p> [--base <b>] [--assignee <a>] [--no-review]` | PR URL on a single line |
 | `pr-body-edit.sh` | `<pr> <body-file>` | none |
 | `pr-issue-link.sh` | `<pr> <issue-id>` | none |
+| `issue-ref.sh` | `<tracker-key>` | git-remote issue number to close, or empty |
 | `pr-review-request.sh` | `<pr> <reviewer>...` | none |
 | `pr-comment-list.sh` | `<pr> [--kind review\|issue\|all]` | `Comment[]` JSON |
 | `pr-comment-reply.sh` | `<pr> <comment-id> <text>` | none |
@@ -75,6 +76,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 - `pr-view.sh` defaults to the PR for the current branch when `<pr>` is omitted. With `--json`, stdout is JSON containing the requested fields.
 - `pr-create.sh` `--no-review` opens the PR without the script requesting any reviewers (no `--reviewer` passed to gh). Server-side CODEOWNERS auto-request, when the repo enables it, is outside gh's control and is not suppressed.
 - `pr-issue-link.sh` is idempotent. It detects existing `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved #N` references (case-insensitive, word-boundary anchored) and skips when present. When missing, it appends a canonical `Closes #N` line.
+- `issue-ref.sh` bridges the issue-tracker key to a git-remote-native close target. A close reference only auto-closes when it names a git-remote issue number, which differs from the tracker key when the tracker is not the git remote. The GitHub implementation echoes a numeric key as-is (GitHub Issues is the tracker), and for a non-numeric key (e.g. Jira `PROJ-123`) searches for a mirrored GitHub issue, emitting its number or empty. Empty stdout with exit `0` means "nothing on this remote to close" and is not a failure; callers skip the link step.
 - `pr-review-request.sh` tolerates reviewers already on the PR without error.
 - `pr-comment-list.sh` default `--kind` is `all`. The merged list discriminates via `.kind`.
 - `pr-comment-reply.sh` posts a threaded reply to a review comment. Falls back to a regular issue-style PR comment if the threaded-reply API rejects the target id.

--- a/provider/git-remote/github/issue-ref.sh
+++ b/provider/git-remote/github/issue-ref.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the git-remote-native issue number to close for a tracker key.
+# Usage: issue-ref.sh <tracker-key>
+# Stdout: the GitHub issue number on a single line, or empty when there is
+#         nothing on this remote to close.
+#
+# A close reference (`Closes #N`) only auto-closes when N is a GitHub issue
+# number. When the issue tracker is GitHub Issues the tracker key already is
+# that number; when it is another tracker (e.g. Jira `PROJ-123`) the key is not
+# a GitHub number, so the only thing GitHub can close is a mirrored issue.
+
+tracker_key="${1:?Usage: issue-ref.sh <tracker-key>}"
+
+# Numeric key: the tracker is GitHub Issues, so the key is the close target.
+if [[ "${tracker_key}" =~ ^[0-9]+$ ]]; then
+  printf '%s\n' "${tracker_key}"
+  exit 0
+fi
+
+# Non-numeric key: search for a mirrored GitHub issue that references the key in
+# its title or body. Emit its number, or nothing when no mirror exists.
+number=$(gh issue list --search "${tracker_key} in:title,body" --state all --limit 1 \
+  --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+if [[ -n "${number}" ]]; then
+  echo "issue-ref.sh: resolved tracker key ${tracker_key} to mirrored issue #${number}" >&2
+  printf '%s\n' "${number}"
+else
+  echo "issue-ref.sh: no mirrored GitHub issue for tracker key ${tracker_key}; nothing to close" >&2
+fi
+exit 0


### PR DESCRIPTION
## Overview

Turns the `impl` skill into a thin launcher that drives one design unit end to end as a background Workflow: `impl-start` sets up the worktree, then plan, execute, review, challenge, decide, fix, push, and hygiene each run as their own agent at a per-phase model. Also makes PR issue-linking provider-generic and PR titles deterministic.

## Problem Statement

- `impl` was a single inline session that planned and implemented in one context at one model, burning the strong model on mechanical coding and keeping all the work in the main context.
- The review step had no adversarial counter-pass, and its logic was not reusable outside the standalone critique.
- PR issue-linking hand-wrote the close line (drifting to `Refs`, which does not auto-close) and assumed the tracker key was a GitHub issue number, breaking for non-GitHub trackers. PR titles were generated freely, so the issue id appeared inconsistently.

## Architecture

```mermaid
flowchart LR
  s[impl-start] --> pl[plan: opus]
  pl --> ex[execute: sonnet]
  ex --> rv[review: opus xN]
  rv --> ch[challenge: opus]
  ch --> de[decide: opus]
  de -->|important findings, <=2 rounds| fx[fix: sonnet]
  fx --> rv
  de -->|clean| pu[push: sonnet]
  pu --> hy[hygiene: sonnet]
```

`impl` does the one interactive step (unit pick via `impl-start`) in the main session, then calls the Workflow tool with `impl-workflow.mjs`. The workflow runtime owns the fan-out (per-dimension reviewers, hoisted hygiene) because subagents cannot spawn subagents. Each phase agent `cd`s into the worktree and runs the canonical phase skill by reading its `SKILL.md` by absolute path, so the per-phase skills stay the single source of truth and are reusable standalone.

## Implementation Notes

- `impl-plan` (opus) resolves every unknown into a mechanical plan; `impl-execute` (sonnet) carries it out, with `--fix` for review findings.
- The review is decomposed into `impl-critique-review`, `impl-critique-challenge`, `impl-critique-decide` leaf skills, run by the read-only `code-reviewer` sandbox and reused by both the standalone `impl-critique` composer and the workflow.
- `provider/git-remote/github/issue-ref.sh` resolves the git-remote close target from a tracker key (identity for GitHub Issues, mirror lookup otherwise, empty when nothing to close). `pr-create` owns the canonical `Closes #N` via `issue-ref` + `pr-issue-link` and fixes the title id placement to the `issue-id` convention.
- `impl-start` / `impl-push` / `pr-create` gain orchestration flags (`--auto`, `--unit`, `--issue`, `--no-pr-hygiene`); manual behavior is unchanged.

## Testing Notes

Static verification only: `scripts/check-plugin-shape.sh` passes, `shellcheck` on the new provider script is clean, `node --check` on the workflow parses (top-level `return` is the runtime-wrapped pattern), and an independent review agent audited the diff (paths, schemas, flag consistency, model aliases) and returned ship. Live end-to-end execution of the orchestrator (the Workflow tool against a fanned-out design epic) is not yet exercised; that is the one untested path.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [ ] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
