### PR TITLE
feat: Refresh PR body on rebase and auto-merge archive PRs

### DIFF
--- a/autocode/design/CLAUDE.md
+++ b/autocode/design/CLAUDE.md
@@ -3,3 +3,5 @@
 Planning and research before code lands. Skills that plan, critique, push, iterate on, and fan out design docs live here (`design-plan`, `design-plan-critique`, `design-plan-push`, `design-plan-iterate`, `design-fanout`). The `codebase-researcher` and `web-researcher` agents are read-only helpers spawned by those skills.
 
 `design-folder.md` is the canonical layout for a design epic (folder, units DAG, fan-out to issues, progress log, archive). It is a fixed spec, not a scaffolded convention; design and impl skills `@`-import it.
+
+`design-pr-body.md` is the canonical recipe for a design-doc PR body (rendered-design link plus PR template filled from the design doc, never a code diff). `design-plan-push` composes it at creation; the `pr-hygiene` agent recomposes it on refresh. Both `@`-import it so the body never diverges.

--- a/autocode/design/design-pr-body.md
+++ b/autocode/design/design-pr-body.md
@@ -1,0 +1,53 @@
+# Design PR body
+
+Canonical recipe for the body of a design-doc PR. Imported by `design-plan-push`
+(composes it at creation) and `pr-hygiene` (recomposes it on refresh) so the two
+never diverge. A design PR's body is a rendered-doc link plus the repo PR
+template filled from the design doc; it is never a code-diff summary.
+
+## Detection
+
+A PR is a design PR when its branch diff touches `.autocode/design/**` and no
+source outside it: `git diff <base>...HEAD --name-only` is non-empty and every
+path is under `.autocode/design/`. (The rendered-design link at the top of the
+body, below, is a secondary marker.)
+
+## Inputs
+
+- `<folder>`: the design folder `.autocode/design/<id>-<shortname>/`. Callers
+  that already resolved it pass it in. Otherwise discover it from the diff:
+  `git diff <base>...HEAD --name-only | grep '^\.autocode/design/'`, then take
+  the containing `<id>-<shortname>` directory (the one holding `DESIGN.md`).
+- `<base>`: resolved base branch. `<branch>`: current branch ref
+  (`git rev-parse --abbrev-ref HEAD`).
+
+## Recipe
+
+Compose to a temp file: `body="$(mktemp -d -t autocode-design-pr)/body.md"`.
+
+1. Rendered-design link(s) at the very top, before any template section, so the
+   reviewer's first click opens the formatted doc instead of a diff. Derive the
+   host base URL:
+   ```
+   base_url=$(git remote get-url origin | sed -E 's#(git@|https://)([^:/]+)[:/]#https://\2/#; s#\.git$##')
+   ```
+   Write a `Rendered design` label, then the link
+   `$base_url/blob/<branch>/.autocode/design/<id>-<shortname>/DESIGN.md` (add one
+   per `units/<slug>.md` when multi-unit). The branch ref keeps links current as
+   commits land during review; after merge the branch is gone, but fan-out writes
+   the permanent link to `DESIGN.md` at the merge commit. (GitHub URL shape; the
+   only supported host.)
+2. Below the link, fill the repo PR template (`@.github/PULL_REQUEST_TEMPLATE.md`;
+   the `pr-template` convention is the pointer). Strip its HTML comments. Fill
+   sections from the design doc, not from a code diff:
+   - `## Overview`: the `DESIGN.md` `## Summary`.
+   - `## Problem Statement`: the design's motivation (from `## Summary` /
+     `## Background`); keep under four bullets.
+   - `## Architecture`: the `DESIGN.md` architecture diagram if it has one (the
+     rendered-doc link already covers the full doc).
+   - `## Checklist`: copy items verbatim; check
+     `Documentation added or modified appropriately` (the design doc is the doc),
+     leave the issue-mention item unchecked (no issue exists pre-fan-out), and
+     mark the test-case item n/a (the PR is text).
+3. Never hand-write an issue reference (`Closes`, `Refs`). Pre-fan-out there is
+   no issue; post-merge fan-out owns linking.

--- a/autocode/design/skills/design-plan-push/SKILL.md
+++ b/autocode/design/skills/design-plan-push/SKILL.md
@@ -22,18 +22,7 @@ Layout: `@~/.autocode/autocode/design/design-folder.md`.
 2. Ensure a worktree + docs branch per `@~/.autocode/autocode/_config/guides/worktree.md`, then delegate to `git-create-branch "docs: design <shortname>"` (skipped if `design-plan` already created the worktree this session). Run this in the same session as `design-plan`: the design folder is uncommitted in that worktree, so on the default branch in a fresh session the glob below will not find it.
 3. Stage the design folder: `git add .autocode/design/<id>-<shortname>/`.
 4. Delegate to `git-commit` (forward a context note describing the design).
