### PR TITLE
docs: Plan background workflow for design-plan unit authoring

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/DESIGN.md
+++ b/.autocode/design/0003-design-unit-workflow/DESIGN.md
@@ -1,0 +1,175 @@
+---
+type: story
+---
+
+# Background workflow for design-plan unit authoring
+
+## Summary
+
+`design-plan` fans out its per-unit `design-unit-author` agents inline via the Task tool, inside the launching session. The authored unit prose itself stays out of context (the agent returns only a path plus a one-line summary, `design-unit-author.md:41`); what fills the window is the dispatch side and the orchestration: each inline Task prompt embeds the full `DESIGN.md` verbatim, so N units mean N copies of the epic plan in the session's tool-use history, and the underspecified-retry judgment pulls fresh research back into context. This lifts that fan-out into a background Workflow script (`author-units.mjs`), mirroring how `impl` runs its phases via `impl-workflow.mjs`: the launching session writes `DESIGN.md`, then launches the workflow and consumes a single structured result, while the parallel authoring and a bounded research-backed retry run in the background out of context. The same change gives `design-unit-author` a structured return contract (`{ underspecified, file, summary }`) so the workflow can branch on a typed result, and drops the interactive shortname prompt in favor of an auto-derived shortname. Research fan-out (step 3) stays inline: its verbatim findings must reach the planner to compose a sourced plan, and it carries no retry loop.
+
+## Background
+
+`design-plan` step 5 today (`autocode/design/skills/design-plan/SKILL.md:43`) dispatches one `design-unit-author` per unit in a single message, waits, and re-dispatches any unit the author reports underspecified. The author returns unstructured text with an in-band "underspecified" signal (`autocode/design/agents/design-unit-author.md:29`). The impl flow already solved the equivalent problem: `impl` is a thin launcher that sets up the worktree, then runs every phase as a background Workflow (`autocode/impl/skills/impl/scripts/impl-workflow.mjs`), keeping heavy work out of the session (`autocode/impl/CLAUDE.md`).
+
+| Piece | Current | Target |
+|---|---|---|
+| Unit-author fan-out | inline Task calls in the session | background Workflow (`author-units.mjs`) |
+| Underspecified retry | re-dispatch inline, judgment in session | bounded research-backed retry in the workflow; genuine gaps surface |
+| `design-unit-author` return | unstructured text, in-band signal | structured `{ underspecified, file, summary }` |
+| Shortname | `AskUserQuestion` prompt | auto-derived from the epic title |
+| Research fan-out | inline Task calls | unchanged (stays inline) |
+
+The shape check (`scripts/check-plugin-shape.sh`) validates SKILL/agent shims, feature-set `CLAUDE.md` presence, and shellchecks `*.sh`. It does not touch `scripts/*.mjs`; the impl precedent confirms workflow scripts live only in the real tree (`plugins/autocode/skills/impl/` carries only `SKILL.md`), referenced by absolute path resolved from `args.homeDir`. So the new script needs no shim and no CI change.
+
+## Architecture
+
+No new packages or deps. One new Workflow script next to its skill, one agent-contract edit, one launcher rewrite, one CLAUDE.md note. The launching session keeps every interactive and narrative step; only the unit-author fan-out crosses into the background.
+
+```
+design-plan (launching session)                         author-units.mjs (background Workflow)
+--------------------------------                        -------------------------------------
+seed -> rough sketch -> gaps
+  |
+  +-- research fan-out (INLINE Task; verbatim findings)
+  |
+compose epic plan + unit DAG
+auto-derive <shortname>
+enter worktree + branch
+allocate <id> from INDEX.md
+write DESIGN.md (in session)
+  |
+  |   Workflow(scriptPath, args:{ homeDir, workdir,
+  |            folder, designText, units[] })
+  +--------------------------------------------------->  phase Author: parallel(units.map(authorOne))
+  |                                                         authorOne(u):
+  |                                                           r1 = agent(design-unit-author,
+  |                                                                schema AUTHOR_SCHEMA)   // writes units/<slug>.md
+  |                                                           if !r1.underspecified -> return r1
+  |                                                         phase Resolve (bounded, x1):
+  |                                                           f  = agent(codebase-researcher, scoped to u)
+  |                                                           r2 = agent(design-unit-author + f, schema)
+  |                                                           return r2   // may still be underspecified
+  |   { authored:[{slug,file,summary,underspecified}],   <- return
+  +<--  underspecified:[slug], retried:[slug] }
+  |
+inspect return; for each still-underspecified unit:
+  resolve in session (more research / tighter deliverable),
+  re-launch the workflow for those units or hand-author
+  |
+final report
+```
+
+The author agents write distinct `units/<slug>.md` files concurrently into the same worktree (parallel-safe; the existing inline fan-out already relies on this). The launching session does not receive the unit prose, only path + one-line summary + the underspecified flag per unit.
+
+## Design decisions
+
+1. **Move only the unit-author fan-out; leave research fan-out inline.** Two seams exist: research (step 3, before plan composition) and unit-authoring (step 5, after `DESIGN.md`). Only unit-authoring moves. Research findings are folded verbatim into the plan so the planner can write a sourced design (`design-plan` rules: every claim cited; prefer "I don't know" over a guess); the findings must enter the main context regardless of how they were gathered, so a research workflow would save little while risking distillation of the grounding the planner needs. Unit-authoring is the high-value seam: the unit files are the deliverable on disk, the session needs only a summary back, and the underspecified-retry is real multi-step orchestration. Rejected: a second research workflow (low payoff, distillation risk); one workflow straddling both seams (impossible, since in-session `DESIGN.md` authoring sits between them and the workflow runs to completion in the background before returning).
+
+2. **One workflow, launched at the step-5 seam.** A single Workflow invocation cannot straddle the in-session `DESIGN.md` write. Since only unit-authoring moves, one script suffices, launched after `DESIGN.md` is written. Mirrors `impl`'s single `impl-workflow.mjs`.
+
+3. **Bounded research-backed retry in the workflow, then surface.** On an underspecified unit, the workflow dispatches a `codebase-researcher` scoped to that unit's deliverable, then re-dispatches `design-unit-author` with the findings (cap: one retry per unit). Units still underspecified after the retry are returned in the structured result for the session to resolve (more research or a tighter deliverable) and re-launch or hand-author. Rationale: the common cause of underspecification is the author lacking concrete file detail it could have found; the workflow runtime can spawn researchers (subagents cannot, which is why the fan-out lives in the workflow), so it can manufacture that missing information without bouncing to the session. A genuine planning gap (the deliverable itself is wrong) cannot be fixed without session judgment, so it surfaces. Rejected: pure surface-to-session (bounces the common, auto-resolvable case back into context); blind in-workflow retry with the same inputs (adds no information, only re-rolls non-determinism); unbounded retry (can loop on an impossible unit).
+
+4. **`design-unit-author` returns a structured contract.** `{ underspecified: boolean, file: string, summary: string }`, enforced by the workflow's `agent(..., { schema })` call (forces a StructuredOutput tool call, model retries on mismatch), exactly as `impl-workflow.mjs` enforces `FINDINGS_SCHEMA`/`DECIDE_SCHEMA`. The agent body documents the contract; the schema literal lives in the script (single consumer). The file remains the deliverable; the structured value is the control signal. The agent stays usable inline (a human caller reads the same fields from prose).
+
+5. **Workflow agents follow agent bodies by absolute path, not `agentType`.** The script's author and researcher agents are default workflow agents told to read `~/.autocode/autocode/design/agents/<name>.md` and follow it (impl's `follow(path, extra)` convention), because the skill/agent catalog is not reliably visible to workflow agents. Paths resolve from `args.homeDir`, never env vars (unexpanded in the workflow runtime). `model: 'opus'` is set per-agent in the script for the author (matching its shim); the per-agent `model` option is safe (the frontmatter-`model: sonnet` rate-limit issue does not apply to the script option).
+
+6. **Auto-derive the shortname; drop the prompt.** Step 5 no longer calls `AskUserQuestion` for `<shortname>`. It derives one from the epic `# <Title>`/`## Summary`: kebab-case, lowercase, 2-4 keywords, filler stripped (same reduction `git-create-branch` uses for short-names), then de-duplicated against `INDEX.md` and existing `.autocode/design/*` folders (suffix `-2`, `-3` on collision). Removes a round-trip; the title already encodes the human label. `--temp` is unaffected (it has no id and an ephemeral folder).
+
+## Runtime flow
+
+1. Steps 1-4 of `design-plan` run unchanged in the session: seed, rough sketch, gap identification with inline research fan-out, plan composition and unit decomposition.
+2. Step 5 (non-temp): auto-derive `<shortname>` from the title; enter the worktree; `git-create-branch`; allocate `<id>` from `INDEX.md`; create `<folder>` and `<folder>/units/`; write `DESIGN.md` in the session; append the `INDEX.md` row.
+3. Resolve workflow args: `homeDir` (`echo "$HOME"`), `workdir` (the worktree root for inspection; the original repo root under `--temp`), `folder` (absolute design folder), `designText` (the `DESIGN.md` just written), `units` (one entry per unit: `slug`, `deliverable`, `dependsOn`, `type`, and the verbatim research findings relevant to it).
+4. Launch the Workflow with `scriptPath = <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/author-units.mjs` and those `args`. The session waits; authoring and retry run in the background.
+5. The workflow authors every unit in parallel; each underspecified unit gets one research-backed retry; it returns `{ authored, underspecified, retried }`.
+6. The session consumes the result. If `underspecified` is empty, it proceeds to the final report (worktree, branch, folder, `<id>`; suggest `/design-plan-critique <id>` or `/design-plan-push <id>`). Otherwise it resolves each surfaced unit (more research or a tighter deliverable) and re-launches the workflow for those slugs or hand-authors them, then reports.
+7. Flat single-unit designs are unchanged: `design-plan` writes `DESIGN.md` itself, no fan-out, no workflow.
+
+## Implementation
+
+Deliverable: `design-plan`'s unit-author fan-out runs as a background Workflow, `design-unit-author` returns a structured contract, and the shortname is auto-derived. One PR.
+
+Files:
+
+- `autocode/design/skills/design-plan/scripts/author-units.mjs` (new). The Workflow script. Mirrors `impl-workflow.mjs` structure:
+  - `export const meta` with `name: 'author-units'`, a description, and `phases: [{ title: 'Author', model: 'opus' }, { title: 'Resolve' }]`.
+  - Reads `args`: `homeDir`, `workdir`, `folder`, `designText`, `units` (array of `{ slug, deliverable, dependsOn, type, research }`). No interactive input; all args resolved by the launcher.
+  - Helpers mirroring impl: `agentBody(name) => ${HOME}/.autocode/autocode/design/agents/${name}.md`, `follow(path, extra)`, `inDir = "Work in ${workdir}: cd into it before inspecting the codebase. "`.
+  - `AUTHOR_SCHEMA = { type:'object', additionalProperties:false, properties:{ underspecified:{type:'boolean'}, file:{type:'string'}, summary:{type:'string'} }, required:['underspecified','file','summary'] }`.
+  - `MAX_RETRY = 1`.
+  - `authorOne(u)`: dispatch `design-unit-author` (read its body, `phase:'Author'`, `model:'opus'`, `schema: AUTHOR_SCHEMA`) with a prompt carrying `folder`, `workdir`, `designText` verbatim, `u`'s assignment, and `u.research` verbatim. If `!underspecified`, return `{ slug, ...result, retried:false }`. Else the bounded retry, both calls tagged with the `{ phase: 'Resolve' }` agent option (never a bare `phase('Resolve')` call): `authorOne` runs inside `parallel`, and `phase()` mutates global state shared across all concurrent units, so a bare call races other units' phase grouping. Dispatch `codebase-researcher` (`{ phase: 'Resolve' }`, its own default model; read-only by contract) scoped to `u.deliverable` plus the author's `summary` (the missing-files question), then re-dispatch the author (`{ phase: 'Resolve', model: 'opus', schema: AUTHOR_SCHEMA }`) with the extra findings appended; return the second result with `retried:true`. Mirrors `impl-workflow.mjs`, where the in-`parallel` review agents pass `{ phase: 'Review' }` as an option and no `phase()` call appears inside a `parallel` map.
+  - Top level: `phase('Author')`; `const authored = (await parallel(units.map(u => () => authorOne(u)))).filter(Boolean)`; `return { authored, underspecified: authored.filter(a => a.underspecified).map(a => a.slug), retried: authored.filter(a => a.retried).map(a => a.slug) }`.
+  - Plain JS only; no `Date.now()`/`Math.random()`/argless `new Date()`.
+- `autocode/design/agents/design-unit-author.md` (edit). Replace the in-band underspecified note (line 29) and the Output section (lines 39-41) with the structured contract: report `underspecified` (boolean), `file` (the `units/<slug>.md` path written, or the intended path when underspecified), and `summary` (the one-line deliverable summary, or the reason it is underspecified and what is missing). Keep "the file is the deliverable, not the message." No frontmatter (body-only real file).
+- `autocode/design/skills/design-plan/SKILL.md` (edit). Step 5:
+  - Drop the `AskUserQuestion` for `<shortname>`; auto-derive it (decision 6) and state the derivation and collision rule inline.
+  - Replace the inline multi-unit fan-out paragraph (line 43) with: write `DESIGN.md`, resolve the workflow args (decision 5, runtime step 3), launch the Workflow (`scriptPath` + `args`), consume `{ authored, underspecified, retried }`, and resolve any surfaced underspecified unit in-session then re-launch or hand-author.
+  - Leave the `--temp` and flat branches behaving as before (flat writes `DESIGN.md` inline, no workflow; `--temp` passes `workdir` = original repo root and a `folder` outside any worktree).
+- `autocode/design/CLAUDE.md` (edit). One line noting `design-plan` launches `author-units.mjs` (a background Workflow) for unit-author fan-out, mirroring impl, with the script living next to the skill under `scripts/`.
+
+No shim changes: no new skill or agent names; the `.mjs` script is not shimmed (shape check ignores it). No CI change.
+
+Public interface (workflow args contract):
+
+```
+args = {
+  homeDir:   string,   // echo "$HOME"
+  workdir:   string,   // worktree root (non-temp) | original repo root (--temp)
+  folder:    string,   // absolute design folder; units written to <folder>/units/<slug>.md
+  designText: string,  // full DESIGN.md text, verbatim, passed to every author
+  units: [ { slug, deliverable, dependsOn: [slug...], type, research } ]
+}
+return = { authored: [ { slug, file, summary, underspecified, retried } ],
+           underspecified: [slug...], retried: [slug...] }
+```
+
+## Edge cases and error handling
+
+- All units well-specified: `underspecified` is empty; the session reports directly. The common path.
+- A unit still underspecified after the one retry: surfaced in `underspecified`; the session resolves and re-launches for those slugs or hand-authors. Not an error.
+- An author agent dies on a terminal error: `parallel` yields `null` for it; `.filter(Boolean)` drops it, and its slug is absent from `authored`. The session detects the missing slug (compare against the units it sent) and re-launches or hand-authors that one.
+- The whole workflow fails (the Workflow tool errors out, not a single agent dying): the session gets no structured result, but `DESIGN.md`, the `INDEX.md` row, and the `<id>` are already written and durable in the worktree. `units/` is empty or partial. The session treats every sent slug as missing and re-launches the workflow, or hand-authors the units; no rollback of the id or the folder. The id, not the run, is the durable token.
+- `--temp`: no worktree, no id, no `INDEX.md`; `workdir` = the original repo root for codebase inspection, `folder` = the temp dir. Authors still inspect the real repo for file shapes.
+- Single-unit (flat) design: no workflow launched; `design-plan` writes `DESIGN.md` itself.
+- Shortname collision with an `INDEX.md` row or an existing `.autocode/design/*` folder: append `-2`, `-3`. The id (not the shortname) is the durable token, so a suffixed shortname is harmless.
+
+## Testing strategy
+
+Markdown-and-script change, no app build. Verification:
+
+- `scripts/check-plugin-shape.sh` passes (no new shims; real files carry no frontmatter; every feature-set has `CLAUDE.md`). This is the CI gate.
+- Static read of `author-units.mjs` against `impl-workflow.mjs`: same helper shape, `args.homeDir` path resolution, `parallel` fan-out, `schema`-typed returns, no forbidden globals.
+- Dry exercise: run `/design-plan` on a small multi-unit seed in a scratch repo; confirm no shortname prompt, the workflow launches after `DESIGN.md`, unit files land under `units/`, and the final report carries the structured tally. Confirm an intentionally vague unit surfaces in `underspecified` after one retry.
+- Confirm `design-unit-author` still works inline (invoke it directly) and reports the three contract fields in prose.
+
+## Alternatives considered
+
+- **Multi-unit decomposition of this epic** (split into agent-contract, workflow-script, launcher units). Rejected: the script, the contract it consumes, and the launcher that feeds it are tightly coupled and only coherent reviewed together (does the launcher pass what the script expects? does the schema match the author's contract?). Splitting would merge dead code (a workflow nothing invokes) ahead of its wiring and make review harder. Flat single-unit fits the modest, cohesive scope.
+- **Move research fan-out too** (one or two extra workflows). Rejected: see decision 1.
+- **Move `design-plan-critique` and `design-plan-iterate` into workflows.** Deferred, out of scope. `critique`'s loop interleaves `AskUserQuestion` user-asks with research dispatch every iteration (`design-plan-critique/SKILL.md:20-26`); not a clean fan-out without restructuring to pre-collect questions. `iterate`'s only fan-out is the apply step (one subagent per affected unit, often one), with triage staying in-session; a workflow there is low payoff for a second script and schema. Both stay in-skill and individually user-invocable. Revisit if either grows a real multi-round fan-out.
+
+## Sources
+
+- `autocode/design/skills/design-plan/SKILL.md:14-49` — current workflow; step 5 inline fan-out (`:43`) and shortname prompt (`:38`).
+- `autocode/design/agents/design-unit-author.md:29,39-41` — current in-band underspecified signal and unstructured output.
+- `autocode/design/agents/codebase-researcher.md` — researcher contract used in the retry.
+- `autocode/impl/skills/impl/scripts/impl-workflow.mjs` — workflow-script template: `meta`, `args.homeDir`, `follow`, `parallel`, schema-typed `agent` returns, plain-JS constraints.
+- `autocode/impl/skills/impl/SKILL.md:21-26` — how a thin launcher resolves args and calls the Workflow tool (`scriptPath` + `args`).
+- `autocode/impl/CLAUDE.md` — "the workflow does the fan-out the per-phase skills cannot (subagents cannot spawn subagents); heavy work stays out of the launching session."
+- `autocode/design/design-folder.md:47-51,70-88` — flat-vs-multi rule; unit-file shape.
+- `scripts/check-plugin-shape.sh:31-124` — shape check covers shims, feature-set `CLAUDE.md`, and `*.sh`; not `*.mjs`. `plugins/autocode/skills/impl/` (only `SKILL.md`) confirms workflow scripts are not shimmed.
+- `autocode/_config/guides/worktree.md` — `EnterWorktree` then `git-create-branch`; the fan-out writes into the same worktree.
+- `autocode/_config/conventions/issue-types.md` — `story` = single-PR user-visible deliverable (the `/design-plan` behavior change).
+- `git-create-branch/SKILL.md:39` — kebab short-name reduction reused for shortname derivation.
+- User decision (this session): also drop the interactive shortname prompt; auto-pick a reasonable one.
+
+## Critique log
+
+Iteration 1:
+- Q: Does `phase('Resolve')` called inside the `parallel(units.map(...))` map (Implementation `authorOne`) race other concurrent units? A: Yes. The Workflow contract states `phase()` mutates global state and warns to use the `{ phase }` agent option inside `parallel`/`pipeline`; `impl-workflow.mjs` confirms the pattern (in-`parallel` review agents pass `{ phase: 'Review' }`, no bare `phase()` inside a map). Rewrote `authorOne` to tag both Resolve calls with the `{ phase: 'Resolve' }` option. Source: Workflow tool contract; `impl-workflow.mjs:139-146`.
+- Q: Is the stated problem (unit prose fills context) accurate? A: No. `design-unit-author.md:41` returns only path + one-line summary, so prose never enters context today. The real cost is N inline Task prompts each embedding full `DESIGN.md` plus the in-session retry research. Reframed the Summary. Source: `design-unit-author.md:41`; `design-plan/SKILL.md:43`.
+- Q: What model and read-only posture for the Resolve-phase agents? A: Re-dispatched author pinned `model: 'opus'` + `schema: AUTHOR_SCHEMA` (matches the Author phase); `codebase-researcher` runs at its own default and is read-only by its own contract (`codebase-researcher.md:71`). Folded into the `authorOne` spec. Source: `codebase-researcher.md:71`.
+- Q: Is whole-workflow failure (Workflow tool error, distinct from a single agent dying) handled? A: It was not. Added an edge case: `DESIGN.md`/`INDEX.md` row/`<id>` are already durable; the session re-launches or hand-authors, no id rollback. Source: existing edge-case list; the id-as-durable-token rule (decision 6, edge cases).
+</content>
+</invoke>

--- a/.autocode/design/0003-design-unit-workflow/DESIGN.md
+++ b/.autocode/design/0003-design-unit-workflow/DESIGN.md
@@ -1,175 +1,176 @@
----
-type: story
----
-
-# Background workflow for design-plan unit authoring
+# Design lifecycle orchestrator
 
 ## Summary
 
-`design-plan` fans out its per-unit `design-unit-author` agents inline via the Task tool, inside the launching session. The authored unit prose itself stays out of context (the agent returns only a path plus a one-line summary, `design-unit-author.md:41`); what fills the window is the dispatch side and the orchestration: each inline Task prompt embeds the full `DESIGN.md` verbatim, so N units mean N copies of the epic plan in the session's tool-use history, and the underspecified-retry judgment pulls fresh research back into context. This lifts that fan-out into a background Workflow script (`author-units.mjs`), mirroring how `impl` runs its phases via `impl-workflow.mjs`: the launching session writes `DESIGN.md`, then launches the workflow and consumes a single structured result, while the parallel authoring and a bounded research-backed retry run in the background out of context. The same change gives `design-unit-author` a structured return contract (`{ underspecified, file, summary }`) so the workflow can branch on a typed result, and drops the interactive shortname prompt in favor of an auto-derived shortname. Research fan-out (step 3) stays inline: its verbatim findings must reach the planner to compose a sourced plan, and it carries no retry loop.
+`design-plan`, `design-plan-critique`, `design-plan-iterate`, `design-plan-push`, and `design-fanout` are driven one at a time, by hand, each in the launching session, so every phase's research churn, prose authoring, and triage fills the main context window. This epic turns `/design` into a stateless, re-entrant orchestrator for the design half of the lifecycle, the mirror of the impl-epic-orchestrator (`0002-impl-epic-orchestrator`) for the impl half. Given a seed or an in-flight epic, it reconstructs the current stage from disk, the tracker, and the open PR, dispatches the next heavy phase into a background workflow or subagent so the work runs off the main context, consumes a single typed result, and advances one step: plan -> critique -> push -> (iterate on review) -> [merge, user-gated] -> fanout -> hand off to the impl orchestrator. Pre-merge thinking runs automatically; merging is the one step pinned to the main session for explicit user approval; fanout runs automatically post-merge. The original narrow scope of this folder (move the unit-author fan-out into a background workflow, give `design-unit-author` a structured `{ underspecified, file, summary }` contract, auto-derive the shortname) folds in as the plan phase's off-context mechanism. To make each phase dispatchable, `design-plan`, `design-plan-critique`, `design-plan-iterate`, and `design-fanout` gain `--auto` modes with structured returns and a `needs_human` signal, mirroring decision 6 of `0002`. Every phase skill stays individually invocable, so repositories without full automation access can still drive the pieces by hand.
 
 ## Background
 
-`design-plan` step 5 today (`autocode/design/skills/design-plan/SKILL.md:43`) dispatches one `design-unit-author` per unit in a single message, waits, and re-dispatches any unit the author reports underspecified. The author returns unstructured text with an in-band "underspecified" signal (`autocode/design/agents/design-unit-author.md:29`). The impl flow already solved the equivalent problem: `impl` is a thin launcher that sets up the worktree, then runs every phase as a background Workflow (`autocode/impl/skills/impl/scripts/impl-workflow.mjs`), keeping heavy work out of the session (`autocode/impl/CLAUDE.md`).
+The per-phase design skills already exist and each works standalone. What is missing is the layer above them: a single re-entrant command that knows where an epic is in its lifecycle and runs the next phase off-context, gating only where a human decision belongs. A second gap is the surface that layer needs: the phase skills are interactive (they call `AskUserQuestion`) and return prose, neither of which a background phase can consume.
 
-| Piece | Current | Target |
-|---|---|---|
-| Unit-author fan-out | inline Task calls in the session | background Workflow (`author-units.mjs`) |
-| Underspecified retry | re-dispatch inline, judgment in session | bounded research-backed retry in the workflow; genuine gaps surface |
-| `design-unit-author` return | unstructured text, in-band signal | structured `{ underspecified, file, summary }` |
-| Shortname | `AskUserQuestion` prompt | auto-derived from the epic title |
-| Research fan-out | inline Task calls | unchanged (stays inline) |
-
-The shape check (`scripts/check-plugin-shape.sh`) validates SKILL/agent shims, feature-set `CLAUDE.md` presence, and shellchecks `*.sh`. It does not touch `scripts/*.mjs`; the impl precedent confirms workflow scripts live only in the real tree (`plugins/autocode/skills/impl/` carries only `SKILL.md`), referenced by absolute path resolved from `args.homeDir`. So the new script needs no shim and no CI change.
+| Phase | Skill | Current behavior | Gap for orchestration |
+|---|---|---|---|
+| Plan | `autocode/design/skills/design-plan/SKILL.md` | In-session: seed prompt, research fan-out, compose `DESIGN.md`, inline `design-unit-author` fan-out, interactive shortname prompt. | Heavy work + N copies of `DESIGN.md` in dispatch prompts fill context; interactive; prose return. |
+| Critique | `autocode/design/skills/design-plan-critique/SKILL.md` | In-session bounded loop (cap 5): generate questions, dispatch researchers, apply edits in place; `AskUserQuestion` on arg ambiguity and on cap. | Interactive gates; prose 2-3 line return; no `needs_human` contract. |
+| Iterate | `autocode/design/skills/design-plan-iterate/SKILL.md` | Triage design-PR review comments, score, apply, reply, resolve threads. No `AskUserQuestion` gates. | Returns a triage table, not machine-readable; no `--auto` contract. |
+| Push | `autocode/design/skills/design-plan-push/SKILL.md` | Compose the design-PR body, commit, open a lightweight PR. Light. | Already thin; needs only a typed PR-URL return. |
+| Fanout | `autocode/design/skills/design-fanout/SKILL.md` | Post-merge: create epic issue + per-unit sub-issues, idempotent by body marker; `AskUserQuestion` on arg ambiguity. | Interactive on ambiguity; prose table return. |
+| Unit authoring | `autocode/design/agents/design-unit-author.md` | Inline Task fan-out; unstructured prose with in-band "underspecified" signal. | Not a typed control signal; retry bounces to the session. |
+| Fanout (auto) | `.github/workflows/autocreate-design-doc-issue.yml` | Pure-shell GH Action fires on merged PR adding a new `DESIGN.md`; same issue shape as the skill. | Independent of the orchestrator; runs only on the default-branch merge event. |
+| Lifecycle state | `autocode/design/design-folder.md`, `provider/issue-tracker/github/issue-epic-list.sh` | `INDEX.md` status is coarse (`active`/`archived`); fine-grained unit/epic state lives in the tracker via `issue-epic-list`. | No single "where is this epic" query; needs disk + tracker + PR reconstruction. |
 
 ## Architecture
 
-No new packages or deps. One new Workflow script next to its skill, one agent-contract edit, one launcher rewrite, one CLAUDE.md note. The launching session keeps every interactive and narrative step; only the unit-author fan-out crosses into the background.
+The orchestrator runs in the main session and owns no durable state. Each turn it reconstructs the stage from three observable sources (disk, the issue tracker, the open PR), runs exactly one phase off the main context, consumes its typed result, and either advances or stops at a gate. The heavy phases (plan, critique) run as background workflows or subagents; merging is the only step pinned to the main session, because it needs explicit user approval.
 
 ```
-design-plan (launching session)                         author-units.mjs (background Workflow)
---------------------------------                        -------------------------------------
-seed -> rough sketch -> gaps
-  |
-  +-- research fan-out (INLINE Task; verbatim findings)
-  |
-compose epic plan + unit DAG
-auto-derive <shortname>
-enter worktree + branch
-allocate <id> from INDEX.md
-write DESIGN.md (in session)
-  |
-  |   Workflow(scriptPath, args:{ homeDir, workdir,
-  |            folder, designText, units[] })
-  +--------------------------------------------------->  phase Author: parallel(units.map(authorOne))
-  |                                                         authorOne(u):
-  |                                                           r1 = agent(design-unit-author,
-  |                                                                schema AUTHOR_SCHEMA)   // writes units/<slug>.md
-  |                                                           if !r1.underspecified -> return r1
-  |                                                         phase Resolve (bounded, x1):
-  |                                                           f  = agent(codebase-researcher, scoped to u)
-  |                                                           r2 = agent(design-unit-author + f, schema)
-  |                                                           return r2   // may still be underspecified
-  |   { authored:[{slug,file,summary,underspecified}],   <- return
-  +<--  underspecified:[slug], retried:[slug] }
-  |
-inspect return; for each still-underspecified unit:
-  resolve in session (more research / tighter deliverable),
-  re-launch the workflow for those units or hand-author
-  |
-final report
+                    main session: /design orchestrator (stateless, re-entrant)
+                            |                              ^
+  reconstruct stage each turn                              | re-invoked on <task-notification>
+        +-------------------+--------------------+         | (phase workflow completion)
+        |                   |                    |         |
+        v                   v                    v         |
+   disk: folder?       tracker:             open design    |
+   committed?          issue-epic-list      PR? (by branch |
+   units/?             (epic/unit status)   / design-diff) |
+        |                   |                    |         |
+        +-------------------+--------------------+         |
+        |  stage in { none, planned, pushed, in-review,    |
+        |             merged, fanned-out }                 |
+        v                                                  |
+   dispatch next phase OFF-CONTEXT  ----------------------+
+        |
+        |  none      -> plan-phase     (bg)  -> { folder, id, units[], open_qs }
+        |  planned   -> critique-phase (bg, --auto) -> { iterations, changes, needs_human }
+        |  planned   -> push           (light/in-session) -> { pr_url }
+        |  in-review -> iterate        (--auto) -> { applied, needs_human }  [+ wait for merge]
+        |  ====================== USER-GATED MERGE (main session only) ======================
+        |  merged    -> fanout         (--auto) -> { epic_key, sub_issues[] }
+        |  fanned-out-> hand off: invoke `impl --from-design <id>` (the 0002 orchestrator)
+        v
+   surface needs_human cases; present merge-ready PR; report stage + next step
 ```
 
-The author agents write distinct `units/<slug>.md` files concurrently into the same worktree (parallel-safe; the existing inline fan-out already relies on this). The launching session does not receive the unit prose, only path + one-line summary + the underspecified flag per unit.
+Heavy-phase dispatch keeps the research findings, the unit prose, and the triage noise out of the main session: the orchestrator sees only a typed result per phase. Each heavy phase is one background Workflow the main-session orchestrator launches directly (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`); the plan workflow absorbs the unit-author fan-out and the critique workflow absorbs the per-iteration research and apply fan-out, each as `agent()`/`parallel()` calls inside the single workflow (no nested workflow, sidestepping the one-level nesting limit, since the orchestrator itself is a main-session skill, not a Workflow).
 
 ## Design decisions
 
-1. **Move only the unit-author fan-out; leave research fan-out inline.** Two seams exist: research (step 3, before plan composition) and unit-authoring (step 5, after `DESIGN.md`). Only unit-authoring moves. Research findings are folded verbatim into the plan so the planner can write a sourced design (`design-plan` rules: every claim cited; prefer "I don't know" over a guess); the findings must enter the main context regardless of how they were gathered, so a research workflow would save little while risking distillation of the grounding the planner needs. Unit-authoring is the high-value seam: the unit files are the deliverable on disk, the session needs only a summary back, and the underspecified-retry is real multi-step orchestration. Rejected: a second research workflow (low payoff, distillation risk); one workflow straddling both seams (impossible, since in-session `DESIGN.md` authoring sits between them and the workflow runs to completion in the background before returning).
+1. **The outer orchestrator is a main-session skill, not a Workflow.** A Workflow runs to completion in the background and cannot call `AskUserQuestion`, but merging a design PR is an inherent user-gated, outward step; and a Workflow cannot nest another Workflow (the plan phase already launches a fan-out workflow). So `/design` is a thin main-session sequencer that launches each phase off-context and waits, exactly as `impl` launches `impl-workflow` (`autocode/impl/skills/impl/SKILL.md:21-26`). User-confirmed (this session): the outer layer need not be a workflow. Rejected: a pure-workflow orchestrator (cannot gate the merge, cannot nest the plan fan-out).
 
-2. **One workflow, launched at the step-5 seam.** A single Workflow invocation cannot straddle the in-session `DESIGN.md` write. Since only unit-authoring moves, one script suffices, launched after `DESIGN.md` is written. Mirrors `impl`'s single `impl-workflow.mjs`.
+2. **Each heavy phase is a background Workflow the orchestrator launches directly.** Plan and critique are the context-heavy phases (research churn, unit prose, per-iteration question/research/apply). A skill invoked via the Skill tool runs *in* the main session, so invoking a phase skill inline does **not** move its work off-context; only a Workflow or a subagent runs off-context, and a subagent cannot nest the fan-outs these phases need (it can spawn neither a Workflow nor a further subagent). So each heavy phase is a background Workflow script (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`) that the main-session orchestrator launches directly via the Workflow tool, consuming only a typed result, exactly as the `0002` orchestrator launches `impl-workflow.mjs` directly and bypasses the `impl` skill wrapper (research this session: `impl-orchestrator-core.md:49`, `impl-workflow.mjs:26-30` "Subagents cannot spawn subagents, so all fan-out lives here in the workflow runtime"). The workflow's agents *read the existing phase skill and agent bodies* for their heuristics, so the logic stays single-source and the workflow owns only the deterministic loop + fan-out scaffolding. The phase skills (`design-plan`, `design-plan-critique`) become thin launchers over the same workflow for the `--auto` path, and keep their in-session interactive loop for the non-`--auto` manual path (decision 8). This is the user's core requirement: drive the lifecycle without polluting the main context. Once the *whole* plan phase runs off-context, the "research must stay inline so the planner sees it" constraint dissolves: the planner is the off-context workflow now, the findings reach it there, and the main session gets only the summary. User-confirmed (this session): workflow-centric dispatch, mirroring `0002`. Rejected: invoking the `--auto` skills inline in the orchestrator's own context (the skill body runs in the main session, so synthesis, research digestion, and critique churn land in the window the design exists to keep clean); dispatching them as subagents (cannot nest the plan unit-author Workflow or the critique apply fan-out).
 
-3. **Bounded research-backed retry in the workflow, then surface.** On an underspecified unit, the workflow dispatches a `codebase-researcher` scoped to that unit's deliverable, then re-dispatches `design-unit-author` with the findings (cap: one retry per unit). Units still underspecified after the retry are returned in the structured result for the session to resolve (more research or a tighter deliverable) and re-launch or hand-author. Rationale: the common cause of underspecification is the author lacking concrete file detail it could have found; the workflow runtime can spawn researchers (subagents cannot, which is why the fan-out lives in the workflow), so it can manufacture that missing information without bouncing to the session. A genuine planning gap (the deliverable itself is wrong) cannot be fixed without session judgment, so it surfaces. Rejected: pure surface-to-session (bounces the common, auto-resolvable case back into context); blind in-workflow retry with the same inputs (adds no information, only re-rolls non-determinism); unbounded retry (can loop on an impossible unit).
+3. **Stateless, re-entrant stage reconstruction.** The orchestrator stores nothing durable; each turn it recomputes the stage from disk (does `.autocode/design/<id>-<short>/` exist; is it committed; does `units/` exist), the tracker (`issue-epic-list --epic <id>`: `[]` means not fanned out, non-empty means fanned out), and the open design PR (found by branch or by a diff touching only `.autocode/design/**`). `INDEX.md` `status` is a coarse two-state flag (`active`/`archived`, `design-folder.md:30-31`) and does not distinguish the pre-archive stages, so the fine-grained stage comes from disk + tracker + PR, not from `INDEX.md`. Mirrors `0002` decision 1 (the tracker is the single source of truth; a stored queue would drift). Rejected: a persistent orchestrator state file (needs reconciliation against the tracker regardless).
 
-4. **`design-unit-author` returns a structured contract.** `{ underspecified: boolean, file: string, summary: string }`, enforced by the workflow's `agent(..., { schema })` call (forces a StructuredOutput tool call, model retries on mismatch), exactly as `impl-workflow.mjs` enforces `FINDINGS_SCHEMA`/`DECIDE_SCHEMA`. The agent body documents the contract; the schema literal lives in the script (single consumer). The file remains the deliverable; the structured value is the control signal. The agent stays usable inline (a human caller reads the same fields from prose).
+4. **Hybrid gating: auto pre-merge, hard-stop at merge, auto post-merge.** Plan, critique, push, and iterate run automatically (they are reversible, in-tree, and the design PR is itself the review artifact). The merge is the single hard gate: it is outward-facing and irreversible, and a design PR exists precisely so a human reviews and merges it. After merge, fanout runs automatically, then the orchestrator hands off. The orchestrator never merges the design PR on its own (distinct from `impl-archive`, which may self-merge its own archive PR with `--admin`). User-selected (this session): hybrid. Rejected: full-auto self-merge of the design PR (defeats the review the PR exists for); fully gated (a round-trip at every phase boundary the user does not want).
 
-5. **Workflow agents follow agent bodies by absolute path, not `agentType`.** The script's author and researcher agents are default workflow agents told to read `~/.autocode/autocode/design/agents/<name>.md` and follow it (impl's `follow(path, extra)` convention), because the skill/agent catalog is not reliably visible to workflow agents. Paths resolve from `args.homeDir`, never env vars (unexpanded in the workflow runtime). `model: 'opus'` is set per-agent in the script for the author (matching its shim); the per-agent `model` option is safe (the frontmatter-`model: sonnet` rate-limit issue does not apply to the script option).
+5. **`--auto` modes with structured returns and `needs_human` for the phase skills.** `design-plan`, `design-plan-critique`, `design-plan-iterate`, and `design-fanout` gain an `--auto` flag that suppresses their `AskUserQuestion` gates in favor of a structured result block carrying a `needs_human` signal. A background phase cannot call `AskUserQuestion`; the structured stop signal lets the orchestrator branch and surface only the cases that genuinely need a person (an ambiguous arg, a critique question research cannot resolve, the iteration cap reached with open questions). Directly mirrors `0002` decision 6 for `pr-rebase`/`pr-fix-ci`/`pr-review`. This is the enabler for decision 2.
 
