### PR TITLE
docs: Plan auto-archive for completed design epics

### DIFF
--- a/.autocode/design/0001-auto-archive-epics/DESIGN.md
+++ b/.autocode/design/0001-auto-archive-epics/DESIGN.md
@@ -1,0 +1,113 @@
+# Auto-archive completed design epics
+
+## Summary
+
+When a design epic's last unit PR merges, nothing archives the design folder: it stays under `.autocode/design/`, the epic issue stays open, and the `INDEX.md` row stays `active`. `design-folder.md` promises "`impl-archive` (manual) or the GH Action moves it," but no archive GH Action ships and `/impl-archive` is invoked entirely by hand, so completed epics silently rot (three flat epics in a downstream repo stuck `active` with closed issues). This epic closes the gap two ways: `/impl` detects a fully-merged epic on its next run and hands off to `/impl-archive`, and a new pure-bash `autocode-archive-design` GitHub Action archives by `design_id` on `workflow_dispatch`. Both open one archive PR that moves the folder, flips the INDEX row, and (multi-unit only) carries `Closes #<epic>` so merging the PR closes the epic. `/impl-archive` drops its current direct `issue-transition` close to match.
+
+## Background
+
+The fan-out half of the lifecycle is automated (a merged design PR creates issues via the `autocreate-design-doc-issue` Action); the archive half is not. The pieces today:
+
+| Component | File | Current behavior |
+|---|---|---|
+| Lifecycle spec | `autocode/design/design-folder.md` | "Epic done = folder under `.autocode/archive/`; `impl-archive` or the GH Action moves it." The Action does not exist. |
+| Manual archive | `autocode/impl/skills/impl-archive/SKILL.md` | Verifies units done, closes the epic via `issue-transition <epic> done` directly (step 4), then opens a lightweight folder-move PR. Epic closes before the PR merges. |
+| Unit launcher | `autocode/impl/skills/impl/SKILL.md` | Thin launcher: `impl-start` picks a unit, a background workflow drives it to a PR. Ends at PR open; never revisits epic completion. |
+| Unit selection | `autocode/impl/skills/impl-start/SKILL.md` | Step 4: a unit is ready iff `todo` and deps `done`. "If the ready set is empty, report why (all done, or blocked) and stop." All-done and blocked collapse to one dead end. |
+| Fan-out Action | `plugins/autocode/templates/autocreate-design-doc-issue/` | Pure-bash composite action + workflow; matches `autocode:epic`/`autocode:unit` markers via `gh api issues?state=all` + GraphQL `sub_issues`. The shape the archive Action mirrors. |
+
+A unit's sub-issue becomes `done` only when its PR merges, but `/impl` ends at PR open. So at the end of an `impl` run the just-pushed unit is `in-review`, not `done`: epic completeness can only be read on a later run, after that merge. That timing is why detection lives at `impl`'s entry (a subsequent run), not at its exit.
+
+## Architecture
+
+Two triggers, one archive behavior. The archive behavior already lives in `/impl-archive` (the manual/AI path); the new Action is its no-AI counterpart, the same skill/Action duality as `design-fanout`/`autocreate-design-doc-issue`. Neither trigger fires unattended on every merge.
+
+```
+last unit PR merges  ──>  epic's units all `done` (closed)
+        │
+        ├─ user runs `/impl --from-design <id>` again
+        │     └─ impl-start discovery: ready set empty AND all units done
+        │           └─ outcome = epic_complete  ──>  /impl hands off to /impl-archive <id>
+        │
+        └─ user dispatches autocode-archive-design (workflow_dispatch, input design_id=<id>)
+              └─ pure-bash: verify all units closed
+                                  │
+        both paths converge ──────┘
+              ▼
+        branch chore/archive-<id>-<short>
+        git mv .autocode/design/<id>-<short>  ->  .autocode/archive/<id>-<short>
+        flip INDEX.md row: active -> archived
+        open PR  (multi-unit: body `Closes #<epic>`; flat: no Closes)
+              ▼
+        PR merges  ->  folder archived + epic issue closed (multi-unit)
+```
+
+Detection contract (both paths read the same source): `issue-epic-list --epic <id>` / `gh api issues?state=all` + GraphQL `sub_issues`, matched on the `<!-- autocode:epic=<id> -->` and `<!-- autocode:unit=<id>/<slug> -->` body markers. Flat design = the single epic-marked issue is also the unit; multi-unit = every sub-issue must be closed.
+
+## Design decisions
+
+1. **Detection at `/impl`'s entry, not its exit.** A unit is `done` only after its PR merges; `/impl` exits at PR open. Checking completeness when `impl-start` discovery runs (a later invocation) reads true merged state. Rejected: archiving inside the same run that pushed the last unit (the unit isn't merged yet, so "last unit done" is unknowable there).
+
+2. **Trigger is user-gated, never an on-merge sweep.** `/impl` hand-off requires the user to run `/impl`; the Action requires an explicit `workflow_dispatch` with `design_id`. Rejected: a `pull_request: closed` sweep of active epics. It only opens PRs (nothing destructive), but firing on every merge across all active epics is uncontrolled and noisy; an explicit by-id trigger is predictable.
+
+3. **Epic closes via the archive PR's `Closes #<epic>`, not a direct transition.** `/impl-archive` today closes the epic before its folder-move PR merges, so an abandoned PR leaves a closed epic with an un-archived folder. Tying the close to the merge (a `Closes #<epic>` link) unifies the manual skill with the Action: both just open a PR. The two layers produce that link the way each layer should. The Action uses `gh` directly (like the fan-out Action), so it hand-writes `Closes #<epic>` in the PR body. `/impl-archive` goes through `pr-create`, where the close line is owned by `pr-issue-link.sh` and never hand-written; so the skill calls `pr-create --issue <epic-key>` WITHOUT `--lightweight` (adding `--no-review --no-pr-hygiene` to keep a mechanical move clean), letting the provider append the canonical `Closes #<ref>`. `--lightweight` would skip that linking, which is why the current flat-only `--lightweight` path cannot carry it. Flat designs have no epic issue, so they keep `--lightweight` and no `Closes`; their single issue was already closed by its own unit PR.
+
+4. **The Action is pure bash, mirroring the fan-out Action.** Archiving is mechanical (folder move, INDEX edit, marker-matched completeness check): no model needed. Reusing the fan-out Action's composite-action + workflow shape, its `gh api` marker queries, and the default `GITHUB_TOKEN` keeps it reliable and dependency-free. The skill remains the AI/interactive path; the Action is the CI path.
+
+5. **`impl-start` reports `epic_complete` vs `waiting` distinctly.** Step 4's single "ready set empty" dead end can't tell `/impl` whether to archive (all done) or wait (remaining units `in-review`/blocked). Splitting the outcome lets `/impl` hand off only when truly complete, and gives a useful nudge in both cases.
+
+## Runtime flow
+
+1. Last unit PR merges; the tracker auto-closes its sub-issue via `Closes #<unit>`. Every unit of the epic is now `done`.
+2. The user runs `/impl --from-design <id>` (intending the next unit). `impl-start` discovery maps markers, computes the ready set: empty. It checks the non-ready units: all `done` -> outcome `epic_complete` (vs some `in-review`/blocked -> `waiting`).
+3. On `epic_complete`, `impl-start` reports "epic complete" with the nudge, and `/impl` hands off to `/impl-archive <id>` instead of launching the unit workflow.
+4. `/impl-archive` (or, on the Action path, the dispatched workflow) verifies completeness from the discovery call, ensures a worktree + `chore/archive-<id>-<short>` branch, `git mv`s the folder to `.autocode/archive/`, flips the INDEX row to `archived`, and opens a PR. Multi-unit: body carries `Closes #<epic>`. Flat: no `Closes`.
+5. Merging the archive PR moves the folder on the default branch and (multi-unit) closes the epic issue via the `Closes` link. The lifecycle invariant holds: folder under `.autocode/archive/` is the epic-level source of truth for done.
+
+## Edge cases and error handling
+
+- **Idempotent re-run.** Both paths skip cleanly if the INDEX row is already `archived` or the source folder is already under `.autocode/archive/` (the move already happened). They also skip in-flight: if the archive branch `chore/archive-<id>-<short>` or its PR already exists (one path opened a PR the other now races), report and stop without recreating the branch or opening a duplicate. The skill and the Action share this idempotency identically. `issue-epic-list` on an already-closed epic is tolerated.
+- **Incomplete epic.** If any unit is not closed, the Action exits reporting the outstanding units (slug + status) and `/impl-archive` stops; never archive a partially-done epic.
+- **Not fanned out.** `issue-epic-list --epic <id>` returns `[]` (design PR not merged / no issues). Report and stop; nothing to archive.
+- **Flat design.** No `units/` dir, no separate epic issue: completeness = the single epic-marked issue is closed; archive PR has no `Closes`.
+- **`waiting` outcome.** Remaining units `in-review` or blocked on unfinished deps: `/impl` does not archive and does not error; it reports what's outstanding (matching today's "blocked" report).
+- **Action token.** The default `GITHUB_TOKEN` needs `contents: write` (branch + commit + push), `pull-requests: write` (open PR), `issues: read` (read issue/sub-issue state). No extra secrets.
+- **`design_id` input.** A `design_id` with no matching `.autocode/design/<id>-*` folder (e.g. already archived, or typo): the Action reports and exits non-fatally.
+
+## Testing strategy
+
+- **Action script (pure bash):** unit-test the archive script against fixture design folders (flat and multi-unit) and a faked `gh` (stubbed `issues?state=all` + `sub_issues` responses) for: all-closed -> archive; one-open -> abort with outstanding list; already-archived -> idempotent skip; flat -> no `Closes`; multi -> `Closes #<epic>`. Assert the `git mv`, the INDEX flip, and the rendered PR body. Mirror the fan-out template's existing test conventions where present.
+- **Skill changes:** no automated harness for skill bodies; verify by reading the updated `impl-start` outcome split and `/impl-archive` PR-body change, and dry-run `/impl --from-design <id>` against an epic whose units are all closed (hand-off fires) vs one with an `in-review` unit (`waiting`).
+- **Shape + CI:** `scripts/check-plugin-shape.sh` must stay green (the template is outside its scope; confirm). `**/*.sh` rule glob already covers the new script.
+
+## Sources
+
+- `autocode/design/design-folder.md` lifecycle section ("`impl-archive` (manual) or the GH Action moves it"; epic-done = folder under `.autocode/archive/`); INDEX.md registry semantics. The gap and the invariant.
+- `autocode/impl/skills/impl-archive/SKILL.md` steps 4-7: current direct `issue-transition <epic> done` then lightweight PR. The behavior being unified.
+- `autocode/impl/skills/impl/SKILL.md`: thin launcher, ends at PR open. Where the hand-off attaches.
+- `autocode/impl/skills/impl-start/SKILL.md` step 4: "ready set empty -> report why and stop." The outcome to split.
+- `autocode/impl/skills/impl/scripts/impl-workflow.mjs`: workflow ends at Push/Hygiene (PR open), confirming a unit is `in-review` not `done` at run end.
+- `plugins/autocode/templates/autocreate-design-doc-issue/.github/workflows/autocreate-design-doc-issue.yml` and `.github/actions/design-fanout/{action.yml,render-design-issues.sh}`: composite-action + workflow shape, marker-matched `gh api issues?state=all` + GraphQL `sub_issues` queries, default-`GITHUB_TOKEN` permission model. The pattern the archive Action mirrors.
+- `autocode/pr/skills/pr-create/SKILL.md` step 6 + Rules: the close line is owned by `pr-issue-link.sh` (never hand-written), and `--lightweight` skips linking. Why the skill path uses `--issue` without `--lightweight` while the Action hand-writes `Closes`.
+- `plugins/autocode/skills/autocode-setup/SKILL.md` Step 6: optional-Action install (copy template into repo `.github/`). Where the new template's install attaches.
+- `scripts/check-plugin-shape.sh` (no `templates/` handling) and `.claude/rules/shell-scripts-conventions.md` (`paths: **/*.sh`): the template is outside shape-check scope; its script is covered by the shell rule. Verified by direct read.
+- Handover trace (`autocode-handover` 2026-06-04): three flat epics (`0001`/`0002`/`0003`) in `backend.ai-lagrange` stuck `active` despite closed issues; `.autocode/archive/` never created. The motivating failure.
+
+## Units
+
+| unit | deliverable | depends-on |
+|---|---|---|
+| [archive-action-template](units/archive-action-template.md) | New pure-bash `autocode-archive-design` GH Action template (workflow_dispatch by `design_id` + composite action + archive script) | |
+| [impl-archive-closes-epic](units/impl-archive-closes-epic.md) | `/impl-archive` drops the direct `issue-transition`; archive PR carries `Closes #<epic>` (multi-unit only) | |
+| [impl-completion-handoff](units/impl-completion-handoff.md) | `impl-start` splits `epic_complete` vs `waiting`; `/impl` hands off to `/impl-archive`; nudge text | impl-archive-closes-epic |
+| [lifecycle-and-setup-wiring](units/lifecycle-and-setup-wiring.md) | `design-folder.md` lifecycle update + `autocode-setup` Step 6 installs the new template | archive-action-template |
+
+## Critique log
+
+### Iteration 1
+
+- Q: pr-create `--issue <epic-key> --no-review --no-pr-hygiene` without `--lightweight`: does that combo actually link `Closes #<epic>`? R: Verified (source read). `--lightweight` skips linking (step 6); the three concerns (link, reviewers, hygiene) are independent flags; `--issue` without `--lightweight` runs linking, `--no-review`/`--no-pr-hygiene` skip the rest. Design mechanism stands, no change.
+- Q: Does the `--auto` result block emit the keys the design says not to break (incl. `epic_key`)? R: Verified (impl-start step 10): emits worktree path, branch, slug, unit_key, epic_key, design_id; `epic_key` empty for flat. `shortname` lives in `.impl-context` but not the result block, so adding it is additive. No change.
+- Q: Fan-out queries / INDEX format / CI assumptions accurate? R: Verified. Epic query `gh api --paginate /repos/$REPO/issues?state=all` + `select(.pull_request | not)`; sub_issues via `-H GraphQL-Features:sub_issues` then REST `/issues/<n>/sub_issues`; CI runs only `check-plugin-shape.sh` + shellcheck; no test harness exists. No change.
+- Q: Skill path idempotency only covers post-merge (folder moved / INDEX archived); an in-flight archive PR from the Action plus an `/impl` hand-off would race on the existing branch. R: (user) Mirror the Action's branch/PR-exists idempotency in `/impl-archive`. Applied to `units/impl-archive-closes-epic.md` Rules and DESIGN edge case.
+- Q: Units describe INDEX status as `status: archived` (frontmatter), but it is a Markdown table column; the flip needs a row-targeted spec. R: (user) Specify row-targeted column edit: match by `<id>` in column 1, replace only that row's status cell `active` -> `archived`, never global. Applied to `units/archive-action-template.md` (steps 2, 5) and `units/impl-archive-closes-epic.md`.