-5. Compose the PR body to a temp file (`body="$(mktemp -d -t autocode-design-pr)/body.md"`) by filling the repo's checked-in PR template, so a design PR reads like every other PR:
-   - Open the body with the `Rendered design` link(s) at the very top, before any template section, so a reviewer's first click opens the formatted doc instead of a diff. Derive base + branch:
-     ```
-     base=$(git remote get-url origin | sed -E 's#(git@|https://)([^:/]+)[:/]#https://\2/#; s#\.git$##')
-     branch=$(git rev-parse --abbrev-ref HEAD)
-     ```
-     Link: `$base/blob/$branch/.autocode/design/<id>-<shortname>/DESIGN.md` (add one per `units/<slug>.md`, multi-unit). The branch ref keeps the link current as commits land during review; after merge the branch is gone, but fan-out writes the permanent link to `DESIGN.md` at the merge commit. (GitHub URL shape; the only supported host.)
-   - Below the link, fill the template skeleton (`@.github/PULL_REQUEST_TEMPLATE.md`; the `pr-template` convention is the pointer). Strip its HTML comments. Fill its sections from the design doc, not from a code diff:
-     - `## Overview`: the `DESIGN.md` `## Summary`.
-     - `## Problem Statement`: the design's motivation (from `## Summary` / `## Background`); keep under four bullets.
-     - `## Architecture`: the `DESIGN.md` architecture diagram if it has one (the rendered-doc link is already at the top).
-     - `## Checklist`: copy items verbatim; check `Documentation added or modified appropriately` (the design doc is the doc), leave the issue-mention item unchecked (no issue exists pre-fan-out), and mark the test-case item n/a (the PR is text).
+5. Compose the PR body per the canonical recipe in `@~/.autocode/autocode/design/design-pr-body.md`, passing `<folder>` (from step 1) and the resolved base. That recipe owns the rendered-design link and the template fill, so the body stays identical to what `pr-hygiene` recomposes on later refresh. Capture the temp path it writes as `body`.
 6. Delegate to `pr-create --lightweight --body-file "$body"`. `--lightweight` skips issue linking and background `pr-hygiene` (the issues do not exist yet); `--body-file` supplies the composed body verbatim.
 7. Report the PR URL. Suggest `/design-plan-iterate` once reviews land, and note that merging this PR triggers fan-out (the `design-fanout` skill or the optional Action).
 

--- a/autocode/impl/skills/impl-archive/SKILL.md
+++ b/autocode/impl/skills/impl-archive/SKILL.md
@@ -21,8 +21,9 @@ Layout, discovery, and lifecycle: `@~/.autocode/autocode/design/design-folder.md
    - `git mv .autocode/design/<id>-<short> .autocode/archive/<id>-<short>` (if the source no longer exists, it is already archived; report and stop).
    - In `.autocode/design/INDEX.md`, flip this epic's row to `status: archived`. The row and its id stay; never removed or reused.
 6. Delegate to `git-commit` (a `chore` commit; note that the epic is complete).
-7. Delegate to `pr-create --lightweight` (the change is a folder move, not code).
-8. Report the PR URL and that merging it archives the folder; note the epic issue is closed.
+7. Delegate to `pr-create --lightweight` (the change is a folder move, not code). Capture the PR number from its result.
+8. Auto-merge: `provider/run.sh git-remote pr-merge <pr-number> --admin`. A folder move needs no review, and `--admin` bypasses required checks. The script is a no-op if the PR is already merged.
+9. Report the PR URL, that it was merged (archiving the folder), and that the epic issue is closed.
 
 ## Rules
 
@@ -30,5 +31,6 @@ Layout, discovery, and lifecycle: `@~/.autocode/autocode/design/design-folder.md
 - All tracker writes go through `provider/run.sh issue-tracker ...`.
 - Idempotent: re-running on an already-archived epic detects the missing source folder and stops cleanly; `issue-transition` tolerates an already-closed epic.
 - Delegate commit and PR creation; do not inline them.
+- Auto-merge the archive PR with `--admin`: it is a pure folder move and warrants no review.
 
 $ARGUMENTS