-6. **Auto-derive the shortname; drop the prompt.** Step 5 no longer calls `AskUserQuestion` for `<shortname>`. It derives one from the epic `# <Title>`/`## Summary`: kebab-case, lowercase, 2-4 keywords, filler stripped (same reduction `git-create-branch` uses for short-names), then de-duplicated against `INDEX.md` and existing `.autocode/design/*` folders (suffix `-2`, `-3` on collision). Removes a round-trip; the title already encodes the human label. `--temp` is unaffected (it has no id and an ephemeral folder).
+6. **`design-unit-author` returns a structured contract and the plan phase runs a bounded research-backed retry.** `{ underspecified: boolean, file: string, summary: string }`, enforced by the plan-phase workflow's `agent(..., { schema })` call exactly as `impl-workflow.mjs` enforces its schemas. On an underspecified unit, the plan phase dispatches a `codebase-researcher` scoped to that unit, then re-dispatches the author with the findings (cap: one retry per unit); units still underspecified surface in the structured result. The retry's two agents pass the `{ phase: 'Resolve' }` agent option, never a bare `phase('Resolve')` call: the author runs inside `parallel`, where `phase()` mutates shared global state and races other units (Workflow tool contract; `impl-workflow.mjs:139-146` passes `{ phase: 'Review' }` as an option and never calls `phase()` inside a `parallel` map). The agent stays usable inline (a human reads the same three fields from prose). This is the original narrow scope of this folder, retained.
+
+7. **Auto-derive the shortname; drop the prompt.** The plan phase derives `<shortname>` from the epic `# <Title>` (kebab-case, 2-4 keywords, filler stripped, the same reduction `git-create-branch` uses), de-duplicated against `INDEX.md` and existing `.autocode/design/*` folders (suffix `-2`, `-3`). The id, not the shortname, is the durable token. Removes an interactive round-trip, which a background plan phase could not make anyway.
+
+8. **Manual fallback preserved.** The orchestrator is an automation layer over the phase skills, not a replacement. `design-plan`, `design-plan-critique`, `design-plan-iterate`, `design-plan-push`, and `design-fanout` stay individually invocable, and their interactive (non-`--auto`) behavior is unchanged. Mirrors `0002` decision 11. Rationale: in repositories where the user lacks full automation access, hand-driving the documented skills must still work.
+
+9. **Hand off to the impl orchestrator at fanout; do not duplicate it.** `/design` owns the design half and stops once issues exist. The implementation half (parallel per-unit launch, monitor, cascade, archive) is owned by `0002-impl-epic-orchestrator`; `/design` invokes `impl --from-design <id>` (or, when that orchestrator is not present, suggests it and stops). Rationale: the two orchestrators meet at the fanout boundary; merging their concerns would couple the design and impl lifecycles and duplicate `0002`.
+
+10. **Design-PR detection without an issue.** Pre-fanout there is no issue key, so the orchestrator cannot use `0002`'s issue-key `pr-find`. It detects the design PR by the design branch (`docs/design-<short>` for the epic) or, as a fallback, by an open PR whose diff touches only `.autocode/design/**` (the design-PR detection rule in `autocode/design/design-pr-body.md`). No `pr-find`/`pr-list` provider script exists today (a known gap); the orchestrator uses `provider/run.sh git-remote pr-view` from the worktree, or a direct `gh pr list --head <branch>`, and the design notes the missing provider abstraction. Rejected: reusing `0002`'s issue-key `pr-find` (no issue exists at this stage).
 
 ## Runtime flow
 