--- a/.autocode/design/0001-auto-archive-epics/units/archive-action-template.md
+++ b/.autocode/design/0001-auto-archive-epics/units/archive-action-template.md
@@ -1,0 +1,93 @@
+---
+depends-on: []
+type: task
+---
+
+# Archive-design GitHub Action template
+
+## Summary
+
+Ship a new pure-bash GitHub Action template `autocode-archive-design`, a sibling of the existing `autocreate-design-doc-issue` fan-out template, that archives a completed design epic by id. It triggers only on `workflow_dispatch` with a required `design_id` input (no on-merge sweep, explicitly rejected in the epic). It resolves the design folder, verifies completeness via the same `autocode:epic`/`autocode:unit` marker-matched `gh` queries the fan-out Action uses (every unit sub-issue closed for multi-unit, the single epic-marked issue closed for flat), and on success creates branch `chore/archive-<id>-<short>`, `git mv`s the folder from `.autocode/design/` to `.autocode/archive/`, flips the epic's `INDEX.md` row from `active` to `archived`, commits, pushes, and opens a PR. Multi-unit PRs carry `Closes #<epic>` so merging closes the epic; flat PRs do not (their single issue was already closed by its own unit PR). The Action is idempotent (skips cleanly if already archived, folder already moved, or the branch/PR already exists) and incomplete-epic-safe (reports outstanding units and aborts without moving anything). It uses `gh` directly like the fan-out Action, not `provider/run.sh`.
+
+## Implementation
+
+Deliverable: the `autocode-archive-design` template directory: a `workflow_dispatch` workflow, a composite action, and a pure-bash archive script, plus bash tests against fixture design folders. The no-AI counterpart of `/impl-archive`, mirroring the `design-fanout`/`autocreate-design-doc-issue` skill/Action duality.
+
+This unit is the template files and their tests ONLY. It does NOT touch `autocode-setup` install wiring or `design-folder.md` (separate units: `lifecycle-and-setup-wiring`).
+
+### Files to read first (study and mirror)
+
+The implementer MUST read these before writing; the new template mirrors their shape, idioms, and `gh` queries:
+
+- `/Users/hhkoo/.autocode/plugins/autocode/templates/autocreate-design-doc-issue/.github/workflows/autocreate-design-doc-issue.yml` (workflow header comment, `permissions` block, checkout + composite-action call shape).
+- `/Users/hhkoo/.autocode/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/action.yml` (composite `runs:` shape, `${{ github.action_path }}/<script>` invocation, `gh api --paginate /repos/$REPO/issues?state=all` epic-by-marker query at action.yml:46-48, GraphQL `sub_issues` header + sub-issue body listing at action.yml:55-57 and :72).
+- `/Users/hhkoo/.autocode/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/render-design-issues.sh` (id/short split idiom `base=$(basename dir); id="${base%%-*}"; short="${base#*-}"` at lines 25-27; flat-vs-multi via `[[ -d "${dir}/units" ]]` at line 60; marker strings `<!-- autocode:epic=${id} -->` line 58 and `<!-- autocode:unit=${id}/${slug} -->` line 69).
+- `/Users/hhkoo/.autocode/plugins/autocode/templates/autocreate-design-doc-issue/.github/actions/design-fanout/create-design-issue.sh` (gh-direct usage, GraphQL node-id pattern, `set -euo pipefail` header).
+
+### Files to create
+
+Templates live beside skills' canonical sources, not as shims. Mirror the fan-out template's `.github/` sub-tree exactly.
+
+```
+plugins/autocode/templates/autocode-archive-design/
+  .github/workflows/autocode-archive-design.yml
+  .github/actions/design-archive/action.yml
+  .github/actions/design-archive/archive-design.sh
+```
+
+A small verify/render helper `.sh` MAY be split out (e.g. `verify-epic-complete.sh`) if it keeps `archive-design.sh` readable; the implementer decides. All `.sh` files executable (`chmod +x`), each headed with `#!/usr/bin/env bash` then `set -euo pipefail` per `.claude/rules/shell-scripts-conventions.md`. Required inputs guarded with `:?`; quote all expansions; pass `shellcheck` (CI installs shellcheck and the `**/*.sh` rule covers the new scripts).
+
+### Workflow: `autocode-archive-design.yml`
+
+- A header comment block matching the fan-out workflow's style: what it does, install note (copy into `<repo>/.github/`), the marker discovery contract ("do not rename"), requires default `GITHUB_TOKEN`.
+- Trigger: `workflow_dispatch` with a single required input `design_id` (string). No `pull_request` / auto-sweep trigger.
+- `permissions:` block: `contents: write`, `pull-requests: write`, `issues: read`.
+- One job: checkout the default branch with `fetch-depth: 0` (full history; the script branches, commits, pushes, opens a PR), then call the composite action `./.github/actions/design-archive`, passing `design-id`, `repo` (`github.repository`), and `github-token` (`secrets.GITHUB_TOKEN`).
+
+### Composite action: `design-archive/action.yml`
+
+- `using: 'composite'`, `name` + `description` like the fan-out action.
+- Inputs: `design-id` (required), `repo` (required), `github-token` (required).
+- Steps run `archive-design.sh` via `${{ github.action_path }}/archive-design.sh`, with `GH_TOKEN: ${{ inputs.github-token }}`, `REPO: ${{ inputs.repo }}`, `DESIGN_ID: ${{ inputs.design-id }}` in `env`. Side-effect script; human-readable progress to stderr/stdout; no `$GITHUB_OUTPUT` contract required.
+
+### Script: `archive-design.sh`
+
+Inputs via env: `GH_TOKEN`, `REPO`, `DESIGN_ID` (all `:?`-guarded). Behavior, in order:
+
+1. Resolve folder: glob `.autocode/design/${DESIGN_ID}-*` -> exactly one folder. Derive `id`/`short` with the render-design-issues.sh idiom (`base=$(basename dir); id="${base%%-*}"; short="${base#*-}"`).
+2. Idempotent skip (report + exit 0) if ANY of: the `.autocode/design/INDEX.md` `<id>` row's status column is already `archived` (it is a Markdown table column `| id | shortname | created | status |`, not a `status:` frontmatter field); the source folder is missing (already moved); `.autocode/archive/<id>-<short>` already exists.
+3. Flat vs multi: `units/` dir present -> multi; absent -> flat (`[[ -d "${dir}/units" ]]`).
+4. Completeness via the SAME marker-matched `gh` queries the fan-out action uses:
+   - Find the epic by `<!-- autocode:epic=<id> -->` body marker via `gh api --paginate /repos/$REPO/issues?state=all` (filter out PRs, `select(.pull_request | not)`).
+   - If no epic-marked issue exists (not fanned out): report and exit (non-fatal).
+   - Multi: list units via the GraphQL `sub_issues` feature header on the epic, match each by `<!-- autocode:unit=<id>/<slug> -->`; every unit sub-issue must be CLOSED.
+   - Flat: the single epic-marked issue must be CLOSED.
+   - If not all closed: print outstanding units (`slug` + `state`) and exit non-zero / non-fatal report; do NOT archive.
+5. Archive (only when complete): configure git identity (github-actions bot); create branch `chore/archive-<id>-<short>`; if that branch or its PR already exists, report and exit without duplicating (PR idempotency); `mkdir -p .autocode/archive`; `git mv .autocode/design/<id>-<short> .autocode/archive/<id>-<short>`; flip the INDEX row (Markdown table column, not frontmatter): match the row by the `<id>` value in the first column and replace only that row's status cell `active` -> `archived`, never a global substitution (other rows may also be `active`); the row and id stay, never removed; commit with a `chore:` message noting the epic is complete; push the branch.
+6. Open the PR with `gh pr create`. Multi-unit: PR body MUST contain `Closes #<epic-number>` so merging closes the epic; body notes it is a folder move. Flat: no `Closes` line; body notes the folder move only.
+
+Constraints: markers `<!-- autocode:epic=<id> -->` / `<!-- autocode:unit=<id>/<slug> -->` are the discovery contract, do NOT rename. The Action uses `gh` directly (GitHub-specific, like the fan-out action); it does NOT go through `provider/run.sh` (that is for skills).
+
+### Public interfaces (contract surface)
+
+- Workflow input: `design_id` (string, required).
+- Composite action inputs: `design-id`, `repo`, `github-token`.
+- Script env contract: `GH_TOKEN`, `REPO`, `DESIGN_ID`.
+- Branch name: `chore/archive-<id>-<short>`. Archive path: `.autocode/archive/<id>-<short>`.
+- PR body marker line (multi only): `Closes #<epic-number>`.
+
+### Tests that prove it
+
+No bats or shared test harness exists in the repo (`find` for `*.bats` and `test*` dirs returns nothing; CI runs only `scripts/check-plugin-shape.sh` + shellcheck per `.github/workflows/ci.yml`). The fan-out template ships no tests to mirror, so add standalone bash test scripts (executable, `set -euo pipefail`, shellcheck-clean) that drive `archive-design.sh` against fixtures with a stubbed `gh`.
+
+Stub `gh` (a shell function or a `PATH`-shimmed script) returns canned `issues?state=all` JSON and canned `sub_issues` GraphQL JSON per scenario; stub `git push`/`gh pr create` to capture (not perform) their args so the PR body is assertable. Build fixture design folders under a temp dir: a flat folder (`DESIGN.md`, no `units/`) and a multi folder (`DESIGN.md` + `units/<slug>.md`), each with a seeded `.autocode/design/INDEX.md` row.
+
+Assert:
+
+- Multi, all units closed -> `git mv` to `.autocode/archive/<id>-<short>` happened, `INDEX.md` row flipped `active` -> `archived`, PR body contains `Closes #<epic>`.
+- Flat, epic issue closed -> `git mv` + INDEX flip happened, PR body contains NO `Closes` line.
+- Multi, one unit open -> abort: prints the outstanding unit (`slug` + `state`), no `git mv`, INDEX unchanged.
+- Idempotent: INDEX row already `archived`, OR `.autocode/archive/<id>-<short>` already exists -> skip with exit 0, no duplicate move/PR.
+- Not fanned out: epic marker absent from `issues?state=all` -> report + exit, no move.
+
+Place the test script(s) inside the template directory (e.g. `plugins/autocode/templates/autocode-archive-design/.github/actions/design-archive/archive-design.test.sh`) so they ship and shellcheck with the script they exercise.