--- a/autocode/pr/agents/pr-hygiene.md
+++ b/autocode/pr/agents/pr-hygiene.md
@@ -21,7 +21,15 @@ Use these to scope the analysis. Read the full branch diff only if the PR descri
    provider/run.sh git-remote pr-view --json number,body
    ```
    If none, output "No PR exists" and stop.
-3. **Documentation assessment** from the scoped diff. Consider:
+3. Resolve the base branch dynamically:
+   ```bash
+   gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+   ```
+4. **Design-PR check.** Apply the detection rule in `@~/.autocode/autocode/design/design-pr-body.md`: `git diff <base>...HEAD --name-only` is non-empty and every path is under `.autocode/design/`. If so, this is a design PR:
+   - Documentation assessment is fixed: output **No docs needed** (the design doc is the doc).
+   - PR description: recompose the body via the recipe in `@~/.autocode/autocode/design/design-pr-body.md` (it self-discovers `<folder>` from the diff), then apply it with `provider/run.sh git-remote pr-body-edit <pr-number> <path>`. Do not run the diff-based draft in step 6; a design body is never a code-diff summary. Include the applied body in the output and stop.
+   - Otherwise continue to step 5.
+5. **Documentation assessment** from the scoped diff. Consider:
    - New public APIs, CLI flags, config options.
    - Behavior changes to existing features.
    - Architectural shifts that affect contributors.
@@ -31,11 +39,7 @@ Use these to scope the analysis. Read the full branch diff only if the PR descri
    Internal refactors, test additions, and pure bug fixes rarely warrant doc updates. Output one of:
    - **No docs needed** with a 1-2 sentence rationale.
    - **Docs update recommended**: for each file, name the section and describe the specific change. Do not apply edits; the caller approves.
-4. Resolve the base branch dynamically:
-   ```bash
-   gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
-   ```
-5. **PR description update**. Compare the current body against the scoped diff.
+6. **PR description update**. Compare the current body against the scoped diff.
    - If current, output "PR description is current".
    - If stale: run `git diff <base>...HEAD` for the full branch diff. Draft a replacement body that reads as if the PR were freshly opened (no changelog, no patch notes). Write it to `$(mktemp -d -t autocode-pr-hygiene)/body.md`. Apply via:
      ```bash

--- a/autocode/pr/skills/pr-rebase/SKILL.md
+++ b/autocode/pr/skills/pr-rebase/SKILL.md
@@ -25,7 +25,8 @@ Rebase the current branch onto its base and resolve conflicts.
    - Small obvious failure (lint, typo): fix and amend the relevant commit (`git commit --amend --no-edit` after re-staging).
    - Non-trivial failure: stop and ask the user.
 6. Push: `git push --force-with-lease`. Never `git push --force`.
-7. Report: rebased branch, conflict count resolved, verify result.
+7. Background hygiene. A rebase rewrites the branch and may resolve content conflicts, so the PR body can be stale. Spawn the `pr-hygiene` agent via the Task tool with `run_in_background: true`; do not wait for it. The prompt includes the rebased branch SHAs (`git log <base>..HEAD --pretty=%H`) and changed files (`git diff <base>...HEAD --name-only`). The agent self-checks for a PR and handles design PRs (recompose) vs code PRs (diff-based) on its own. Skip only if the rebase was a no-op (step 2 already stops then).
+8. Report: rebased branch, conflict count resolved, verify result, and that hygiene was dispatched.
 
 ## Rules
 

--- a/plugins/autocode/skills/impl-archive/SKILL.md
+++ b/plugins/autocode/skills/impl-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl-archive
-description: Close out a completed design epic. Verifies every unit is done, closes the epic issue, and moves the design folder to .autocode/archive/ via a lightweight PR.
+description: Close out a completed design epic. Verifies every unit is done, closes the epic issue, and moves the design folder to .autocode/archive/ via a lightweight PR that it auto-merges with --admin.
 ---
 
 Read through @~/.autocode/autocode/impl/skills/impl-archive/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/provider/git-remote/contract.md
+++ b/provider/git-remote/contract.md
@@ -13,7 +13,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 - Exit codes: `0` success, `1` expected failure (bad input, missing resource), `2` unexpected failure (network, crash).
 - JSON: `snake_case` keys, `[]` for empty arrays, `""` for empty strings, never `null` (except where the shape explicitly allows it, e.g. `line: <integer|null>` for PR comments without a line).
 - PR identifier is provider-native as a string (GitHub PR number).
-- Idempotency: `pr-issue-link.sh` is a no-op when the link is already present. `pr-review-request.sh` tolerates already-requested reviewers. `pr-thread-resolve.sh` tolerates already-resolved threads.
+- Idempotency: `pr-issue-link.sh` is a no-op when the link is already present. `pr-review-request.sh` tolerates already-requested reviewers. `pr-thread-resolve.sh` tolerates already-resolved threads. `pr-merge.sh` is a no-op on an already-merged PR.
 
 ## Shared types
 