-1. Steps 1-4 of `design-plan` run unchanged in the session: seed, rough sketch, gap identification with inline research fan-out, plan composition and unit decomposition.
-2. Step 5 (non-temp): auto-derive `<shortname>` from the title; enter the worktree; `git-create-branch`; allocate `<id>` from `INDEX.md`; create `<folder>` and `<folder>/units/`; write `DESIGN.md` in the session; append the `INDEX.md` row.
-3. Resolve workflow args: `homeDir` (`echo "$HOME"`), `workdir` (the worktree root for inspection; the original repo root under `--temp`), `folder` (absolute design folder), `designText` (the `DESIGN.md` just written), `units` (one entry per unit: `slug`, `deliverable`, `dependsOn`, `type`, and the verbatim research findings relevant to it).
-4. Launch the Workflow with `scriptPath = <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/author-units.mjs` and those `args`. The session waits; authoring and retry run in the background.
-5. The workflow authors every unit in parallel; each underspecified unit gets one research-backed retry; it returns `{ authored, underspecified, retried }`.
-6. The session consumes the result. If `underspecified` is empty, it proceeds to the final report (worktree, branch, folder, `<id>`; suggest `/design-plan-critique <id>` or `/design-plan-push <id>`). Otherwise it resolves each surfaced unit (more research or a tighter deliverable) and re-launches the workflow for those slugs or hand-authors them, then reports.
-7. Flat single-unit designs are unchanged: `design-plan` writes `DESIGN.md` itself, no fan-out, no workflow.
+1. Invoke `/design <seed>` (new epic) or `/design <id|shortname>` (resume an in-flight epic). With a seed and no matching folder, the stage is `none`.
+2. Reconstruct the stage:
+   - `none`: no design folder for this seed/id.
+   - `planned`: folder + `DESIGN.md` exist (committed or uncommitted in a worktree); no open design PR.
+   - `pushed`/`in-review`: an open design PR exists for the folder's branch.
+   - `merged`: the design PR merged (folder committed on the default branch) and `issue-epic-list --epic <id>` returns `[]`.
+   - `fanned-out`: `issue-epic-list --epic <id>` returns a non-empty array.
+3. `none` -> launch the plan workflow `design-plan-workflow.mjs` (off-context): it interprets the seed, fans out research, composes `DESIGN.md`, auto-derives the shortname, creates the worktree + branch + `<id>` + `INDEX.md` row, and authors the unit files via the bounded research-backed fan-out, returning `{ folder, id, units[], underspecified[], open_qs }`. Surface any `underspecified`/`open_qs`; otherwise continue.
+4. `planned` -> launch the critique workflow `design-critique-workflow.mjs` (off-context, bounded to 5 iterations): it interrogates and edits the design in place, returning `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`. If `needs_human`, surface the open questions and stop; else continue to push.
+5. `planned` (critique clean) -> run push (`design-plan-push`; light, may stay in-session): commit the folder, compose the design-PR body, open the lightweight PR, returning `{ pr_url, branch }`. Stage becomes `in-review`.
+6. `in-review` -> if the PR has review comments, run iterate (`design-plan-iterate --auto`): triage and apply, returning `{ applied, replied, needs_human }`. Then present the PR for the user to review and merge. This is the hard gate: the orchestrator waits for the user to merge on the host; it never merges the design PR itself.
+7. `merged` -> run fanout (`design-fanout --auto`): create the epic issue + per-unit sub-issues (idempotent), returning `{ epic_key, sub_issues[] }`.
+8. `fanned-out` -> hand off: invoke `impl --from-design <id>` (the impl orchestrator) when present, else report the epic + sub-issues and suggest it. `/design`'s responsibility ends here.
+9. Report the stage reached, the typed result of the phase run, and the next step.
 