--- a/.autocode/design/0001-auto-archive-epics/units/impl-archive-closes-epic.md
+++ b/.autocode/design/0001-auto-archive-epics/units/impl-archive-closes-epic.md
@@ -1,0 +1,43 @@
+---
+depends-on: []
+type: task
+---
+
+# Archive PR closes the epic on merge
+
+## Summary
+
+`/impl-archive` closes a completed epic's issue eagerly via a direct `issue-transition <epic> done` (step 4) before its folder-move PR merges, so an abandoned archive PR leaves a closed epic with an un-archived folder. This unit drops that direct transition and instead has the archive PR carry `Closes #<epic>` (multi-unit only), tying the epic close to the PR merge. Flat designs have no separate epic issue, so they get no `Closes` line; their single issue was already closed by its own unit PR. The result unifies the manual skill with the new `autocode-archive-design` Action: both just open a PR that closes the epic on merge.
+
+## Implementation
+
+Deliverable: edit the canonical body-only skill source `autocode/impl/skills/impl-archive/SKILL.md` (in the worktree; do not touch the plugin shim). Read it first, plus `autocode/design/design-folder.md` (lifecycle + markers) and `autocode/pr/skills/pr-create/SKILL.md` (issue-link interface) before editing.
+
+Changes:
+
+- Remove step 4 entirely. Do not call `provider/run.sh issue-tracker issue-transition <epic-key> done`. The epic is no longer closed eagerly.
+
+- Capture the epic issue key/number during discovery (step 2). The discovery call `provider/run.sh issue-tracker issue-epic-list --epic <id>` already returns the epic row, matched by the `<!-- autocode:epic=<id> -->` body marker. Step 2 already maps markers to `{slug, key, status}` and the epic issue; make it explicit that the epic row's key is retained for the `Closes` linkage. Flat designs return a single row that is both epic and unit, with no separate epic issue, so there is no epic key to carry.
+
+- Wire the `Closes #<epic>` into the delegated PR creation (current step 7, `pr-create --lightweight`). Verified pr-create interface: pr-create never accepts a hand-written `Closes` in the body. It links the issue in its step 6 by resolving `provider/run.sh git-remote issue-ref <issue-id>` and appending a canonical `Closes #<ref>`, where `<issue-id>` comes from `--issue <tracker-key>`. But pr-create step 6 (link the issue) is skipped under `--lightweight`. So passing `--issue` alone with `--lightweight` will not link. The implementer must reconcile this so the multi-unit archive PR actually carries `Closes #<epic>`. Pick the mechanism that fits pr-create's contract as read, not a guess:
+  - Multi-unit: delegate to `pr-create --issue <epic-key>` WITHOUT `--lightweight` for the linking step to run, OR keep `--lightweight` and supply the close line via the body file pr-create accepts (verify against pr-create's `--body-file` / `--lightweight` rules: `--lightweight` skips link/reviewers/hygiene, and the PR body rule states the body never carries a hand-written close line, so prefer the `--issue` linking path over a hand-written `Closes`). State the chosen flag combination explicitly in the skill step.
+  - Flat: no epic key -> delegate with no issue linkage (current lightweight behavior unchanged), no `Closes` line.
+
+- Update surrounding prose:
+  - Step 8 report: for multi-unit, say "merging the PR closes the epic" (the epic is still open until merge). Drop the current "the epic issue is closed" wording, which implied it was already closed. Flat: report only that merging archives the folder.
+  - Step 6 git-commit delegation and the worktree / `git mv` / INDEX flip to `archived` / `pr-create` delegation: keep unchanged.
+
+- Update the Rules bullet that reads "`issue-transition` tolerates an already-closed epic." There is no direct transition anymore. Restate idempotency to cover both post-merge and in-flight state, mirroring the Action's idempotency exactly (single source of truth):
+  - Post-merge: the source folder is missing (already moved) OR the `<id>` row in `.autocode/design/INDEX.md` is already `archived` -> report and stop cleanly.
+  - In-flight: the archive branch `chore/archive-<id>-<short>` or its PR already exists (e.g. the Action or a prior skill run opened one that has not merged) -> report and stop without recreating the branch or opening a duplicate PR. Without this, a concurrent Action dispatch plus `/impl` hand-off would race: the skill would see the folder still present and INDEX still `active`, then collide on the existing branch.
+  - Keep the other Rules bullets (never archive an epic with outstanding units; completion read from the discovery call; tracker writes via `provider/run.sh issue-tracker`; delegate commit and PR creation).
+
+- INDEX flip precision (where the skill flips the row before the `pr-create` delegation): `.autocode/design/INDEX.md` is a Markdown table (`| id | shortname | created | status |`), not frontmatter. Match the row by the `<id>` value in the first column and replace only that row's status cell `active` -> `archived`. Never a global substitution: other rows may also be `active`, and the per-epic invariant is row-scoped.
+
+Single source of truth: this skill must stay the manual/AI counterpart of the new `autocode-archive-design` Action (separate unit); both open a PR that closes the epic on merge. Keep their behavior identical.
+
+Out of scope (separate units): the GH Action template, the `impl`/`impl-start` completion hand-off, and the `design-folder.md` lifecycle + `autocode-setup` wiring.
+
+Files to read: `autocode/impl/skills/impl-archive/SKILL.md` (modify), `autocode/design/design-folder.md`, `autocode/pr/skills/pr-create/SKILL.md`.
+
+Verification: no automated harness for skill bodies. Dry-run `/impl-archive <id>` on a multi-unit epic (whose units are all closed): the archive PR body contains `Closes #<epic>` and the epic issue is NOT closed until the PR merges. Dry-run on a flat epic: the archive PR has no `Closes` line.

--- a/.autocode/design/0001-auto-archive-epics/units/impl-completion-handoff.md
+++ b/.autocode/design/0001-auto-archive-epics/units/impl-completion-handoff.md
@@ -1,0 +1,65 @@
+---
+depends-on: [impl-archive-closes-epic]
+type: task
+---
+
+# Hand off a completed epic from /impl to /impl-archive
+
+## Summary
+
+Today `impl-start` step 4 collapses two unlike dead ends into one "ready set empty" report: an epic with every unit `done` (archivable) and an epic still waiting on `in-review`/blocked units (not archivable). And `/impl` never revisits epic completion, so a fully-merged epic is never archived without a hand-run of `/impl-archive`. This unit splits that dead end into two machine-readable outcomes, `epic_complete` vs `waiting`, surfaces them in `impl-start`'s human report and its `--auto` result block, and adds one control-flow branch to `/impl`: on `epic_complete`, hand off to `/impl-archive <id>` instead of launching the unit workflow. Detection lands on a subsequent `/impl` run, because a unit is `done` only after its PR merges and `/impl` exits at PR open, so the run that pushed the last unit cannot see it merged. `/impl` stays a thin launcher; archiving stays `/impl-archive`'s job.
+
+## Implementation
+
+Modify two canonical body-only skill sources (not the plugin shims):
+
+- `autocode/impl/skills/impl-start/SKILL.md`
+- `autocode/impl/skills/impl/SKILL.md`
+
+Read both current skills, plus `autocode/design/design-folder.md` (lifecycle, ready-set rule, discovery, the `--auto` result-block contract). Read `autocode/impl/skills/impl/scripts/impl-workflow.mjs` only if needed to confirm the workflow ends at Push/Hygiene (PR open); it does, so the hand-off attaches in the SKILL launcher, not the `.mjs`.
+
+### impl-start changes (step 4 + step 10)
+
+In step 4 (ready set empty case), split the single dead end into two outcomes computed from the per-unit `{slug, status}` map already built in step 3:
+
+- `epic_complete`: ready set empty AND every unit's status is `done`. Flat design: the single epic-marked issue is `done` (closed).
+- `waiting`: ready set empty AND at least one unit is not `done` (any of `in-progress`, `in-review`, or `todo` blocked on an unfinished dep).
+
+Reporting:
+
+- Interactive `epic_complete`: a clear "epic complete" message carrying the nudge: `Epic <id>-<short> complete. Archive it: /impl-archive <id> (or dispatch the autocode-archive-design workflow with design_id=<id>).`
+- Interactive `waiting`: report the outstanding units (slug + status), as today's "blocked/all-remaining" report does.
+
+Under `--auto` (step 10), extend the existing structured result block with one field that lets the caller branch. Do not break the current keys (worktree path, branch, slug, unit_key, epic_key, design_id). Add:
+
+```
+outcome: ready | epic_complete | waiting
+```
+
+- `ready`: a unit was selected; emit the unit-selection fields as today.
+- `epic_complete` / `waiting`: omit the unit-selection fields (slug, unit_key, worktree); include `design_id` and `shortname` so the caller can route. For `waiting`, also include the outstanding units (slug + status).
+
+`impl-start` only detects and reports/returns the outcome. It does not archive.
+
+### impl changes (step 1 + Workflow/Rules prose)
+
+After step 1 delegates to `impl-start`, capture the `outcome` (alongside the existing worktree path, `slug`, `unit_key`, `design_id`) and route on it. This is the only added control-flow branch:
+
+- `ready`: proceed as today; resolve workflow inputs (step 2) and launch the background workflow (step 3).
+- `epic_complete`: do NOT launch the unit workflow. Hand off to `/impl-archive <id>` using the `design_id` from `impl-start`. Archiving (folder move, INDEX flip, epic close) is `/impl-archive`'s job; do not inline it. This hand-off to the target's behavior is why this unit depends on `impl-archive-closes-epic`.
+- `waiting`: report the outstanding units and stop. No archive, no error.
+
+Update step 1's prose to capture `outcome`, and the Workflow/Rules sections to state the three-way route while keeping `/impl` a thin launcher (it routes; it does not implement archive logic).
+
+### Edge cases
+
+- Flat design: the single issue `done` -> `epic_complete`. Hand-off still runs `/impl-archive <id>`, which for a flat design moves the folder and flips the INDEX row only (no separate epic issue to close).
+- The three stuck flat epics in the downstream repo become archivable by re-running `/impl --from-design <id>`: the single issue is closed -> `epic_complete` -> hand-off.
+
+### Verification
+
+No automated harness for skill bodies. Dry-run `/impl --from-design <id>` against:
+
+- (a) an epic with all units closed -> hand-off to `/impl-archive` fires;
+- (b) an epic with one unit `in-review` -> `waiting`, no archive;
+- (c) an epic with a ready unit -> normal workflow launch.

--- a/.autocode/design/0001-auto-archive-epics/units/lifecycle-and-setup-wiring.md
+++ b/.autocode/design/0001-auto-archive-epics/units/lifecycle-and-setup-wiring.md
@@ -1,0 +1,50 @@
+---
+depends-on: [archive-action-template]
+type: task
+---
+
+# Lifecycle doc and setup wiring for the archive Action
+
+## Summary
+
+`design-folder.md` promises "`impl-archive` (manual) or the GH Action moves it," but no archive GH Action existed, so the doc named vapor. This unit lands the doc to match the now-shipped `autocode-archive-design` Action and the `/impl` hand-off, and makes `/autocode-setup` install the new template. The lifecycle section's Done-semantics bullets name the `autocode-archive-design` Action (triggered by `workflow_dispatch` with a `design_id` input) and the impl-driven hand-off (`/impl` detects a fully-merged epic on its next `--from-design <id>` run, outcome `epic_complete`, and hands off to `/impl-archive`). The epic transition table's `in-progress -> done` row reflects that the epic now closes via the archive PR's `Closes #<epic>` on merge, not a direct transition. `autocode-setup` Step 6 extends its optional-Action install to also offer and copy the `autocode-archive-design` template (workflow + `design-archive` composite action) into the repo `.github/`, same AskUserQuestion gate (default no). Canonical Action behavior stays in the template and the `/impl-archive` skill; the doc carries only the trigger and one or two sentences.
+
+## Implementation
+
+Depends on `archive-action-template`: the setup step installs the template that unit creates, and the doc references the Action it defines. Read these first: `~/.autocode/autocode/design/design-folder.md`, `~/.autocode/plugins/autocode/skills/autocode-setup/SKILL.md`, and the existing fan-out template under `~/.autocode/plugins/autocode/templates/autocreate-design-doc-issue/` (install-shape reference). The archive template's file paths come from the `archive-action-template` unit; reference them as `plugins/autocode/templates/autocode-archive-design/.github/{workflows/autocode-archive-design.yml, actions/design-archive/...}`.
+
+Files to modify:
+
+- `~/.autocode/autocode/design/design-folder.md` (worktree: `autocode/design/design-folder.md`)
+- `~/.autocode/plugins/autocode/skills/autocode-setup/SKILL.md` (worktree: `plugins/autocode/skills/autocode-setup/SKILL.md`). Bootstrap-exception plugin-native skill, not a shim. Edit it directly.
+
+### design-folder.md (`## Lifecycle`)
+
+Done semantics, the Epic-done bullet. Current text:
+
+> Epic done: the whole folder is moved to `.autocode/archive/<id>-<shortname>/`. Location is the epic-level source of truth. `impl-archive` (manual) or the GH Action moves it once every unit is done and closes the epic.
+
+Update so "the GH Action" names the shipped `autocode-archive-design` Action (triggered by `workflow_dispatch` with a `design_id` input). Also document the impl-driven hand-off: `/impl` detects a fully-merged epic on its next `--from-design <id>` run (`impl-start` outcome `epic_complete`) and hands off to `/impl-archive`. One or two sentences plus the trigger; do not restate the Action's internals (canonical behavior lives in the template and the `/impl-archive` skill).
+
+Epic transition table, the `in-progress -> done` row. Current trigger: "every unit is `done`; `impl-archive` (or the GH Action) closes the epic." Clarify the epic now closes via the archive PR's `Closes #<epic>` on merge, not a direct transition. Keep wording tight; do not duplicate DESIGN.md.
+
+### autocode-setup SKILL.md (Step 6)
+
+Step 6 currently offers only the fan-out template and copies `plugins/autocode/templates/autocreate-design-doc-issue/` into the repo `.github/`. Extend it to also offer and install the archive template. The implementer decides whether one prompt covers both Actions or a paired second AskUserQuestion option; keep the same gate (default no).
+
+Copy from `~/.autocode/plugins/autocode/templates/autocode-archive-design/`, preserving relative paths (`mkdir -p` each destination; keep `.sh` files executable):
+
+- workflow `.github/workflows/autocode-archive-design.yml` -> `<repo-root>/.github/workflows/`
+- composite action dir `.github/actions/design-archive/` -> `<repo-root>/.github/actions/design-archive/`
+
+Frame the archive Action: "On `workflow_dispatch` with a design id, archive a completed epic (move its folder to `.autocode/archive/`, flip INDEX, and for multi-unit close the epic via the PR). Without it, run `/impl-archive <id>` manually (or it runs automatically next time you `/impl` a fully-merged epic)."
+
+Preserve existing behavior: if a destination file exists, show a diff and ask before overwriting.
+
+### autocode-update reconciliation (flag, not a hard deliverable)
+
+Finding: `autocode-update` has no template-copy logic. It pulls `~/.autocode`. A repo set up before this template existed will not auto-receive it (same gap as the fan-out template today). Recommend either a one-line note in `autocode-update` pointing users to re-run `/autocode-setup` for new templates, or leaving it to a setup re-run. Keep out of the hard deliverable unless trivial.
+
+### Verification
+
+No automated harness for skill or doc bodies. Manual: re-run `/autocode-setup` in a test repo, confirm both templates are offered and installed under `.github/` (workflow + composite action dir, `.sh` executable); read the updated `design-folder.md` lifecycle section for correctness. Out of scope: Action internals (`archive-action-template` unit) and the `/impl`, `impl-start`, `/impl-archive` skill changes (separate units).

--- a/.autocode/design/INDEX.md
+++ b/.autocode/design/INDEX.md
@@ -1,0 +1,5 @@
+# Design index
+
+| id | shortname | created | status |
+|------|-------------------|------------|----------|
+| 0001 | auto-archive-epics | 2026-06-04 | active |


### PR DESCRIPTION
**Rendered design:** [DESIGN.md](https://github.com/hhoikoo/autocode/blob/docs/design-auto-archive-epics/.autocode/design/0001-auto-archive-epics/DESIGN.md)

Units: [archive-action-template](https://github.com/hhoikoo/autocode/blob/docs/design-auto-archive-epics/.autocode/design/0001-auto-archive-epics/units/archive-action-template.md) · [impl-archive-closes-epic](https://github.com/hhoikoo/autocode/blob/docs/design-auto-archive-epics/.autocode/design/0001-auto-archive-epics/units/impl-archive-closes-epic.md) · [impl-completion-handoff](https://github.com/hhoikoo/autocode/blob/docs/design-auto-archive-epics/.autocode/design/0001-auto-archive-epics/units/impl-completion-handoff.md) · [lifecycle-and-setup-wiring](https://github.com/hhoikoo/autocode/blob/docs/design-auto-archive-epics/.autocode/design/0001-auto-archive-epics/units/lifecycle-and-setup-wiring.md)

## Overview

Closes the archive half of the design lifecycle. When an epic's last unit PR merges, nothing archives the design folder: it stays under `.autocode/design/`, the epic issue stays open, and the `INDEX.md` row stays `active`. This epic adds two user-gated archive triggers (an `/impl` hand-off and a pure-bash `autocode-archive-design` GH Action) that both open one PR moving the folder to `.autocode/archive/`, flipping the INDEX row, and (multi-unit) carrying `Closes #<epic>` so the merge closes the epic.

## Problem Statement

- `design-folder.md` promises "`impl-archive` (manual) or the GH Action moves it," but no archive Action ships and `/impl-archive` is fully manual, so completed epics rot (three flat epics stuck `active` with closed issues in a downstream repo).
- `/impl-archive` closes the epic eagerly before its PR merges, so an abandoned PR leaves a closed epic with an un-archived folder.
- `impl-start` collapses "all units done" and "blocked/in-review" into one dead end, so `/impl` can never tell a complete epic from a waiting one.

## Architecture

```
last unit PR merges  ──>  epic's units all done (closed)
        │
        ├─ user runs /impl --from-design <id> again
        │     └─ impl-start: ready set empty AND all units done
        │           └─ outcome = epic_complete  ──>  /impl hands off to /impl-archive <id>
        │
        └─ user dispatches autocode-archive-design (workflow_dispatch, design_id=<id>)
              └─ pure-bash: verify all units closed
                                  │
        both paths converge ──────┘
              ▼
        branch chore/archive-<id>-<short>
        git mv .autocode/design/<id>-<short>  ->  .autocode/archive/<id>-<short>
        flip INDEX.md row: active -> archived
        open PR  (multi-unit: body Closes #<epic>; flat: no Closes)
              ▼
        PR merges  ->  folder archived + epic issue closed (multi-unit)
```

Skill/Action duality mirrors `design-fanout`/`autocreate-design-doc-issue`: `/impl-archive` is the AI/interactive path, the new Action is the no-AI CI path, both just open a PR. Four units: the Action template, the `/impl-archive` close-on-merge change, the `impl-start`/`impl` completion hand-off, and the lifecycle-doc + `autocode-setup` wiring.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to: _(n/a: design doc, text only)_
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