@@ -62,6 +62,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 | `pr-view.sh` | `[--json <fields>] [<pr>]` | JSON of requested fields |
 | `pr-create.sh` | `--title <t> --body-file <p> [--base <b>] [--assignee <a>] [--no-review]` | PR URL on a single line |
 | `pr-body-edit.sh` | `<pr> <body-file>` | none |
+| `pr-merge.sh` | `<pr> [--admin] [--squash\|--merge\|--rebase]` | none |
 | `pr-issue-link.sh` | `<pr> <issue-id>` | none |
 | `issue-ref.sh` | `<tracker-key>` | git-remote issue number to close, or empty |
 | `pr-review-request.sh` | `<pr> <reviewer>...` | none |
@@ -77,6 +78,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 - `pr-create.sh` `--no-review` opens the PR without the script requesting any reviewers (no `--reviewer` passed to gh). Server-side CODEOWNERS auto-request, when the repo enables it, is outside gh's control and is not suppressed.
 - `pr-issue-link.sh` is idempotent. It detects existing `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved #N` references (case-insensitive, word-boundary anchored) and skips when present. When missing, it appends a canonical `Closes #N` line.
 - `issue-ref.sh` bridges the issue-tracker key to a git-remote-native close target. A close reference only auto-closes when it names a git-remote issue number, which differs from the tracker key when the tracker is not the git remote. The GitHub implementation echoes a numeric key as-is (GitHub Issues is the tracker), and for a non-numeric key (e.g. Jira `PROJ-123`) searches for a mirrored GitHub issue, emitting its number or empty. Empty stdout with exit `0` means "nothing on this remote to close" and is not a failure; callers skip the link step.
+- `pr-merge.sh` default method is `--squash`; `--admin` bypasses required reviews and checks. Idempotent: an already-merged PR exits `0` as a no-op.
 - `pr-review-request.sh` tolerates reviewers already on the PR without error.
 - `pr-comment-list.sh` default `--kind` is `all`. The merged list discriminates via `.kind`.
 - `pr-comment-reply.sh` posts a threaded reply to a review comment. Falls back to a regular issue-style PR comment if the threaded-reply API rejects the target id.

--- a/provider/git-remote/github/pr-merge.sh
+++ b/provider/git-remote/github/pr-merge.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Merge a PR.
+# Usage: pr-merge.sh <pr-number> [--admin] [--squash|--merge|--rebase]
+# Default merge method is --squash. --admin bypasses required reviews/checks.
+# Side-effect only; no stdout. Idempotent: an already-merged PR is a no-op.
+
+pr_number="${1:?Usage: pr-merge.sh <pr-number> [--admin] [--squash|--merge|--rebase]}"
+shift
+
+method="--squash"
+admin=""
+for arg in "$@"; do
+  case "${arg}" in
+    --admin) admin="--admin" ;;
+    --squash | --merge | --rebase) method="${arg}" ;;
+    *)
+      echo "pr-merge.sh: unknown argument: ${arg}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+state="$(gh pr view "${pr_number}" --json state -q .state)"
+if [[ "${state}" == "MERGED" ]]; then
+  echo "pr-merge.sh: PR #${pr_number} already merged" >&2
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+# admin is intentionally unquoted: empty means omit the flag entirely.
+gh pr merge "${pr_number}" ${admin} "${method}"


### PR DESCRIPTION
## Overview

Keeps PR descriptions fresh after a rebase and auto-merges the `impl-archive` folder-move PR.

- `pr-rebase` dispatches the `pr-hygiene` agent in the background after push.
- `pr-hygiene` recognizes a design PR and recomposes its rendered-doc-link body via a shared recipe instead of overwriting it with a diff summary.
- `impl-archive` merges its lightweight archive PR with `--admin` via a new `pr-merge.sh` git-remote provider script.

## Problem Statement

- A rebase rewrites the branch and may resolve content conflicts, but nothing refreshed the PR body afterward, so it drifted from the branch.
- Design PRs carry a bespoke body (rendered-doc link plus the PR template filled from the design doc). The existing diff-based `pr-hygiene` draft would clobber that body, which is why design PRs skipped hygiene entirely.
- The `impl-archive` PR is a pure folder move that needs no review, yet still required a manual merge.

## Implementation Notes

- `autocode/design/design-pr-body.md` is the canonical design-PR body recipe; `design-plan-push` (at creation) and `pr-hygiene` (on refresh) both import it so the body never diverges. Detection: the branch diff touches only `.autocode/design/**`.
- `pr-merge.sh`: default `--squash`, optional `--admin` to bypass required checks, no-op on an already-merged PR. Registered in the git-remote provider contract.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