-## Implementation
-
-Deliverable: `design-plan`'s unit-author fan-out runs as a background Workflow, `design-unit-author` returns a structured contract, and the shortname is auto-derived. One PR.
-
-Files:
-
-- `autocode/design/skills/design-plan/scripts/author-units.mjs` (new). The Workflow script. Mirrors `impl-workflow.mjs` structure:
-  - `export const meta` with `name: 'author-units'`, a description, and `phases: [{ title: 'Author', model: 'opus' }, { title: 'Resolve' }]`.
-  - Reads `args`: `homeDir`, `workdir`, `folder`, `designText`, `units` (array of `{ slug, deliverable, dependsOn, type, research }`). No interactive input; all args resolved by the launcher.
-  - Helpers mirroring impl: `agentBody(name) => ${HOME}/.autocode/autocode/design/agents/${name}.md`, `follow(path, extra)`, `inDir = "Work in ${workdir}: cd into it before inspecting the codebase. "`.
-  - `AUTHOR_SCHEMA = { type:'object', additionalProperties:false, properties:{ underspecified:{type:'boolean'}, file:{type:'string'}, summary:{type:'string'} }, required:['underspecified','file','summary'] }`.
-  - `MAX_RETRY = 1`.
-  - `authorOne(u)`: dispatch `design-unit-author` (read its body, `phase:'Author'`, `model:'opus'`, `schema: AUTHOR_SCHEMA`) with a prompt carrying `folder`, `workdir`, `designText` verbatim, `u`'s assignment, and `u.research` verbatim. If `!underspecified`, return `{ slug, ...result, retried:false }`. Else the bounded retry, both calls tagged with the `{ phase: 'Resolve' }` agent option (never a bare `phase('Resolve')` call): `authorOne` runs inside `parallel`, and `phase()` mutates global state shared across all concurrent units, so a bare call races other units' phase grouping. Dispatch `codebase-researcher` (`{ phase: 'Resolve' }`, its own default model; read-only by contract) scoped to `u.deliverable` plus the author's `summary` (the missing-files question), then re-dispatch the author (`{ phase: 'Resolve', model: 'opus', schema: AUTHOR_SCHEMA }`) with the extra findings appended; return the second result with `retried:true`. Mirrors `impl-workflow.mjs`, where the in-`parallel` review agents pass `{ phase: 'Review' }` as an option and no `phase()` call appears inside a `parallel` map.
-  - Top level: `phase('Author')`; `const authored = (await parallel(units.map(u => () => authorOne(u)))).filter(Boolean)`; `return { authored, underspecified: authored.filter(a => a.underspecified).map(a => a.slug), retried: authored.filter(a => a.retried).map(a => a.slug) }`.
-  - Plain JS only; no `Date.now()`/`Math.random()`/argless `new Date()`.
-- `autocode/design/agents/design-unit-author.md` (edit). Replace the in-band underspecified note (line 29) and the Output section (lines 39-41) with the structured contract: report `underspecified` (boolean), `file` (the `units/<slug>.md` path written, or the intended path when underspecified), and `summary` (the one-line deliverable summary, or the reason it is underspecified and what is missing). Keep "the file is the deliverable, not the message." No frontmatter (body-only real file).
-- `autocode/design/skills/design-plan/SKILL.md` (edit). Step 5:
-  - Drop the `AskUserQuestion` for `<shortname>`; auto-derive it (decision 6) and state the derivation and collision rule inline.
-  - Replace the inline multi-unit fan-out paragraph (line 43) with: write `DESIGN.md`, resolve the workflow args (decision 5, runtime step 3), launch the Workflow (`scriptPath` + `args`), consume `{ authored, underspecified, retried }`, and resolve any surfaced underspecified unit in-session then re-launch or hand-author.
-  - Leave the `--temp` and flat branches behaving as before (flat writes `DESIGN.md` inline, no workflow; `--temp` passes `workdir` = original repo root and a `folder` outside any worktree).
-- `autocode/design/CLAUDE.md` (edit). One line noting `design-plan` launches `author-units.mjs` (a background Workflow) for unit-author fan-out, mirroring impl, with the script living next to the skill under `scripts/`.
-
-No shim changes: no new skill or agent names; the `.mjs` script is not shimmed (shape check ignores it). No CI change.
-
-Public interface (workflow args contract):
-
-```
-args = {
-  homeDir:   string,   // echo "$HOME"
-  workdir:   string,   // worktree root (non-temp) | original repo root (--temp)
-  folder:    string,   // absolute design folder; units written to <folder>/units/<slug>.md
-  designText: string,  // full DESIGN.md text, verbatim, passed to every author
-  units: [ { slug, deliverable, dependsOn: [slug...], type, research } ]
-}
-return = { authored: [ { slug, file, summary, underspecified, retried } ],
-           underspecified: [slug...], retried: [slug...] }
-```
+Flat single-unit designs collapse the plan phase to a `DESIGN.md`-only write with no unit fan-out; critique, push, and fanout still run (fanout creates one issue). `--temp` plans are a single throwaway plan with no worktree, id, PR, or fanout: the orchestrator refuses to advance a `--temp` folder past plan and points the user at `/design-plan-critique <dir>`.
 
 ## Edge cases and error handling
 
-- All units well-specified: `underspecified` is empty; the session reports directly. The common path.
-- A unit still underspecified after the one retry: surfaced in `underspecified`; the session resolves and re-launches for those slugs or hand-authors. Not an error.
-- An author agent dies on a terminal error: `parallel` yields `null` for it; `.filter(Boolean)` drops it, and its slug is absent from `authored`. The session detects the missing slug (compare against the units it sent) and re-launches or hand-authors that one.
-- The whole workflow fails (the Workflow tool errors out, not a single agent dying): the session gets no structured result, but `DESIGN.md`, the `INDEX.md` row, and the `<id>` are already written and durable in the worktree. `units/` is empty or partial. The session treats every sent slug as missing and re-launches the workflow, or hand-authors the units; no rollback of the id or the folder. The id, not the run, is the durable token.
-- `--temp`: no worktree, no id, no `INDEX.md`; `workdir` = the original repo root for codebase inspection, `folder` = the temp dir. Authors still inspect the real repo for file shapes.
-- Single-unit (flat) design: no workflow launched; `design-plan` writes `DESIGN.md` itself.
-- Shortname collision with an `INDEX.md` row or an existing `.autocode/design/*` folder: append `-2`, `-3`. The id (not the shortname) is the durable token, so a suffixed shortname is harmless.
+- `none` with an ambiguous id/shortname match: the orchestrator (main session) may `AskUserQuestion` to disambiguate before dispatching; the dispatched phases never do.
+- Plan returns `underspecified` units or `open_qs`: surface them; the user resolves (more research or a tighter deliverable) and re-invokes `/design <id>`, which re-enters at the `planned` stage.
+- Critique returns `needs_human`: surface the unresolved questions; stop. Re-invoking `/design <id>` re-runs critique (idempotent: it appends to the Critique log) or proceeds to push once the user clears the questions.
+- Design PR has unresolved or contested review comments: iterate applies the high-confidence ones and surfaces the rest; the merge gate stays the user's.
+- Merge gate: the orchestrator never merges the design PR. It waits; on re-invocation after the user merges, it detects `merged` and runs fanout.
+- Fanout is partially complete (some issues exist): `design-fanout` is idempotent by body marker (`design-fanout/SKILL.md:20-21`); re-running creates only the missing issues. The GH Action (`autocreate-design-doc-issue.yml`) may have already fanned out on merge; the orchestrator detects `fanned-out` via `issue-epic-list` and skips straight to hand-off.
+- The impl orchestrator (`0002`) is not merged/available: hand-off degrades to reporting the epic + sub-issues and suggesting `impl --from-design <id>`; no failure.
+- `--temp`: no worktree, id, PR, or fanout; the orchestrator runs only the plan phase and stops.
+- Flat single-unit design: no unit fan-out in plan; fanout creates a single issue with no sub-issues; no impl-orchestrator cascade (one unit).
 
 ## Testing strategy
 
 Markdown-and-script change, no app build. Verification:
 
-- `scripts/check-plugin-shape.sh` passes (no new shims; real files carry no frontmatter; every feature-set has `CLAUDE.md`). This is the CI gate.
-- Static read of `author-units.mjs` against `impl-workflow.mjs`: same helper shape, `args.homeDir` path resolution, `parallel` fan-out, `schema`-typed returns, no forbidden globals.
-- Dry exercise: run `/design-plan` on a small multi-unit seed in a scratch repo; confirm no shortname prompt, the workflow launches after `DESIGN.md`, unit files land under `units/`, and the final report carries the structured tally. Confirm an intentionally vague unit surfaces in `underspecified` after one retry.
-- Confirm `design-unit-author` still works inline (invoke it directly) and reports the three contract fields in prose.
+- `scripts/check-plugin-shape.sh` passes (no new shims that restate definitions; real files carry no frontmatter; every feature-set has `CLAUDE.md`; `*.sh` shellcheck clean). This is the CI gate.
+- `--auto` skill modes: dry-run each of `design-plan`, `design-plan-critique`, `design-plan-iterate`, `design-fanout` with `--auto` on a scratch design and assert the structured result block, including `needs_human` on a forced ambiguous arg and (critique) an intentionally vague unit that survives the cap.
+- Static read of any new workflow script against `impl-workflow.mjs`: same helper shape, `args.homeDir` path resolution, `parallel` fan-out, `schema`-typed returns, `{ phase }` option inside `parallel` (never a bare `phase()`), no forbidden globals.
+- Orchestrator skill: validated by `scripts/check-plugin-shape.sh` plus a manual end-to-end dry run on a small two-unit seed, exercising stage reconstruction at each point (`none` -> `planned` -> `in-review` -> `merged` -> `fanned-out`), the merge gate (the orchestrator stops and does not merge), and the hand-off call. No automated harness exists for full skill runs; the dry run is the acceptance gate.
+- Confirm `design-unit-author` still works inline (invoke it directly) and reports the three contract fields in prose; confirm every phase skill's non-`--auto` interactive path is unchanged (manual fallback).
 
 ## Alternatives considered
 
-- **Multi-unit decomposition of this epic** (split into agent-contract, workflow-script, launcher units). Rejected: the script, the contract it consumes, and the launcher that feeds it are tightly coupled and only coherent reviewed together (does the launcher pass what the script expects? does the schema match the author's contract?). Splitting would merge dead code (a workflow nothing invokes) ahead of its wiring and make review harder. Flat single-unit fits the modest, cohesive scope.
-- **Move research fan-out too** (one or two extra workflows). Rejected: see decision 1.
-- **Move `design-plan-critique` and `design-plan-iterate` into workflows.** Deferred, out of scope. `critique`'s loop interleaves `AskUserQuestion` user-asks with research dispatch every iteration (`design-plan-critique/SKILL.md:20-26`); not a clean fan-out without restructuring to pre-collect questions. `iterate`'s only fan-out is the apply step (one subagent per affected unit, often one), with triage staying in-session; a workflow there is low payoff for a second script and schema. Both stay in-skill and individually user-invocable. Revisit if either grows a real multi-round fan-out.
+- **Pure-workflow orchestrator** (no main-session loop): rejected; a workflow cannot gate the user merge, cannot nest the plan fan-out, and cannot `AskUserQuestion` to disambiguate (decision 1).
+- **One mega-skill that runs every phase inline in the launching session**: rejected; it fills the main context with exactly the research/prose/triage noise this epic exists to remove (decision 2).
+- **A non-re-entrant `/design-all` that chains the phases once, top to bottom**: rejected; it cannot resume a half-finished epic (e.g. after the user merges out of band, or after a `needs_human` stop), and the merge gate forces a resume boundary regardless (decision 3).
+- **Keep the narrow original scope** (only move the unit-author fan-out to a background workflow): superseded; the user asked for the full orchestrator, and the fan-out is one phase of it. The original work is retained as decision 6 and folded into the plan unit.
+- **Move `design-fanout` entirely into the orchestrator**: rejected; the GH Action and the standalone skill must keep producing the identical issue shape for the manual path, so fanout stays a skill the orchestrator invokes (decisions 8, 9).
 
 ## Sources
 
-- `autocode/design/skills/design-plan/SKILL.md:14-49` — current workflow; step 5 inline fan-out (`:43`) and shortname prompt (`:38`).
-- `autocode/design/agents/design-unit-author.md:29,39-41` — current in-band underspecified signal and unstructured output.
-- `autocode/design/agents/codebase-researcher.md` — researcher contract used in the retry.
-- `autocode/impl/skills/impl/scripts/impl-workflow.mjs` — workflow-script template: `meta`, `args.homeDir`, `follow`, `parallel`, schema-typed `agent` returns, plain-JS constraints.
-- `autocode/impl/skills/impl/SKILL.md:21-26` — how a thin launcher resolves args and calls the Workflow tool (`scriptPath` + `args`).
-- `autocode/impl/CLAUDE.md` — "the workflow does the fan-out the per-phase skills cannot (subagents cannot spawn subagents); heavy work stays out of the launching session."
-- `autocode/design/design-folder.md:47-51,70-88` — flat-vs-multi rule; unit-file shape.
-- `scripts/check-plugin-shape.sh:31-124` — shape check covers shims, feature-set `CLAUDE.md`, and `*.sh`; not `*.mjs`. `plugins/autocode/skills/impl/` (only `SKILL.md`) confirms workflow scripts are not shimmed.
-- `autocode/_config/guides/worktree.md` — `EnterWorktree` then `git-create-branch`; the fan-out writes into the same worktree.
-- `autocode/_config/conventions/issue-types.md` — `story` = single-PR user-visible deliverable (the `/design-plan` behavior change).
-- `git-create-branch/SKILL.md:39` — kebab short-name reduction reused for shortname derivation.
-- User decision (this session): also drop the interactive shortname prompt; auto-pick a reasonable one.
+- `autocode/design/skills/design-plan/SKILL.md:14-49` — current plan workflow; inline unit fan-out (`:43`), interactive shortname (`:38`), `INDEX.md` `active` row (`:41`). Read this session.
+- `autocode/design/skills/design-plan-critique/SKILL.md:11-12,21-26,37` — critique loop, the two `AskUserQuestion` gates (arg ambiguity, cap), the 5-iteration cap, the 2-3 line prose return. Research this session.
+- `autocode/design/skills/design-plan-iterate/SKILL.md:1-2,6,19-46` — design-PR comment triage between push and merge; no `AskUserQuestion` gates; outputs a triage table (not machine-readable). Research this session.
+- `autocode/design/skills/design-plan-push/SKILL.md` — lightweight design-PR open; composes the body from `design-pr-body.md`; the design folder is uncommitted in the worktree until this runs. Read prior turns.
+- `autocode/design/skills/design-fanout/SKILL.md:9,13-31,39` — post-merge epic + sub-issue creation, idempotent by body marker, `AskUserQuestion` on arg ambiguity, prose table return, "run only after the design PR merged". Research this session.
+- `.github/workflows/autocreate-design-doc-issue.yml:24-107` and `.github/actions/design-fanout/action.yml:61-81` — the pure-shell GH Action that fans out on a merged PR adding a new `DESIGN.md`; same issue shape as the skill. Research this session.
+- `autocode/design/agents/design-unit-author.md:29,39-41` — current in-band underspecified signal and unstructured output, replaced by the structured contract. Read this session.
+- `autocode/design/agents/codebase-researcher.md:71` — read-only researcher used in the plan-phase retry. Read this session.
+- `autocode/design/design-folder.md:7-9,18-31,73-78,111-119,152-179` — folder layout, `INDEX.md` schema and the `active`/`archived` two-state status, unit frontmatter and DAG, `issue-epic-list` discovery, four-state lifecycle, epic-done = folder moved. Research this session.
+- `provider/issue-tracker/github/issue-epic-list.sh:13-15,53-84,88-110` — `[]` means not yet fanned out; non-empty means fanned out; per-unit `{key,summary,type,status,parent}` with status mapping. Research this session.
+- `provider/git-remote/github/pr-view.sh:8` — raw `gh pr view` passthrough; no `pr-find`/`pr-list` provider script exists (design-PR detection gap). Research this session.
+- `autocode/design/design-pr-body.md` — design-PR detection rule (diff touches only `.autocode/design/**`); used for branchless PR detection. Read prior turns.
+- `autocode/impl/skills/impl/SKILL.md:21-26`, `autocode/impl/skills/impl/scripts/impl-workflow.mjs`, `autocode/impl/CLAUDE.md` — thin-launcher pattern, the Workflow call contract, `args.homeDir` path resolution, `parallel` fan-out, `{ phase }` option inside `parallel`, schema-typed returns, plain-JS constraints. Read this session.
+- `.autocode/design/0002-impl-epic-orchestrator/DESIGN.md` — the impl-half orchestrator this epic mirrors: stateless re-entrancy (decision 1), `--auto`+`needs_human` modes (decision 6), manual fallback (decision 11), user-gated merge, hand-off boundary. Read this session.
+- `autocode/impl/skills/impl-archive/SKILL.md:22` — `impl-archive` flips `INDEX.md` to `archived` and may self-merge its own PR with `--admin` (contrast: `/design` never self-merges the design PR). Research this session.
+- `git-create-branch/SKILL.md:34,39` — the kebab short-name reduction reused for shortname derivation; branch shortname is a non-reproducible slug. Read this session.
+- Claude Code `Workflow` tool contract (this session's tool definition) — the outer orchestrator cannot be a workflow (no `AskUserQuestion`, one-level nesting); the `{ phase }` option avoids the global `phase()` race inside `parallel`.
+- User decisions (this session): rescope this folder into the design orchestrator mirroring `0002`; outer layer need not be a workflow; phases run off the main context; hybrid autonomy (auto pre-merge, user-gated merge, auto fanout); also drop the interactive shortname prompt.
+- `impl-orchestrator-core.md:49`, `impl-workflow.mjs:26-30,30,139-146` — the `0002` orchestrator launches `impl-workflow.mjs` directly (bypassing the `impl` skill), all fan-out lives in the workflow ("Subagents cannot spawn subagents"), the `inWt` helper, and `{ phase }` passed as an option inside `parallel`. Researched this critique session; grounds decision 2's workflow-centric dispatch.
+- `design-plan/SKILL.md:38,41,43`, `design-plan-push/SKILL.md:22` — worktree + branch + `<id>` + `INDEX.md` creation is a plan-phase responsibility today (`design-plan` delegates `git-create-branch` inside the worktree); `design-plan-push` only re-creates them as a fresh-session fallback. Researched this critique session.
+- `impl` SKILL.md:9, `0002` DESIGN.md:84 — the hand-off entry interface `impl --from-design <id|shortname>` is the real `0002` epic-mode entry point. Researched this critique session; confirms decision 9 / runtime-flow step 8.
+- User decision (this critique session): workflow-centric off-context dispatch (each heavy phase is a background Workflow the orchestrator launches directly; the `--auto` phase skills are thin launchers over the same workflow; non-`--auto` interactive paths unchanged).
 
 ## Critique log
 
-Iteration 1:
-- Q: Does `phase('Resolve')` called inside the `parallel(units.map(...))` map (Implementation `authorOne`) race other concurrent units? A: Yes. The Workflow contract states `phase()` mutates global state and warns to use the `{ phase }` agent option inside `parallel`/`pipeline`; `impl-workflow.mjs` confirms the pattern (in-`parallel` review agents pass `{ phase: 'Review' }`, no bare `phase()` inside a map). Rewrote `authorOne` to tag both Resolve calls with the `{ phase: 'Resolve' }` option. Source: Workflow tool contract; `impl-workflow.mjs:139-146`.
-- Q: Is the stated problem (unit prose fills context) accurate? A: No. `design-unit-author.md:41` returns only path + one-line summary, so prose never enters context today. The real cost is N inline Task prompts each embedding full `DESIGN.md` plus the in-session retry research. Reframed the Summary. Source: `design-unit-author.md:41`; `design-plan/SKILL.md:43`.
-- Q: What model and read-only posture for the Resolve-phase agents? A: Re-dispatched author pinned `model: 'opus'` + `schema: AUTHOR_SCHEMA` (matches the Author phase); `codebase-researcher` runs at its own default and is read-only by its own contract (`codebase-researcher.md:71`). Folded into the `authorOne` spec. Source: `codebase-researcher.md:71`.
-- Q: Is whole-workflow failure (Workflow tool error, distinct from a single agent dying) handled? A: It was not. Added an edge case: `DESIGN.md`/`INDEX.md` row/`<id>` are already durable; the session re-launches or hand-authors, no id rollback. Source: existing edge-case list; the id-as-durable-token rule (decision 6, edge cases).
-</content>
-</invoke>
+Iteration 1 (this session):
+
+- Q: How does the orchestrator run plan and critique "off-context" when a skill invoked via the Skill tool runs *in* the main session, and a subagent cannot nest the fan-outs these phases need? -> Researched `0002`'s dispatch (`impl-orchestrator-core.md:49`, `impl-workflow.mjs:26-30`): the main-session orchestrator launches `impl-workflow.mjs` directly. User chose workflow-centric: each heavy phase is a background Workflow (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`) the orchestrator launches directly; the `--auto` skills become thin launchers; non-`--auto` interactive paths unchanged. Applied to decision 2, the architecture prose, the unit table, runtime steps 3-4, and both phase units.
+- Q: Does `design-critique-auto` deliver an off-context mechanism? -> No; it added only an `--auto` flag to an in-session loop. Resolved: added `design-critique-workflow.mjs` owning the loop + apply fan-out; its agents read the `design-plan-critique` body so heuristics stay single-source.
+- Q: Is "create worktree + branch" a plan-phase or push-phase responsibility (units disagreed)? -> Plan-phase (`design-plan/SKILL.md:41`; push is a fallback, `design-plan-push/SKILL.md:22`). Fixed the misleading "branch `design-plan-push` creates" parenthetical in `design-orchestrator-core` and moved worktree/branch/id/`INDEX.md` creation into the plan workflow's `Synthesize` phase.
+- Q: Is the hand-off `impl --from-design <id>` a real `0002` interface? -> Yes (`impl` SKILL.md:9, `0002` DESIGN.md:84; also accepts `<shortname>`). No change; noted in Sources.
+- Q: Does `codebase-researcher` exist at the cited path? -> Yes (`autocode/design/agents/codebase-researcher.md`). No change.
+
+Iteration 2 (consistency pass over the revised design):
+
+- Q: Does the revised plan unit keep the interactive shortname prompt in non-`--auto` mode, contradicting decision 7 (drop the prompt in *both* modes)? -> Yes, a self-introduced contradiction. Fixed: non-`--auto` auto-derives the shortname too; the seed prompt is the only `AskUserQuestion` the non-`--auto` path keeps.
+- Q: The plan workflow has no `args.worktree` (unlike `impl-workflow.mjs`), since `Synthesize` creates the worktree mid-run; how does `inWt` get the path? -> Clarified in the plan unit: `inWt` is built from the worktree path `Synthesize` returns and is available only to the `Author`/`Resolve` phases after it.
+- No new design-level questions; the revised design is internally consistent. Loop converged.
+
+## Units
+
+| Unit | Deliverable | depends-on |
+|---|---|---|
+| [design-plan-orchestrator-ready](units/design-plan-orchestrator-ready.md) | `design-plan-workflow.mjs`: the whole plan phase off-context (research, `DESIGN.md` synthesis, worktree/branch/id/`INDEX.md`, unit-author fan-out with the structured `design-unit-author` contract + bounded research-backed retry); `design-plan --auto` becomes a thin launcher over it with a structured return + auto-derived shortname | none |
+| [design-critique-auto](units/design-critique-auto.md) | `design-critique-workflow.mjs`: the critique loop off-context (question generation, researcher fan-out, apply fan-out, cap 5); `design-plan-critique --auto` becomes a thin launcher over it with a structured return + `needs_human` signal; non-`--auto` keeps its in-session interactive loop | none |
+| [design-iterate-auto](units/design-iterate-auto.md) | `design-plan-iterate --auto` with a structured machine-readable return | none |
+| [design-fanout-auto](units/design-fanout-auto.md) | `design-fanout --auto` with a structured return (epic key + sub-issue keys), suppressing the ambiguity gate | none |
+| [design-orchestrator-core](units/design-orchestrator-core.md) | The `/design` orchestrator skill: re-entrant stage reconstruction, off-context phase dispatch, hybrid gates with the user-gated merge, hand-off to the impl orchestrator, manual fallback | design-plan-orchestrator-ready, design-critique-auto, design-iterate-auto, design-fanout-auto |

--- a/.autocode/design/0003-design-unit-workflow/units/design-critique-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/units/design-critique-auto.md
@@ -1,0 +1,77 @@
+---
+depends-on: []
+type: task
+---
+
+# Add an --auto mode to design-plan-critique
+
+## Summary
+
+`design-plan-critique` is an interactive in-session loop: it calls `AskUserQuestion` on argument ambiguity during discovery and again when the 5-iteration cap is reached, and it returns a 2-3 line prose summary. A background phase cannot answer an `AskUserQuestion` prompt, and a skill invoked inline runs in the main session, so neither the gates nor the loop's question/research/apply churn can move off-context by an inline invocation alone (DESIGN.md decision 2). Move the critique loop off the main context into a background Workflow script (`autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs`) whose agents read the existing `design-plan-critique` body for the critique heuristics (single-source), and add an `--auto` flag that makes `design-plan-critique` a thin launcher over that workflow, ending with a structured result block carrying a `needs_human` signal. Under `--auto` an ambiguous argument is a fail-fast error instead of a prompt; every per-iteration question resolves via a researcher only (the loop never asks the user mid-pass); hitting the cap stops and returns `needs_human: true` rather than prompting; and any question research cannot resolve becomes a `needs_human` entry. The in-place edits to `DESIGN.md`, `units/*.md`, and the `## Critique log` are unchanged. The default (non-`--auto`) interactive in-session loop is untouched, preserving the manual fallback (DESIGN.md decision 8).
+
+## Implementation
+
+Deliverable: one new workflow script plus an `--auto` thin-launcher path on `design-plan-critique`, mirroring `0002` decision 6 (the `--auto` + `needs_human` pattern) and the workflow-centric dispatch the plan phase uses (`design-plan-workflow.mjs`).
+
+Files to create:
+
+- `autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs`: the background critique loop, sibling to `impl-workflow.mjs` and `design-plan-workflow.mjs`. Plain JS, no shim, not shape-checked.
+
+Files to modify:
+
+- `autocode/design/skills/design-plan-critique/SKILL.md` (body-only real skill; no frontmatter per the layout rule): add `--auto` as a thin launcher over the workflow; keep the non-`--auto` interactive loop verbatim. No shim change unless the shim's `description` needs the `--auto` mention; the shim at `plugins/autocode/skills/design-plan-critique/SKILL.md` carries frontmatter only and forwards `$ARGUMENTS`, so confirm whether its `description` should note `--auto`.
+
+### The workflow script
+
+Model on `impl-workflow.mjs` / `design-plan-workflow.mjs`. The workflow owns only the deterministic loop + fan-out scaffolding; its agents read the `design-plan-critique` body for the actual question-generation, resolution, and apply heuristics, so the critique logic stays single-source (the workflow does not restate it).
+
+- `export const meta` with `name`, `description`, and a `phases` array (`Question`, `Resolve`, `Apply`), one group per loop concern.
+- Path resolution via `args.homeDir`; args from the launcher: `{ homeDir, repoRoot, folder }` (the resolved design folder; the workflow reads `DESIGN.md` + `units/*.md` from it).
+- The loop, bounded to 5 iterations (`SKILL.md:26,37`), each iteration:
+  1. `Question`: one `agent` reads the design + the `design-plan-critique` body and emits this pass's follow-up questions via `schema` (`SKILL.md:22`).
+  2. `Resolve`: one `agent` per question inside `parallel`, each dispatching a `codebase-researcher` (researcher-only; never asks the user mid-loop). A question the researcher cannot resolve is returned with an `unresolved` flag and collected into `needs_human_reasons`; it does not abort the loop. Pass `{ phase: 'Resolve' }` as the agent option, never a bare `phase()` inside the map.
+  3. `Apply`: one `agent` per affected unit inside `parallel` writes the resolutions into `units/<slug>.md` (the existing apply fan-out, `SKILL.md:25`); the `DESIGN.md` edits and the `## Critique log` append are done by a single serial `agent` (shared file, `SKILL.md:24`). Pass `{ phase: 'Apply' }` as the option.
+  4. Stop when a pass produces no new questions (converged) or at 5 iterations (cap).
+
+The apply-phase fan-out moving into the workflow is what makes critique off-context: a subagent cannot spawn the per-unit apply subagents, but a Workflow's `parallel` can, exactly as `design-plan-workflow.mjs` runs its author fan-out.
+
+### `design-plan-critique` skill edits (thin launcher under `--auto`)
+
+- Under `--auto`: resolve `homeDir` (`echo "$HOME"`), `repoRoot` (`git rev-parse --show-toplevel`), and the design `folder` (the existing discovery glob, `SKILL.md:13-17`). An ambiguous or unresolvable arg is a fail-fast error (no `AskUserQuestion`), because there is no design to critique yet. Launch the Workflow with `args: { homeDir, repoRoot, folder }`, wait, and emit the structured result block below in place of the prose summary (`SKILL.md:30`). The `/design` orchestrator launches the same workflow directly and does not route through this skill.
+- Without `--auto`: the existing interactive in-session loop is unchanged, including both `AskUserQuestion` gates (arg ambiguity `SKILL.md:11,17`; cap `SKILL.md:26`) and the 2-3 line prose summary (`SKILL.md:30`). This is the only place those gates survive (the manual fallback, DESIGN.md decision 8).
+
+### Structured return
+
+The `--auto` launcher emits the workflow's return verbatim. Scalar and list fields only, in a single fenced block, no surrounding prose, matching the `impl-start --auto` block convention (`autocode/impl/skills/impl-start/SKILL.md:16,30`):
+
+```
+status: done | cap_reached | error
+iterations_run: <int>
+questions_resolved: <int>
+needs_human: <bool>
+needs_human_reasons: [{ question, why }, ...]
+files_modified: [<path>, ...]
+critique_log_path: <path to DESIGN.md holding the ## Critique log>
+```
+
+Field semantics:
+
+- `status: done` -> the loop converged (a pass produced no new questions) before the cap.
+- `status: cap_reached` -> stopped at 5 iterations (`SKILL.md:26,37`); implies `needs_human: true` when open questions remain.
+- `status: error` -> fail-fast on an ambiguous/unresolvable arg during discovery (the launcher never reaches the workflow); other result fields omitted or zeroed.
+- `needs_human: true` when any unresolved-by-research question exists or the cap was reached with open questions. `needs_human_reasons` pairs each surfaced question with why research could not close it.
+- `files_modified` lists the `DESIGN.md` and `units/*.md` paths the workflow edited this run (`SKILL.md:24-25`).
+- `critique_log_path` points at the `DESIGN.md` that holds the appended `## Critique log` (`SKILL.md:24`).
+
+Unchanged behavior to preserve in both modes: the loop structure (generate questions -> resolve -> apply in place + append `## Critique log` -> repeat, cap 5; `SKILL.md:21-26`), the in-place edit and source-citation rules (`SKILL.md:34-36`), and the cap value of 5 (`SKILL.md:26,37`).
+
+### Tests that prove it
+
+Markdown-and-script change; verification per the epic testing strategy (`DESIGN.md` testing strategy):
+
+- `scripts/check-plugin-shape.sh` passes (real skill body-only, no frontmatter; `design-critique-workflow.mjs` carries no frontmatter and is not a skill/agent file; shim unchanged or description-only).
+- Static read of `design-critique-workflow.mjs` against `impl-workflow.mjs`: same helper shape, `args.homeDir` path resolution, `parallel` fan-out, `schema`-typed returns, `{ phase: '...' }` passed as options inside `parallel` (never a bare `phase()` in a map), no forbidden globals; the loop is bounded to 5 iterations.
+- Dry-run `design-plan-critique --auto` on a scratch design: assert it launches the workflow (no in-session question/research/apply churn in the launching session) and the structured block parses with all listed fields and no surrounding prose.
+- Force an ambiguous arg under `--auto`: assert `status: error` and a descriptive error message, no `AskUserQuestion`, no workflow launched.
+- Seed an intentionally vague unit that research cannot resolve and that survives 5 iterations: assert `status: cap_reached`, `needs_human: true`, and a matching `needs_human_reasons` entry.
+- Run the non-`--auto` path unchanged: assert it still runs the in-session loop, prompts on ambiguity/cap, and returns the 2-3 line prose summary (manual fallback intact, DESIGN.md decision 8).

--- a/.autocode/design/0003-design-unit-workflow/units/design-fanout-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/units/design-fanout-auto.md
@@ -1,0 +1,75 @@
+---
+depends-on: []
+type: task
+---
+
+# design-fanout --auto with a structured epic + sub-issue return
+
+## Summary
+
+`design-fanout` gains an `--auto` flag that suppresses its one `AskUserQuestion` gate (the ambiguous id/shortname match) in favor of a structured result block carrying the epic key, every sub-issue's key and created-or-existing status, and a `needs_human` signal, so the `/design` orchestrator can fan a merged design folder out unattended and branch only when the arg is genuinely ambiguous. Under `--auto` the id is required and a multi-folder match returns `needs_human: true` instead of prompting; the structured block replaces the prose role/number/created-or-existing table. The idempotent body-marker creation, the GitHub-permalink bodies, the epic + per-unit sub-issue shape, and the `provider/run.sh issue-tracker` write path are unchanged, so the issues this skill emits stay byte-identical to both its own interactive mode and the pure-shell GitHub Action. All interactive behavior is preserved when `--auto` is absent.
+
+## Implementation
+
+Deliverable: edit one source file, the canonical body-only skill. The shim and the provider scripts need no change.
+
+Files to modify:
+
+- `autocode/design/skills/design-fanout/SKILL.md` (the real, body-only skill; args at `:9`, idempotency at `:20`, creation at `:25-30`, report at `:31`, preconditions at `:39`): add the `--auto` arg, the suppressed ambiguity gate, and the structured return.
+
+Files NOT modified (note for the implementer):
+
+- `plugins/autocode/skills/design-fanout/SKILL.md` already forwards `$ARGUMENTS` (verified: shim body is `Read through @~/.autocode/...design-fanout/SKILL.md ... $ARGUMENTS is forwarded.`), so `--auto` flows through with no edit. Its `description` carries no mode list and stays accurate; leave it.
+- `provider/issue-tracker/github/issue-epic-list.sh`: the idempotency call (`issue-epic-list --epic <id>`, `design-fanout/SKILL.md:20`) and its `Issue[]` contract (`key`, `summary`, `description`, `type`, `status`, `parent`; `issue-epic-list.sh:53-84`) already return everything `--auto` needs. The structured result reads `key` and matches `description` markers; no provider change.
+
+### `--auto` mode
+
+Add `--auto` to the `## Args` section (currently `<id | shortname>` defaulting to the most recent folder, with `AskUserQuestion` on ambiguity; `design-fanout/SKILL.md:9`). Default (flag absent) keeps the `AskUserQuestion` disambiguation and the prose report verbatim (DESIGN.md decision 8, manual fallback preserved; the GH Action and the interactive skill must keep producing the identical issue shape, DESIGN.md decision 5 alternatives).
+
+When `--auto` is set:
+
+| Current behavior (`SKILL.md` line) | Default | `--auto` |
+|---|---|---|
+| Arg defaults to most recent folder (`:9`) | implicit most-recent | id required; absent or unresolvable arg returns `needs_human: true`, `reason` naming the missing/unknown id (no implicit most-recent under automation, per DESIGN.md decision 5: an ambiguous arg is the canonical `needs_human` case) |
+| Ambiguous id/shortname match (`:9`) | `AskUserQuestion` to disambiguate | no prompt; return `needs_human: true`, `reason` naming the candidate folders |
+| Final report (`:31`) | prose table role/number/created-or-existing | the structured result block below, in place of the table |
+
+The idempotency check (`:20`), the permalink base (`:19`), the body-file construction (`:21`), and every `provider/run.sh issue-tracker issue-create` call (`:26-30`) are unchanged in both modes. `--auto` changes only how the arg ambiguity is handled and how the result is reported; it never alters the issues created.
+
+Structured result (the contract `design-orchestrator-core` consumes, per DESIGN.md decision 5 and runtime-flow step 7):
+
+```
+{ epic_key: string,
+  epic_status: "created" | "existing",
+  sub_issues: [ { slug: string, key: string, status: "created" | "existing" } ],
+  needs_human: bool,
+  reason: string }
+```
+
+- `epic_key`: the epic (or flat) issue number, as a string, matching the `key` field of `issue-epic-list` (`issue-epic-list.sh:56`).
+- `epic_status` / per-unit `status`: `"existing"` when the body marker was already present and creation was skipped (`design-fanout/SKILL.md:20`), `"created"` otherwise.
+- `sub_issues`: one entry per `units/<slug>.md`, in folder order; `[]` for a flat design (the single issue is reported only as `epic_key`, since the flat issue is both epic and unit, `design-folder.md:49`).
+- On a clean fan-out: `needs_human: false`, `reason: ""`.
+- On an ambiguous or unresolvable arg: `needs_human: true`, `epic_key: ""`, `sub_issues: []`, `reason` naming the problem; no issues are created (the skill stops before the idempotency call).
+
+The skill emits this block as its final output in `--auto` mode in place of the step-4 prose table. The "run only after the design PR merged" precondition (`:39`) is unchanged: under `--auto` the orchestrator only reaches fanout at the `merged` stage (DESIGN.md runtime-flow step 7).
+
+### Idempotency under partial fan-out
+
+No new logic; the structured return surfaces the existing idempotency (`design-fanout/SKILL.md:20-21`, DESIGN.md edge case). When the GH Action already fanned out on merge, every marker is present, so `issue-epic-list` returns the full set: `epic_status` and every `sub_issues[].status` come back `"existing"` and nothing is created. A partial fan-out (some markers present, some absent) reports the pre-existing ones as `"existing"` and the freshly created ones as `"created"` in the same block.
+
+### Rules section
+
+Extend `## Rules` (`design-fanout/SKILL.md:33-39`): state that `--auto` suppresses the ambiguity `AskUserQuestion` (id required; ambiguous or unresolvable arg returns `needs_human: true` and creates nothing) and emits the structured result instead of the prose table. The all-writes-through-`provider/run.sh`, idempotent, no-issue-numbers-written-back, and merged-only-precondition rules are unchanged.
+
+### Tests that prove it
+
+Per DESIGN.md testing strategy (dry-run each `--auto` skill on a scratch design, assert the structured block including `needs_human` on a forced ambiguous arg):
+
+- Multi-unit scratch design, `--auto` with an explicit id, no issues yet: assert the block has `epic_status: "created"`, one `sub_issues` entry per unit with `status: "created"`, `needs_human: false`, and that the created issues carry the same markers and bodies as the interactive mode (shape parity, DESIGN.md decision 5).
+- Re-run the same fan-out with `--auto`: assert `epic_status: "existing"` and every `sub_issues[].status: "existing"`, zero new issues (idempotency).
+- Partial fan-out (epic exists, one unit missing) with `--auto`: assert mixed `"existing"` / `"created"` statuses.
+- Forced ambiguous arg (two folders matching the shortname) with `--auto`: assert `needs_human: true`, `epic_key: ""`, `sub_issues: []`, a `reason` naming the candidates, and that no `AskUserQuestion` fires and no issue is created.
+- Missing/unknown id with `--auto`: assert `needs_human: true`, `reason` naming the id, no issues created.
+- Flat single-unit design with `--auto`: assert one `epic_key`, `sub_issues: []`, `needs_human: false`.
+- Default mode (no `--auto`): the ambiguity gate still prompts and the prose table is unchanged (regression guard for decision 8 manual fallback).

--- a/.autocode/design/0003-design-unit-workflow/units/design-iterate-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/units/design-iterate-auto.md
@@ -1,0 +1,69 @@
+---
+depends-on: []
+type: task
+---
+
+# Unattended --auto mode for design-plan-iterate
+
+## Summary
+
+`design-plan-iterate` triages review comments on a design-doc PR between push and merge: it scores each comment 0-100, applies the high-confidence edits to `DESIGN.md` / `units/*.md`, delegates the commit to `git-commit`, replies to threads, and resolves them (`autocode/design/skills/design-plan-iterate/SKILL.md:1-3,19-46`). Unlike critique and fanout it already has no `AskUserQuestion` gates: it is self-contained and confidence-scored, so it is nearly orchestration-ready today. The one gap is its return: it ends by printing a prose triage table to the user (`SKILL.md:45`), which the in-review phase of the `/design` orchestrator cannot consume. This unit adds an `--auto` flag that, in place of the prose table, emits a single structured machine-readable result block carrying a `needs_human` signal so the orchestrator can apply the high-confidence triage unattended and surface only the contested or low-confidence comments to the user before the user-gated merge (epic decision 5, runtime flow step 6). Non-`--auto` invocation keeps today's interactive prose-table behavior verbatim, preserving manual invocability (epic decision 8). This unit edits one skill body and touches no sibling.
+
+## Implementation
+
+Edit the single real skill body; frontmatter lives in the shim, which already forwards `$ARGUMENTS` (`plugins/autocode/skills/design-plan-iterate/SKILL.md:6`), so `--auto` reaches the body with no shim change. Confirmed: no shim frontmatter update required.
+
+File to modify:
+
+- `autocode/design/skills/design-plan-iterate/SKILL.md`
+
+Follow the existing `--auto` contract convention from `impl-start` (`autocode/impl/skills/impl-start/SKILL.md:16,30`): an `## Args` entry documenting `--auto` as "run unattended and end with a structured result", and a terminal step that emits the structured result block in place of the human triage table.
+
+### --auto behavior
+
+`design-plan-iterate` has no `AskUserQuestion` gates to suppress (epic Background table row "Iterate"; `SKILL.md` has no such call), so `--auto` is lighter here than for critique or fanout. The delta is twofold:
+
+1. The terminal output (`SKILL.md:45`, "Output a triage table to the user") becomes a structured result block.
+2. The triage's discussion band becomes a `needs_human` deferral rather than an in-tree action the orchestrator would have to interpret.
+
+The triage rubric stays as-is (`SKILL.md:21-38`); only the mapping of each band's outcome to the unattended result changes. Mirroring `pr-review --auto` in 0002 (`.autocode/design/0002-impl-epic-orchestrator/units/pr-ci-review-auto.md:47-51`):
+
+- High-confidence band (50-100 human / 70-100 bot): apply the edit, reply, and resolve the thread, exactly as today. Count toward `applied`.
+- Discussion band (20-49 human / 30-69 bot): the human-reviewer 20-49 row today replies asking for clarification (`SKILL.md:29`), an interactive back-and-forth the orchestrator cannot drive. Under `--auto`, defer instead: do not block, count the comment toward `skipped`, leave the thread for a human, and set `needs_human: true` with a reason. The bot 30-69 "optional, update if trivial else resolve" row applies the trivial update when unambiguous, else defers to `skipped`.
+- Spurious band (0-19 human / 0-29 bot): resolve as spurious with the existing explanation comment, as today. Count toward `skipped` (resolved, not deferred for a human).
+
+Preserve every existing rule under `--auto`: edits land only in `DESIGN.md` / `units/*.md` (never source code), no build verify step, commit via `git-commit`, never `--no-verify`, and never resolve a thread without an explanation comment (`SKILL.md:48-53`).
+
+### Structured result
+
+Terminal block under `--auto`, mirroring the 0002 decision 6 shape and the proposed shape in the epic research:
+
+```
+{
+  applied: [<comment-id>, ...],
+  skipped: [<comment-id>, ...],
+  replied: <int>,
+  threads_resolved: <int>,
+  needs_human: <bool>,
+  needs_human_reasons: [<string>, ...]
+}
+```
+
+- `applied`: comment ids whose edits were applied to `DESIGN.md` / `units/*.md` this run.
+- `skipped`: comment ids not applied (spurious-resolved or deferred for a human).
+- `replied`: count of threads that received a reply (`pr-comment-reply`, `SKILL.md:42`).
+- `threads_resolved`: count of threads closed (`pr-thread-resolve`, `SKILL.md:44`).
+- `needs_human`: true when any discussion-band comment was deferred (any contested / low-confidence comment the orchestrator should surface rather than auto-apply).
+- `needs_human_reasons`: one short reason per deferred comment, summarizing what the human must decide.
+
+Scalar and list fields only, in a fenced block, no prose, so the orchestrator parses it directly. This is the in-review phase's branch signal: the orchestrator applies `applied`, then surfaces `needs_human_reasons` to the user before the user-gated merge (epic runtime flow step 6). The block must be the skill's terminal output under `--auto`, replacing the prose table, mirroring how `impl-start --auto` emits its block instead of the human next-step (`autocode/impl/skills/impl-start/SKILL.md:30`).
+
+### Tests
+
+Per the epic testing strategy (dry-run each `--auto` skill on a scratch design and assert the structured result block, including `needs_human` on a forced low-confidence comment):
+
+- `design-plan-iterate --auto` against a design PR with one high-confidence and one low-confidence (discussion-band) comment: assert the high-confidence id is in `applied`, the low-confidence id is in `skipped`, `needs_human: true`, and `needs_human_reasons` carries one entry.
+- With only spurious comments: assert all ids in `skipped`, `needs_human: false`, and each thread resolved with an explanation (`threads_resolved` equals the comment count).
+- Non-`--auto` regression: invoke without the flag and confirm the interactive path (the prose triage table, the 20-49 clarification reply) is unchanged.
+
+No automated harness runs full skill bodies; these are manual dry runs, the acceptance gate per the epic.

--- a/.autocode/design/0003-design-unit-workflow/units/design-orchestrator-core.md
+++ b/.autocode/design/0003-design-unit-workflow/units/design-orchestrator-core.md
@@ -1,0 +1,87 @@
+---
+depends-on: [design-plan-orchestrator-ready, design-critique-auto, design-iterate-auto, design-fanout-auto]
+type: story
+---
+
+# The /design lifecycle orchestrator
+
+## Summary
+
+A new `/design` skill: a thin, stateless, re-entrant main-session sequencer for the design half of the lifecycle, the mirror of the impl-epic-orchestrator (`0002`). Given a seed or an in-flight epic, each turn it reconstructs the lifecycle stage from three observable sources (disk, the issue tracker, the open design PR), dispatches exactly one phase off the main context, consumes a single typed result, and either advances or stops at a gate. The phase order is plan -> critique (`--auto`) -> push -> iterate (`--auto`) -> [user-gated merge] -> fanout (`--auto`) -> hand off `impl --from-design <id>`. Pre-merge phases run automatically; the merge is the single hard gate the orchestrator never crosses (it never merges the design PR); fanout runs automatically post-merge. Every phase skill stays individually invocable for repos without full automation access. This is the keystone unit: it consumes the `--auto` typed-return contracts the four sibling units add and wires them into the re-entrant loop.
+
+## Implementation
+
+Deliverable: the `design` skill (the `/design` command), a thin main-session sequencer that owns no durable state and delegates all heavy work to the off-context phase skills.
+
+Files to create:
+
+- `autocode/design/skills/design/SKILL.md` (real file, body-only, no frontmatter; `.claude/rules/prompt-engineering.md` "Frontmatter lives only in the shim").
+- `plugins/autocode/skills/design/SKILL.md` (shim: frontmatter + a one-line `@~/.autocode/autocode/design/skills/design/SKILL.md` read line, mirroring `plugins/autocode/skills/impl/SKILL.md:1-6`). Skill name `design` is globally unique across feature-sets (`.claude/rules/prompt-engineering.md` file-layout table).
+
+Files to modify:
+
+- `autocode/design/CLAUDE.md`: add `design` as the orchestrator entry, framed as the automation layer over the per-phase skills (mirrors `autocode/impl/CLAUDE.md` describing `impl` as the orchestrator over its per-phase skills).
+
+No provider script, workflow script, or settings key is added by this unit. The plan and critique phases are background Workflow scripts (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`) the sibling units add; this skill (a main-session skill, not a Workflow) launches them directly via the Workflow tool and consumes only their typed results, mirroring how the `0002` orchestrator launches `impl-workflow.mjs` directly and bypasses the `impl` skill wrapper (`impl-orchestrator-core.md:49`). Launching from a main-session skill keeps the single permitted Workflow nesting level for the phase workflow's own fan-out (DESIGN.md decisions 1, 2).
+
+Skill body shape (mirror `autocode/impl/skills/impl/SKILL.md`: intent paragraph, `## Args`, `## Workflow`, `## Rules`, trailing `$ARGUMENTS`):
+
+Args:
+- A seed (new epic) or an `<id|shortname>` selector (resume), per DESIGN.md runtime-flow step 1.
+- `--temp`: throwaway plan, no worktree/id/PR/fanout; refuse to advance past plan (DESIGN.md runtime flow, `--temp` paragraph).
+
+Stage reconstruction (DESIGN.md decision 3, runtime-flow step 2), each turn, from:
+- Disk: resolve the folder via `.autocode/design/INDEX.md` then `.autocode/design/<id>-*` / `*-<shortname>` (the glob-then-INDEX pattern in `design-plan-push/SKILL.md:14-17`); check `DESIGN.md` and `units/` presence and whether the folder is committed.
+- Tracker: `provider/run.sh issue-tracker issue-epic-list --epic <id>` returns `[]` when not yet fanned out, non-empty when fanned out (`issue-epic-list.sh:13-15,94-97`).
+- Open design PR: detected by the design branch `docs/design-<short>` (created in the plan phase via `git-create-branch`, `design-plan/SKILL.md:41`; `design-plan-push/SKILL.md:22` only re-creates it as a fallback in a fresh session) or, as a fallback, by an open PR whose diff touches only `.autocode/design/**` (`design-pr-body.md:9-13`). No `pr-find`/`pr-list` provider script exists (`provider/git-remote/github/pr-view.sh` is a raw passthrough; DESIGN.md decision 10); use `provider/run.sh git-remote pr-view` from the worktree or a direct `gh pr list --head <branch>`. Note the missing provider abstraction in the skill body.
+
+Stage set and transitions (DESIGN.md architecture diagram, runtime-flow steps 3-8):
+
+```
+  none       -> launch design-plan-workflow.mjs    (Workflow) -> { folder, id, units[], underspecified[], open_qs }
+  planned    -> launch design-critique-workflow.mjs (Workflow) -> { iterations_run, files_modified, needs_human, needs_human_reasons[] }
+  planned    -> push           (design-plan-push; light, may stay in-session) -> { pr_url, branch }
+  in-review  -> iterate        (design-plan-iterate --auto) -> { applied, replied, needs_human }
+  =================== USER-GATED MERGE (orchestrator never merges) ===================
+  merged     -> fanout         (design-fanout --auto) -> { epic_key, sub_issues[] }
+  fanned-out -> hand off: invoke `impl --from-design <id>` (the 0002 orchestrator)
+```
+
+Stage definitions (DESIGN.md runtime-flow step 2):
+- `none`: no folder for the seed/id.
+- `planned`: folder + `DESIGN.md` exist (committed or uncommitted in a worktree); no open design PR.
+- `in-review` (covers `pushed`): an open design PR exists for the folder's branch.
+- `merged`: the design PR merged (folder committed on the default branch) and `issue-epic-list --epic <id>` returns `[]`.
+- `fanned-out`: `issue-epic-list --epic <id>` returns non-empty.
+
+`INDEX.md` `status` is a coarse two-state flag (`active`/`archived`, `design-folder.md:30-31`, set `active` by `design-plan`, `archived` by `impl-archive`); it does not distinguish the pre-archive stages, so the fine-grained stage comes from disk + tracker + PR, not from `INDEX.md` (DESIGN.md decision 3).
+
+Cross-unit contracts consumed (the typed `--auto` returns the four sibling units deliver, per DESIGN.md architecture diagram and runtime flow):
+- `design-plan-orchestrator-ready`: plan phase returns `{ folder, id, units[], underspecified[], open_qs }`.
+- `design-critique-auto`: `--auto` returns `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`.
+- `design-iterate-auto`: `--auto` returns `{ applied, replied, needs_human }`.
+- `design-fanout-auto`: `--auto` returns `{ epic_key, sub_issues[] }`.
+
+Gating and dispatch rules (DESIGN.md decisions 1, 2, 4):
+- The orchestrator is a main-session skill, not a Workflow: it can `AskUserQuestion` to disambiguate an id/shortname (DESIGN.md edge case 1) and it gates the merge; a Workflow could do neither and cannot nest the plan fan-out (decision 1, mirrors `impl/SKILL.md:21-26`).
+- Heavy phases (plan, critique) are background Workflow scripts the orchestrator launches directly via the Workflow tool; it consumes only the typed result (decision 2). It never invokes the `--auto` phase skills inline (a skill runs in the main session, so its synthesis/critique churn would pollute the context the design exists to keep clean) nor as subagents (a subagent cannot nest the phase workflow's own fan-out).
+- Hybrid gating: plan/critique/push/iterate auto; hard-stop at the merge; fanout auto post-merge (decision 4). On a `needs_human` result from critique or iterate, surface the reasons and stop; otherwise advance.
+- Merge gate: present the merge-ready PR and stop; the orchestrator never merges the design PR (distinct from `impl-archive`, which may self-merge with `--admin`; DESIGN.md decision 4). On re-invocation after the user merges, the stage reconstructs to `merged`.
+
+Hand-off (DESIGN.md decision 9, runtime-flow step 8): at `fanned-out`, invoke `impl --from-design <id>` (the `0002` orchestrator) when present; when absent, report the epic + sub-issues and suggest it, no failure. `/design`'s responsibility ends here.
+
+Manual fallback (DESIGN.md decision 8): the skill body states that `design-plan`, `design-plan-critique`, `design-plan-iterate`, `design-plan-push`, and `design-fanout` remain individually invocable with unchanged interactive behavior; the orchestrator is an automation layer, not a replacement.
+
+Edge cases the body must cover (DESIGN.md "Edge cases and error handling"):
+- Ambiguous id/shortname: `AskUserQuestion` to disambiguate before dispatching (main session only).
+- Plan returns `underspecified`/`open_qs`: surface; user re-invokes `/design <id>` to re-enter at `planned`.
+- Critique `needs_human`: surface unresolved questions, stop; re-invoke re-runs critique (idempotent) or proceeds.
+- Contested review comments: iterate applies high-confidence ones, surfaces the rest; merge gate stays the user's.
+- Fanout partially complete or already done by the GH Action (`autocreate-design-doc-issue.yml`): `issue-epic-list` reports `fanned-out`; skip straight to hand-off (`design-fanout` is idempotent by body marker).
+- `--temp`: run only the plan phase and stop; point the user at `/design-plan-critique <dir>`.
+- Flat single-unit design: no unit fan-out in plan; fanout creates one issue; no impl cascade.
+
+Tests that prove it (DESIGN.md "Testing strategy"):
+- `scripts/check-plugin-shape.sh` passes: the shim carries frontmatter and the `@`-read line, the real file is body-only (no leading `---`), `autocode/design/` keeps its `CLAUDE.md`. This is the CI gate.
+- Manual end-to-end dry run on a small two-unit seed, exercising stage reconstruction at each point (`none` -> `planned` -> `in-review` -> `merged` -> `fanned-out`), confirming the merge gate stops without merging and the hand-off call fires. No automated harness exists for full skill runs; the dry run is the acceptance gate.
+- Confirm each phase skill's non-`--auto` interactive path is unchanged (manual fallback), by invoking one directly.

--- a/.autocode/design/0003-design-unit-workflow/units/design-plan-orchestrator-ready.md
+++ b/.autocode/design/0003-design-unit-workflow/units/design-plan-orchestrator-ready.md
@@ -1,0 +1,119 @@
+---
+depends-on: []
+type: task
+---
+
+# Make the design-plan phase orchestrator-ready
+
+## Summary
+
+Move the *whole* `design-plan` heavy phase off the main context into a background Workflow script (`autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs`) mirroring `impl-workflow.mjs`, so the `/design` orchestrator can launch it directly and consume only a typed result (DESIGN.md decision 2, workflow-centric dispatch). The workflow owns research fan-out, `DESIGN.md` synthesis, shortname derivation, worktree + branch + `<id>` + `INDEX.md` creation, and the unit-author fan-out with a structured `design-unit-author` contract (`{ underspecified, file, summary }`) plus a bounded research-backed retry. Its agents *read the existing `design-plan` and `design-unit-author` bodies* for their heuristics, so the planning logic stays single-source and the workflow owns only the deterministic loop + fan-out scaffolding. `design-plan --auto` becomes a thin launcher over this workflow (compute `homeDir` + seed, launch, emit the structured result block); `design-plan` without `--auto` keeps its existing in-session interactive loop verbatim (the manual fallback, DESIGN.md decision 8). `design-unit-author` gains the three-field contract usable both via `schema` (in the workflow) and as inline prose (a human reading the same three fields). All changes touch `design-plan` and `design-unit-author` together, so they ship as one PR.
+
+## Implementation
+
+Deliverable: one new workflow script, edits to two body-only source files, and one shim description touch-up. Maps to DESIGN.md decisions 2, 6, 7 and runtime-flow step 3.
+
+Files to create:
+
+- `autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs`: the background plan workflow, sibling to `impl-workflow.mjs` (`autocode/impl/skills/impl/scripts/impl-workflow.mjs`). Plain JS, no shim, not shape-checked (`scripts/check-plugin-shape.sh` only rejects real skill/agent files that open with `---`).
+
+Files to modify:
+
+- `autocode/design/skills/design-plan/SKILL.md`: add `--auto` as a thin launcher over the workflow; keep the non-`--auto` interactive path unchanged.
+- `autocode/design/agents/design-unit-author.md`: replace the in-band underspecified signal (`:29`, `:39-41`) with the three-field contract usable both via `schema` and as inline prose.
+
+Files NOT modified (note for the implementer):
+
+- `plugins/autocode/skills/design-plan/SKILL.md`: the shim already forwards `$ARGUMENTS`, so `--auto` flows through with no edit; touch only its `description` to mention `--auto` if it lists modes (it currently does not, so it may stay verbatim).
+- No shim for the `.mjs`: workflow scripts are launched by absolute path, exactly as `impl-workflow.mjs` has none (`impl/SKILL.md:22-23`).
+
+### The workflow script
+
+Model on `impl-workflow.mjs` exactly. Same helper shape and constraints (DESIGN.md testing strategy, "Static read against `impl-workflow.mjs`"):
+
+- `export const meta` with `name`, `description`, and a `phases` array declaring `Research`, `Synthesize`, `Author`, `Resolve`.
+- Path resolution via `args.homeDir` only: `const HOME = args.homeDir`, then a `skill`/agent-path helper that reads canonical bodies by absolute path (`${HOME}/.autocode/autocode/design/...`), mirroring `impl-workflow.mjs:19,29`. No forbidden globals; `parallel`, `agent`, `phase`, `log` are the workflow runtime's, as in the template. Unlike `impl-workflow.mjs` (where the worktree pre-exists in args because `impl-start` created it), the design plan worktree does not exist at launch: the `Synthesize` phase creates it, so the `inWt` cd-into-worktree prefix is built from the worktree path `Synthesize` returns, not from args, and is therefore only available to the `Author`/`Resolve` phases that follow `Synthesize`.
+- Args from the orchestrator (and from the thin-launcher skill): `{ homeDir, repoRoot, seed }`. The workflow owns the entire heavy phase; the launcher passes only the seed and paths, mirroring how the `0002` orchestrator launches `impl-workflow.mjs` directly with light args (`impl-orchestrator-core.md:49`).
+
+Phases, top-level sequential, with `phase('<Title>')` called only at top level (never inside a `parallel` map):
+
+1. `Research` (`phase('Research')`): one `agent` per research gap inside `parallel`, each dispatching `codebase-researcher` (read-only; body at `${HOME}/.autocode/autocode/design/agents/codebase-researcher.md`). The gaps come from a prior planning `agent` that interprets the seed and lists what to research (mirrors how `design-plan` sketches a rough plan then fans out researchers today). Each call passes `{ label, phase: 'Research', schema: RESEARCH_SCHEMA }`.
+2. `Synthesize` (`phase('Synthesize')`): one `agent` that reads the `design-plan` body for the `DESIGN.md` composition rules, composes `DESIGN.md` from the seed + research findings, derives the `<shortname>` (below), creates the worktree + branch via `git-create-branch`, allocates the `<id>` and appends the `INDEX.md` row, writes `DESIGN.md` into `<repoRoot>/.autocode/design/<id>-<short>/`, and computes the per-unit assignments. Returns `{ folder, id, units: [{ slug, deliverable, dependsOn, type, research }] }` via `schema`. This agent is where the previously-inline `design-plan` synthesis now runs, off the main context. Worktree + branch + `<id>` + `INDEX.md` creation is a plan-phase responsibility today (`design-plan/SKILL.md:41`; `design-plan-push` only re-creates them as a fallback in a fresh session, `design-plan-push/SKILL.md:22`), so it stays in the plan phase, now inside this workflow agent.
+3. `Author` (`phase('Author')`): one `agent` per unit inside `parallel`, mirroring `impl-workflow.mjs:139-146`. Each call passes `inWt` (cd into the worktree first), the agent-body read line for `design-unit-author`, the unit assignment from `Synthesize`, the full `DESIGN.md` text, and that unit's `research`. Options: `{ label: \`author:${slug}\`, phase: 'Author', model: 'opus', schema: UNIT_SCHEMA }`.
+4. `Resolve` (`phase('Resolve')`): the bounded research-backed retry (below).
+
+CRITICAL: never call the global `phase(...)` inside a `parallel` map; declare the phase once before the map and pass `{ phase: '...' }` as the agent OPTION (the template calls `phase('...')` only at top level and passes `{ phase }` as an option inside `parallel`, `impl-workflow.mjs:139-146`). Global `phase()` mutates shared state and races concurrent units.
+
+`UNIT_SCHEMA` (the `design-unit-author` contract, DESIGN.md decision 6):
+
+```
+{ type: 'object', additionalProperties: false,
+  properties: {
+    underspecified: { type: 'boolean' },
+    file: { type: 'string' },
+    summary: { type: 'string' } },
+  required: ['underspecified', 'file', 'summary'] }
+```
+
+Bounded research-backed retry (the `Resolve` phase), cap one retry per unit:
+
+- After the `Author` fan-out resolves, collect units whose result has `underspecified: true`.
+- For each, run a second `parallel` map: first an `agent` dispatch to `codebase-researcher` scoped to that one unit's gap, then a re-`agent` of `design-unit-author` with the same assignment plus the researcher findings, again `{ schema: UNIT_SCHEMA }`.
+- CRITICAL: both retry agents pass `{ phase: 'Resolve' }` as the agent OPTION (e.g. `{ label, phase: 'Resolve', model, schema }`), never a bare `phase('Resolve')` call inside the map. Same rule the template follows passing `{ phase: 'Review' }` as an option (`impl-workflow.mjs:145`); a bare `phase()` inside `parallel` races the other concurrent units' phase state.
+- A unit still `underspecified` after its one retry stays in the underspecified set.
+
+Workflow return block (consumed by the thin-launcher skill and by the orchestrator):
+
+```
+{ folder: string,                     // <repoRoot>/.autocode/design/<id>-<short>/
+  id: string,                         // zero-padded 4-digit, "" for --temp
+  units: [{ slug, file }],            // every unit authored; [] for flat
+  underspecified: [{ slug, file }],   // those still underspecified after retry
+  open_qs: [string] }                 // research gaps the workflow could not resolve
+```
+
+Flat single-unit designs skip the `Author`/`Resolve` fan-out: `Synthesize` writes `DESIGN.md` only and returns `units: []`. `--temp` plans are a single throwaway synthesis with no worktree, id, branch, or `INDEX.md` row: the workflow returns `id: ""`, `units: []`, and the orchestrator refuses to advance a `--temp` folder past plan.
+
+### Shortname derivation (inside `Synthesize`)
+
+DESIGN.md decision 7, replacing the interactive shortname `AskUserQuestion` (`design-plan/SKILL.md:38`):
+
+- Derive from the `# <Title>` H1 of the composed `DESIGN.md`: kebab-case, lowercase, 2-4 keywords, strip the same filler words `git-create-branch` uses (`the`, `a`, `an`, `is`, `of`, `for`, `to`, `in`, `on`, `with`; `git-create-branch/SKILL.md:39`). This is the documented reduction reused, referenced by name, not reimplemented.
+- Dedup against `INDEX.md` (`<repoRoot>/.autocode/design/INDEX.md`) and existing `.autocode/design/*` folder names: on collision append `-2`, then `-3`, etc. The `<id>`, not the shortname, is the durable token (`design-folder.md:11,13`), so a suffixed shortname is fine.
+
+### `design-plan` skill edits (thin launcher under `--auto`)
+
+`--auto` arg: add `--auto` to `## Args` (currently freeform-description / `--temp`, `design-plan/SKILL.md:9-10`).
+
+- Under `--auto`: the skill is a thin launcher. It resolves `homeDir` via `echo "$HOME"` and `repoRoot` via `git rev-parse --show-toplevel` (mirroring `impl/SKILL.md:18,22`), takes the seed non-interactively from `$ARGUMENTS` (a background plan phase cannot `AskUserQuestion`; the orchestrator never invokes plan with an empty seed), launches the Workflow with `scriptPath: <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs` and `args: { homeDir, repoRoot, seed }`, waits, and emits the workflow's return as the structured result block below in place of the prose final report (`:45-47`). The `/design` orchestrator launches the same workflow directly and does not route through this skill (mirrors `0002`, where the orchestrator launches `impl-workflow.mjs` directly and bypasses the `impl` skill, `impl-orchestrator-core.md:49`); the `--auto` skill is the manual entry point to the same off-context phase.
+- Without `--auto`: the in-session interactive path stays (the manual fallback, DESIGN.md decision 8) with one change required by decision 7: the seed `AskUserQuestion` on empty `$ARGUMENTS` (`:14`) and the inline `design-unit-author` fan-out (`:43`) are unchanged, but the interactive shortname prompt (`:38`) is dropped here too and replaced by the auto-derivation below (decision 7 drops the prompt in *both* modes; a human running the skill no longer answers it). The seed prompt is the only `AskUserQuestion` the non-`--auto` path keeps; the `--auto` workflow path drops that one too (it takes the seed from `$ARGUMENTS`).
+
+Structured result block (DESIGN.md runtime-flow step 3), emitted in `--auto` mode:
+
+```
+{ folder: string,            // <repoRoot>/.autocode/design/<id>-<short>/
+  id: string,                // zero-padded 4-digit, "" for --temp
+  units: [{ slug, file }],   // from the workflow return; [] for flat
+  underspecified: [{ slug, file }],  // from the workflow return
+  open_qs: [string] }        // unresolved gaps from the workflow
+```
+
+The orchestrator surfaces `underspecified`/`open_qs` (DESIGN.md edge case "Plan returns `underspecified` units or `open_qs`"). `--temp` + `--auto` returns `id: ""`, `units: []`, and refuses fan-out (the temp dir has no worktree); the orchestrator refuses to advance a `--temp` folder past plan.
+
+### `design-unit-author` agent edits
+
+Replace the in-band underspecified signal and unstructured output (`design-unit-author.md:29,39-41`) with the three-field contract:
+
+- `## Output`: the agent reports `underspecified` (true when it cannot name concrete files, `:29`), `file` (the `units/<slug>.md` path it wrote, or the path it would write when underspecified), and `summary` (one-line deliverable). Invoked inline by a human (the non-`--auto` plan path), it states these three fields in prose; invoked by the workflow with `{ schema: UNIT_SCHEMA }`, the runtime returns them as the typed object. Same three fields either way (DESIGN.md decision 6: "the agent stays usable inline").
+- Keep the existing workflow steps (`:22-29`), the parallel-invocation note (`:5`), and all `## Rules` (`:32-37`). The retry contract is invisible to the agent: it receives a fresh prompt with the researcher findings on the re-author and authors as normal.
+
+### Tests that prove it
+
+Per DESIGN.md testing strategy:
+
+- `scripts/check-plugin-shape.sh` passes: no new shim restates a definition; `design-plan-workflow.mjs` carries no frontmatter and is not a skill/agent file; the design feature-set keeps its `CLAUDE.md`.
+- Static read of `design-plan-workflow.mjs` against `impl-workflow.mjs`: same helper shape, `args.homeDir` path resolution, `inWt` helper, `parallel` fan-out, `schema`-typed returns, `{ phase: '...' }` passed as options inside `parallel` (never a bare `phase()` in a map), top-level `phase()` calls only, no forbidden globals.
+- `design-plan --auto` dry run on a scratch two-unit seed: assert it launches the workflow (no inline research/synthesis in the launching session) and emits the structured result block with `folder`, `id`, `units`, `underspecified`, `open_qs`; assert no `AskUserQuestion` (seed, shortname, or fan-out resolution).
+- Forced underspecified unit (an intentionally vague deliverable): assert the workflow runs one `codebase-researcher` + one re-author for it, and that a unit still vague after the retry appears in `underspecified`.
+- Shortname derivation: assert kebab-case 2-4 keywords from the title with filler stripped, and `-2` suffix on a forced collision against `INDEX.md`.
+- Inline regression: invoke `design-unit-author` directly and confirm it reports the three contract fields in prose; run `design-plan` without `--auto` and confirm the interactive shortname path, inline fan-out, and prose report are unchanged (manual fallback, decision 8).

--- a/.autocode/design/INDEX.md
+++ b/.autocode/design/INDEX.md
@@ -4,3 +4,4 @@
 |------|-------------------|------------|----------|
 | 0001 | auto-archive-epics | 2026-06-04 | active |
 | 0002 | impl-epic-orchestrator | 2026-06-08 | active |
+| 0003 | design-unit-workflow | 2026-06-08 | active |


### PR DESCRIPTION
**Rendered design:** [DESIGN.md](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/DESIGN.md)

Units: [design-plan-orchestrator-ready](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/units/design-plan-orchestrator-ready.md) | [design-critique-auto](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/units/design-critique-auto.md) | [design-iterate-auto](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/units/design-iterate-auto.md) | [design-fanout-auto](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/units/design-fanout-auto.md) | [design-orchestrator-core](https://github.com/hhoikoo/autocode/blob/docs/design-unit-workflow/.autocode/design/0003-design-unit-workflow/units/design-orchestrator-core.md)

## Overview

Turns `/design` into a stateless, re-entrant orchestrator for the design half of the lifecycle, mirroring the impl-epic-orchestrator (`0002`). Given a seed or in-flight epic it reconstructs the current stage from disk, the tracker, and the open PR; dispatches the next heavy phase into a background workflow or subagent; consumes a single typed result; and advances one step: plan -> critique -> push -> (iterate on review) -> [merge, user-gated] -> fanout -> hand off to the impl orchestrator. Pre-merge thinking runs automatically; merging is the one step pinned to the main session for explicit user approval; fanout runs automatically post-merge.

## Problem Statement

- Every design phase (plan, critique, iterate, push, fanout) is driven by hand, one at a time, each in the launching session; research churn, unit-author fan-out, and triage noise fill the main context window.
- The phase skills are interactive (`AskUserQuestion`) and return prose; neither is consumable by a background phase dispatcher.
- `design-unit-author` has an in-band "underspecified" text signal and no typed return contract, so an orchestrator cannot branch on it.
- No single layer knows where an epic is in its lifecycle and can run the next phase automatically.

## Architecture

```
                main session: /design orchestrator (stateless, re-entrant)
                        |                              ^
  reconstruct stage each turn                          | re-invoked on <task-notification>
      +-------------------+--------------------+       |
      |                   |                    |       |
      v                   v                    v       |
 disk: folder?       tracker:             open design  |
 committed?          issue-epic-list      PR?          |
 units/?             (epic/unit status)                |
      |                   |                    |       |
      +-------------------+--------------------+       |
      |  stage: none | planned | pushed | in-review |  |
      |             merged | fanned-out               |
      v                                               |
 dispatch next phase OFF-CONTEXT  --------------------+
      |
      |  none      -> plan-phase     (bg workflow)  -> { folder, id, units[], open_qs }
      |  planned   -> critique-phase (bg workflow, --auto) -> { iterations, changes, needs_human }
      |  planned   -> push           (light/in-session) -> { pr_url }
      |  in-review -> iterate        (--auto) -> { applied, needs_human }
      |  ============== USER-GATED MERGE (main session only) ==============
      |  merged    -> fanout         (--auto) -> { epic_key, sub_issues[] }
      |  fanned-out-> hand off: invoke `impl --from-design <id>`
      v
 surface needs_human cases; present merge-ready PR; report stage + next step
```

Heavy phases (plan, critique) run as background Workflows (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`); the main session sees only a typed result per phase. The outer orchestrator is a main-session skill (not a Workflow) so it can gate the merge and nest the phase workflows.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
    * n/a: text-only design PR
* [x] Documentation added or modified appropriately
