### PR TITLE
docs: Plan parallel epic orchestration for impl

### DIFF
--- a/.autocode/design/0002-impl-epic-orchestrator/DESIGN.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/DESIGN.md
@@ -1,0 +1,164 @@
+# Parallel epic orchestration for impl
+
+## Summary
+
+`impl` today drives one design unit at a time: it sets up a worktree and launches a background workflow that carries that single unit from plan to an open PR, then stops. Re-running it starts the next unit by hand. This epic turns `impl` into a stateless, re-entrant epic-level orchestrator. Given a fanned-out design epic, it computes the dependency-ready set of units, launches a per-unit background workflow for each (capped at a configurable default of 3 concurrent), keeps the launch pipeline full as workflows finish, and runs a separate monitoring pass over the open PRs that auto-rebases, fixes CI, and triages review comments. Merging stays gated on explicit user approval; on each merge the orchestrator cascades into newly-unblocked units and, when every unit is done, triggers the existing archive flow. The orchestrator holds no durable storage of its own: the tracker's issue states are the only cross-session source of truth, and live workflow-run tracking is session-scoped (the harness does not expose another session's runs). So the orchestrator is re-entrant within a session and across `--resume`; a fresh re-entry rebuilds the unit set from the tracker and restarts any unit left `in-progress` with no live run rather than assuming it resumes. Every per-phase skill remains individually invocable, so repositories without full automation access can still drive the pieces by hand.
+
+## Background
+
+The per-unit machinery already exists and is unchanged by this epic. What is missing is the layer above it: launching many units in parallel, keeping a concurrency cap full, and monitoring the resulting PRs. A second gap is the surface the monitor needs: there is no single provider call for PR mergeability/CI/review state, and the remediation skills cannot run unattended.
+
+| Component | File | Current behavior |
+|---|---|---|
+| `impl` launcher | `autocode/impl/skills/impl/SKILL.md` | One interactive `impl-start`, then launches one `impl-workflow`, waits, reports. One unit per invocation. |
+| Per-unit workflow | `autocode/impl/skills/impl/scripts/impl-workflow.mjs` | plan -> execute -> review -> challenge -> decide -> fix -> push -> hygiene; ends at PR-open (unit -> `in-review`). |
+| Unit setup | `autocode/impl/skills/impl-start/SKILL.md` | `--unit <slug> --auto` already does non-interactive per-unit setup, emits a structured block. |
+| Archive | `autocode/impl/skills/impl-archive/SKILL.md` | Already verifies all units done, closes the epic, moves the folder, opens a lightweight PR, and self-merges it with `--admin`. |
+| DAG + lifecycle | `autocode/design/design-folder.md` | Unit `depends-on` lives in unit-file frontmatter; `issue-epic-list` returns per-unit status; a unit is workable when all deps are `done`. |
+| PR state | `provider/git-remote/github/pr-view` | Raw `gh pr view` passthrough; no normalized mergeable/CI/review contract. |
+| Remediation | `pr-rebase`, `pr-fix-ci`, `pr-review` | No `--auto` mode; `AskUserQuestion` gates and prose-only returns block unattended use. |
+| Conflict surface | `PROGRESS.md` | Append-only, one block per unit; every dependent unit's rebase touches it. No union merge driver scaffolded. |
+
+## Architecture
+
+The orchestrator runs in the main session. It owns no durable state of its own: it reconstructs everything each turn from two sources of truth, the issue tracker (unit/epic states) and the harness's workflow-run tracking (which units have a live background run). Two background-workflow types do the heavy work off the main context: the existing per-unit `impl-workflow`, and a new `monitor-workflow`. Merging is the only step pinned to the main session, because it requires explicit user approval.
+
+```
+                         main session: impl orchestrator (stateless, re-entrant)
+                                 |                         ^
+   reconstruct state each turn   |                         | re-invoked on <task-notification>
+        +------------------------+-------------------+     | (workflow completion) or cron tick
+        |                        |                   |     |
+        v                        v                   v     |
+  issue-epic-list          workflow-run         INDEX.md   |
+  (unit/epic status)        tracking          (epic ids)   |
+        |                        |                          |
+        |  ready set = todo units whose deps are all done   |
+        v                                                   |
+  launch wave (cap=3, refill as slots free) ----------------+
+        |                                   launches background
+        v                                                  |
+  impl-start --unit --auto  -->  impl-workflow.mjs (bg) ----+--> opens unit PR -> in-review
+        |                          (plan..push..hygiene)              |
+        v                                                             v
+  on user command / cron:  launch monitor-workflow.mjs (bg) --> fan out one checker per in-review PR
+        |                                                             |
+        |                                          pr-status + --auto rebase / fix-ci / review
+        v                                                             |
+  read typed per-PR report  <---------------------------------------+
+        |
+        |  present merge-ready PRs; USER approves
+        v
+  gh pr merge --admin  -->  unit done  -->  cascade: recompute ready set, launch unblocked
+        |
+        v
+  all units done  -->  impl-archive (self-merges archive PR)  -->  epic closed
+```
+
+## Design decisions
+
+1. Stateless, re-entrant orchestrator. The orchestrator stores nothing durable of its own; it recomputes the ready set, the in-flight set, and the done set on every invocation. The done/ready/in-review distinctions come from the tracker (the only cross-session source of truth); the running set comes from the run ids the orchestrator launched in the current session, tracked in its working context, since live workflow-run tracking is session-scoped and a different session cannot enumerate another session's runs (harness research, this session). Rationale: the tracker is already the single source of truth for unit lifecycle (`design-folder.md`), and a stored queue would drift from it across sessions, crashes, and manual merges. A persistent state file would not buy cross-session resume anyway: the harness loses in-flight workflows on session exit (`resumeFromRunId` is same-session only), so the correct recovery on any fresh re-entry is to restart `in-progress` units from the tracker, not to resume a run id. Rejected alternative: a persistent orchestrator state file under `.autocode/`, which would need its own reconciliation against the tracker and still could not revive a dead run.
+
+2. Two-loop split. The launch pipeline is self-sustaining within a session: launching a per-unit workflow is background work the harness tracks, so when one finishes the main loop is re-invoked (`<task-notification>`) and the orchestrator refills the cap. This refill depends on the harness re-invoking the idle main loop on workflow completion; the `Workflow` tool contract states this, though the public docs do not document an idle-REPL wake guarantee (the tool contract governs, as noted in Sources). The monitor/merge loop is human-paced: run on command or on an opt-in cron tick. Rationale: keeping the cap full needs no human input and should not wait for one, whereas merging requires approval and reviews/CI arrive over wall-clock time. Rejected alternative: a single pure-workflow orchestrator, which cannot gate on a user merge decision mid-run and cannot nest workflows.
+
+3. Concurrency cap, default 3, configurable. The cap is on concurrently-running unit workflows. Rationale: each unit workflow itself fans out internally (per-dimension reviewers), so an unbounded wave multiplies fan-out and saturates the agent pool. 3 balances throughput against that. Exposed as a settings key so heavy repos can lower it. Rejected alternative: hardcoding, which gives no escape hatch on constrained machines.
+
+4. Monitoring is its own background workflow. A monitoring pass is a `monitor-workflow` that fans out one checker per in-review PR, runs the `--auto` remediation skills as its agents, and returns a typed per-PR verdict. It never merges. Rationale: the per-PR checks are independent fan-out that should stay off the main context, mirroring `impl-workflow`; merging is the one step that must stay in the main session for approval. Rejected alternative: dispatching monitor subagents directly from the orchestrator's own context, which fills the main window with check/remediation noise.
+
+5. Auto-remediate, gate merge. The monitor auto-runs `pr-rebase`, `pr-fix-ci`, and `pr-review` (triage) on blocked PRs; only the merge needs explicit user approval, and `gh pr merge --admin` is acceptable once approved. Rationale: rebase and CI fixes are unblockers, not outward-facing actions; merging is the irreversible, outward step. This requires adding `--auto` modes to those three skills (decision 6), since they otherwise stop for the user and return only prose.
+
+6. `--auto` modes with structured returns for the remediation skills. `pr-rebase`, `pr-fix-ci`, and `pr-review` gain an `--auto` flag that suppresses their `AskUserQuestion` gates in favor of a structured result that includes a `needs_human` signal (e.g. a rebase whose conflict exceeds the existing 5-file guardrail, or a non-trivial verify failure, returns `needs_human` rather than prompting). Rationale: a workflow's agents cannot call `AskUserQuestion`; a structured stop signal lets the monitor branch and surface only the cases that genuinely need a person. This is the enabler that makes decision 4 feasible.
+
+7. Normalized PR-status provider script. A new `pr-status` git-remote script returns one typed JSON object (state, mergeable, merge-state, CI rollup, review decision, draft, url), and a `pr-find` script maps a unit to its PR number. `pr-find` resolves primarily by the sub-issue key via the GitHub closing-reference link (the `Closes #<key>` in the PR body; GraphQL `closingIssuesReferences`/`closedByPullRequestsReferences`, with `gh pr list --search` as a simpler eventually-consistent fallback), not by a reconstructed branch: the branch shortname is a model-generated slug of the issue summary and is not reproducible across sessions (research finding), so the issue key is the only durable unit->PR handle. Branch-substring match on the `/<key>/` segment is a secondary path. Rationale: the provider boundary owns git-host knowledge (CLAUDE.md single-source-of-truth); scattering raw `gh pr view --json ...` parsing into the orchestrator and monitor would duplicate and leak it. Rejected alternative: inline `gh` calls in the workflow scripts; and unit->PR mapping by reconstructed branch, which the non-deterministic shortname makes unreliable cross-session.
+
+8. `PROGRESS.md` seed at design-folder creation, plus a union merge driver and a `pr-rebase` backstop. The `union` driver is line-based, so it only resolves cleanly when `PROGRESS.md` already exists at the merge-base: today the file is first created by the first unit's `impl-push` (`impl-push/SKILL.md`), so two first-wave units each create it with a `# Progress: <short>` header and `union` concatenates them into a duplicate header with no conflict and no stop (the skill backstop never fires because the driver suppresses the conflict). Fix: seed `.autocode/design/<id>-<short>/PROGRESS.md` with its header when the design folder is created, so it merges to `main` with the design PR and is a common ancestor for every unit before any unit branches; `union` then resolves every append cleanly (research finding, this session). With the seed in place, scaffold `.gitattributes` with the built-in `union` driver for `PROGRESS.md` so the high-frequency append conflict auto-resolves at the git layer (both blocks kept, no markers, rebase never stops). Additionally teach `pr-rebase` an explicit `PROGRESS.md` union resolution, mirroring its existing `INDEX.md` special-case, so repos on an older setup without the `.gitattributes` still auto-resolve. Rationale: `PROGRESS.md` is the one structural shared write during a parallel epic; resolving it mechanically keeps the monitor's auto-rebase from burning a judgment call on every dependent unit. Rejected alternative: moving the `PROGRESS.md` append post-merge via a GitHub Action, which splits in-PR vs post-merge behavior and drops the rollup from the PR diff.
+
+9. Opt-in cron for periodic monitoring, off by default. The launch pipeline self-sustains without cron. For hands-off monitoring while away, the orchestrator offers (a plain prompt at launch, or a `--watch` flag) to schedule a periodic monitoring tick via `CronCreate`, which runs a `monitor-workflow` and emits a `PushNotification` when PRs become merge-ready. Cron never merges. Rationale: the user wants minimal babysitting but explicit merge control; opt-in cron drives remediation and notification without ever crossing the merge gate. Rejected alternative: always-on cron (unwanted by default) or cloud Routines (lose local `gh` auth and stdio providers).
+
+10. Failure-resistant reconciliation. "Live workflow run" means a run id this session launched and has not yet seen complete; the harness does not expose another session's runs (harness research). On each re-entry, a unit that is `in-progress` in the tracker but has no live run in this session is classified as needing recovery: within the same session this is a genuine crash; on a fresh session or `--resume` it is the expected state (the run did not survive session exit). In both cases the orchestrator surfaces the unit and offers restart, and never silently relaunches over a run still live in this session. `resumeFromRunId` is offered only for a run launched in the current session (the only case it works, per the same-session-only tool contract); a cross-session in-progress unit is restarted, not resumed. Restart is not a bare relaunch: `impl-start`/`git-create-branch` hard-stop on the dead run's leftover branch (research finding), so restart first removes the dead worktree, deletes the leftover branch, and resets the sub-issue to `todo`, then lets the normal wave relaunch it; before any deletion, reconciliation confirms by issue key that no open PR exists (a run that died after push leaves a PR and is in-review, not needs-recovery). Rationale: double-launching a unit live in this session corrupts its worktree and PR; assuming a dead cross-session run resumes would strand the unit forever; relaunching without cleanup would error on the existing branch.
+
+11. Manual fallback preserved. The orchestrator is an automation layer over the existing phase skills, not a replacement; `impl-start`, `impl-plan`, `impl-execute`, the `impl-critique-*` skills, `impl-push`, `pr-rebase`, `pr-fix-ci`, `pr-review`, and `impl-archive` stay individually invocable. Rationale: in repositories where the user lacks the access for full automation, hand-driving the documented skills must still work.
+
+## Runtime flow
+
+1. Invoke `impl --from-design <id|shortname>` (epic mode). The orchestrator reads `INDEX.md` to resolve the epic and calls `issue-epic-list --epic <id>` for per-unit `{slug, status}`; it reads each unit file's `depends-on` from the design folder.
+2. Reconcile: for each unit, resolve its PR by sub-issue key (`pr-find <key>`, the `Closes`-link lookup) and classify: done (sub-issue closed), in-review (an open PR exists, even if the tracker status still reads `in-progress` from a run that died between push and the status flip), running (a run id launched this session, not yet complete), or needs-recovery (`in-progress`, no open PR, no live run in this session). The PR-existence check by issue key, not the tracker status alone, is what prevents deleting a branch out from under a live PR. Surface needs-recovery units with a restart choice (resume only when the run id belongs to this session). Worktree paths are recovered from `git worktree list --porcelain` by matching the `/<key>/` segment of each worktree's branch (the issue key is embedded in the branch; the shortname tail is a non-reproducible slug), not from any stored launch output, so a fresh session can still locate them.
+
+   Restart of a needs-recovery unit (decision 10): a unit that died before `impl-push` has no PR but may hold a worktree, a branch, and partial commits; `git-create-branch` hard-stops on an existing branch and `impl-start` has no reuse path (research finding). So restart first cleans up: remove the dead worktree (`git worktree remove --force`), delete the leftover branch, and transition the sub-issue back to `todo`; the unit then re-enters the ready set and launches fresh in the next wave. The partial work is discarded (the unit never reached review); note this in the surfaced choice.
+3. Compute the ready set: `todo` units whose `depends-on` are all `done`. Launch units up to the cap (default 3) minus the running count: `impl-start --unit <slug> --auto`, then the `impl-workflow` for each. Report the wave and what is queued.
+4. Each per-unit workflow runs to an open PR and exits; its completion re-invokes the orchestrator, which refills the cap with the next queued ready unit. This repeats with no user input until the cap cannot be filled (all remaining units blocked or in-flight).
+5. Monitoring (on user command, or an opt-in cron tick): launch `monitor-workflow`. It fans out one checker per in-review PR; each reads `pr-status`, and if blocked runs the matching `--auto` remediation (`pr-rebase` on conflict, `pr-fix-ci` on red CI, `pr-review` on review comments), returning `{pr, slug, state, action_taken, merge_ready, needs_human}`.
+6. The orchestrator reads the report, surfaces `needs_human` cases, and presents merge-ready PRs. On cron, it emits a `PushNotification` instead of blocking.
+7. The user approves specific PRs; the orchestrator merges them (`gh pr merge --admin` allowed). Each merge flips a unit to `done`.
+8. Cascade in the same turn: recompute the ready set (newly-unblocked units), prune the merged units' worktrees, and launch the next wave under the cap. Merging unit A may put sibling B's PR into conflict; the next monitoring pass auto-rebases it.
+9. When every unit is `done`, the orchestrator invokes `impl-archive` with the epic id (so its multiple-epic prompt never fires); archive self-merges its PR and closes the epic.
+
+Flat single-unit designs collapse this to a wave of one with no cascade; archive still runs. Bare ticket / `type: desc` invocations keep today's single-unit launch behavior, with monitoring applicable to the one PR but no cascade.
+
+## Edge cases and error handling
+
+- Empty ready set with units remaining: report which units are blocked on which unfinished deps; do nothing else.
+- Cap smaller than the ready set: launch up to the cap, report the queued remainder; refill is automatic on workflow completion. Log what was queued (no silent truncation).
+- Crashed/abandoned unit (in-progress, no live run): surface and offer resume/restart; never auto-relaunch.
+- `pr-rebase --auto` hitting the >5-file conflict guardrail or a non-trivial verify failure: return `needs_human`; the orchestrator surfaces it rather than the workflow stalling.
+- `monitor-workflow` over zero in-review PRs: returns an empty report; the orchestrator reports nothing actionable.
+- Cron tick in a headless context that lacks `gh` auth or stdio providers: the monitor pass fails fast and notifies; document that local-session cron is the supported path.
+- Single-unit / flat epic and the bare-ticket path: no cascade, no epic close beyond the one unit; archive handles flat.
+
+## Testing strategy
+
+- Provider scripts (`pr-status`, `pr-find`): unit-level shell tests with mocked `gh` output (fixture JSON), asserting the normalized shape and the unit->PR mapping; follow the existing `provider/` test conventions.
+- `--auto` skill modes: dry-run each skill with `--auto` on a scratch branch and assert the structured result block (including `needs_human` on a forced large conflict and a forced verify failure).
+- `.gitattributes` union driver: construct two branches each appending a distinct `PROGRESS.md` block, rebase one onto the other, assert both blocks survive with no conflict markers.
+- Orchestrator skills: validated by `scripts/check-plugin-shape.sh` (shim/source shape) plus a manual end-to-end dry run on a small two-unit epic (one dependent), exercising launch, cascade, and archive. No automated harness exists for full skill runs; the dry run is the acceptance gate.
+- `monitor-workflow`: exercised in the same dry run with one PR needing a rebase and one merge-ready, asserting the typed verdicts and that no merge happens without approval.
+
+## Alternatives considered
+
+- Pure-workflow orchestrator (no main-session loop): rejected because a workflow cannot pause for a user merge decision or nest further workflows, and merging must stay user-gated.
+- Storing orchestrator state in a file: rejected; the tracker is already authoritative and a file would need reconciliation against it regardless (decision 1).
+- Driving the remediation skills as-is, escalating on their existing prompts: rejected because unattended/cron runs would stall at any `AskUserQuestion`, and the skills return no machine-readable verdict to branch on (decisions 4, 6).
+
+## Sources
+
+- `autocode/impl/skills/impl/SKILL.md`, `autocode/impl/skills/impl/scripts/impl-workflow.mjs`, `autocode/impl/CLAUDE.md`: current launcher and per-unit workflow shape, the launch-call contract, and the in-workflow fan-out pattern. Read this session.
+- `autocode/impl/skills/impl-start/SKILL.md`: `--unit <slug> --auto` non-interactive setup and its structured result block. Read this session.
+- `autocode/impl/skills/impl-archive/SKILL.md`: archive already self-merges with `--admin` (step 8) and prompts only on multiple active epics. Read this session.
+- `autocode/design/design-folder.md`: unit DAG, `depends-on` in unit frontmatter, `issue-epic-list` discovery, lifecycle states, `PROGRESS.md` format and shared-append nature. Read this session.
+- `provider/run.sh`, `provider/git-remote/github/*`, `provider/issue-tracker/github/*`, `provider/ci/github/*`: the provider surface; `pr-view` is a raw passthrough with no normalized contract, and no PR-status/PR-find/PR-approval call exists (gaps confirmed). Read this session.
+- `autocode/pr/skills/{pr-rebase,pr-fix-ci,pr-review}/SKILL.md`: no `--auto` mode; `pr-rebase` has 3 `AskUserQuestion` gates and the `INDEX.md` id-collision special-case to mirror for `PROGRESS.md`; prose-only returns. Read this session.
+- `autocode/_config/guides/worktree.md`: worktree creation already prefers `EnterWorktree` with a bare-git fallback; teardown via `ExitWorktree`. Read this session.
+- `autocode/_config/settings-schema.md`, `autocode/_config/conventions/issue-types.md`: settings key authoring rules and the `epic`/`story`/`task`/`bug` type set. Read this session.
+- Claude Code `Workflow` and `ScheduleWakeup` tool contracts (this session's tool definitions): background workflows return a run id immediately and re-invoke the main loop on completion ("when harness-tracked work finishes, you are re-invoked automatically"); `CronCreate` schedules session-scoped ticks; `PushNotification` sends desktop/phone alerts; `EnterWorktree`/`ExitWorktree` change session cwd and are the preferred worktree primitives. The public docs at code.claude.com describe a synchronous workflow model that does not match this harness; the tool contract governs.
+- Harness cross-session semantics (`claude-code-guide`, this session, citing `code.claude.com/docs/en/{workflows,scheduled-tasks,tools-reference,sub-agents,interactive-mode}`): workflow-run tracking and `TaskList` are session-scoped; `resumeFromRunId` is same-session only ("the next session starts the workflow fresh"); in-flight workflows are lost on session exit; `CronCreate` tasks are session-scoped, restored on `--resume`/`--continue` within a 7-day auto-expiry, and fire only while the session is open and idle between turns; no documented guarantee wakes a closed/detached REPL on background completion. This bounds the re-entrancy claim to within-session + `--resume` and drives the restart-not-resume reconciliation (decisions 1, 10).
+- `impl-push/SKILL.md` (this session): `PROGRESS.md` is first created by the first unit's `impl-push`, not seeded at fan-out or design time; nothing earlier creates it. This is why concurrent first-wave units collide on the header under a line-based `union` driver, and why decision 8 seeds the header at design-folder creation.
+- `EnterWorktree`/`git worktree` (this session): a unit's worktree directory name is set by the tool and is not reconstructable from the slug alone; the durable mapping from a unit branch to its worktree path is `git worktree list --porcelain`, used for stateless recovery of in-review units' worktrees.
+- User decisions (this session): concurrency cap default 3 and configurable; auto-remediate with user-gated merge and `--admin` allowed; opt-in cron only; failure-resistant reconciliation; worktree-tool over bare git; manual invocability preserved; design layer out of scope (owned separately).
+
+## Units
+
+| Unit | Deliverable | depends-on |
+|---|---|---|
+| [pr-status-provider](units/pr-status-provider.md) | Normalized `pr-status` and `pr-find` git-remote provider scripts | none |
+| [pr-rebase-auto](units/pr-rebase-auto.md) | `pr-rebase --auto` with structured `needs_human` return, plus the `PROGRESS.md` union resolution | none |
+| [pr-ci-review-auto](units/pr-ci-review-auto.md) | `--auto` modes with structured returns for `pr-fix-ci` and `pr-review` | none |
+| [progress-union-gitattributes](units/progress-union-gitattributes.md) | `.gitattributes` `PROGRESS.md merge=union` scaffolding in setup + update, plus seeding the `PROGRESS.md` header at design-folder creation so `union` has a common ancestor | none |
+| [impl-orchestrator-core](units/impl-orchestrator-core.md) | `impl` rewritten as the stateless re-entrant launch/cascade/archive orchestrator with the concurrency-cap setting | pr-status-provider |
+| [impl-orchestrator-monitor](units/impl-orchestrator-monitor.md) | `monitor-workflow` plus orchestrator monitoring, user-gated merge, notifications, and opt-in cron | impl-orchestrator-core, pr-status-provider, pr-rebase-auto, pr-ci-review-auto |
+
+## Critique log
+
+### Iteration 1
+
+- Q: Does cross-session re-entrancy hold given the harness? A: No. Workflow-run tracking and `TaskList` are session-scoped, `resumeFromRunId` is same-session only, in-flight workflows die on session exit (harness research). Re-scoped decision 1 to within-session + `--resume`; "live run" = a run id launched this session; cross-session in-progress units restart from the tracker, not resume. No durable state needed (it would not revive a dead run).
+- Q: Can a running workflow be mapped back to its unit/epic? A: No harness handle (`meta.name` is the static `impl-unit`; codebase research). The orchestrator tracks the run ids it launched this session in working context; the cap counts those. Noted as a per-session-orchestrator cap (concurrent epics in one session contend).
+- Q: Crashed-unit recovery via `resumeFromRunId`? A: Only valid same-session; offer restart otherwise (decision 10 rewritten).
+- Q: Worktree path recovery for in-review units without stored state? A: `git worktree list --porcelain` keyed by the unit branch (deterministic from issue key); `EnterWorktree` dir name is tool-internal and not reconstructable from the slug (research). Added to runtime-flow step 2 and the orchestrator/monitor units.
+- Q: Does the `PROGRESS.md union` driver resolve the first-creation collision? A: No. `impl-push` creates the file (not seeded at fan-out), so two first-wave units each write the header and `union` duplicates it silently (research). Resolution (user decision): seed the `# Progress:` header at design-folder creation so it is a common ancestor; decision 8 and the `progress-union-gitattributes` unit updated; the unit test claim corrected.
+- Q: Refill loop depends on idle-REPL wake on workflow completion? A: Tool contract asserts it; public docs do not document an idle-wake guarantee. Tool contract governs (noted in decision 2 and Sources).
+
+### Iteration 2
+
+- Q: Can the orchestrator reconstruct a unit's branch from `issue-epic-list` to find its PR cross-session? A: No. The branch `<short>` is a model-generated slug of the issue summary (`git-create-branch/SKILL.md:34`), not reproducible and divergent if the title is edited; the unit slug is not used in the branch (research). Resolution: `pr-find` keyed by sub-issue key via the `Closes` link (GraphQL `closing/closedBy...References`), branch as secondary; worktree recovery matches the `/<key>/` branch segment (the issue key is embedded). Decision 7, pr-status-provider unit, core/monitor reconciliation updated.
+- Q: Is "restart in-progress units" safe over a dead run's leftovers? A: No. A unit dies before `impl-push` so it holds a branch + worktree + partial commits; `git-create-branch` hard-stops on the existing branch and `impl-start` has no reuse path (research). Resolution: restart cleans up first (remove worktree, delete branch, reset sub-issue to `todo`) then relaunches via the normal wave; before any deletion, reconciliation confirms by issue key that no open PR exists (a run that died after push is in-review, not needs-recovery). Decision 10 and runtime-flow step 2 updated.
+- DAG change: reconciliation's issue-key PR check makes `impl-orchestrator-core` depend on `pr-status-provider` (was none). Units table and frontmatter updated; no cycle (`pr-status-provider` is a leaf).

--- a/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-core.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-core.md
@@ -1,0 +1,78 @@
+---
+depends-on: [pr-status-provider]
+type: story
+---
+
+# Stateless re-entrant epic orchestrator for impl
+
+## Summary
+
+Rewrite `impl` from a one-unit launcher into the stateless, re-entrant epic orchestrator. Given a fanned-out design epic, it reconstructs all state each turn (never from its own durable storage): the issue tracker is the cross-session source of truth for done / in-review / todo, and the running set is the run ids it launched in the current session (live workflow-run tracking is session-scoped; the harness does not expose another session's runs). It reconciles each unit into done / in-review / running / needs-recovery, computes the dependency-ready set, launches a capped wave of per-unit background workflows, refills the cap as workflows finish (the harness re-invokes the main loop on completion within the session), cascades into newly-unblocked units when the user merges a unit, prunes merged units' worktrees, and invokes the existing `impl-archive` when every unit is done. The concurrency cap is a new shared setting (`impl.max-concurrent-units`, default 3). This unit owns the launch / cascade / archive layer and the cap setting; the monitoring, user-gated merge, notification, and cron layers are a separate dependent unit that extends the same files. Argument routing splits epic mode (`--from-design <id|shortname>` and flat designs) from today's single-unit launch (bare ticket / `<type>: <desc>`); the manual per-phase skills stay individually invocable.
+
+## Implementation
+
+Deliverable: `impl` runs an epic to completion as a self-sustaining background launch pipeline plus a user-gated merge/cascade/archive finish, holding no durable state of its own.
+
+### Files modified
+
+| File | Role |
+|---|---|
+| `autocode/impl/skills/impl/SKILL.md` | Real skill body. Replace the single-unit launcher workflow with the orchestrator: arg routing, discovery, reconciliation, ready-set computation, capped wave launch, refill-on-completion, merge-driven cascade, worktree pruning, archive trigger. Single-unit path retained as the bare-ticket branch. Leave a clear `## Monitoring` seam (named but deferred) for the monitor unit to fill. |
+| `plugins/autocode/skills/impl/SKILL.md` | Shim. Update `description` frontmatter to reflect the epic orchestrator (currently describes a one-unit launcher). Body `@`-read line and `$ARGUMENTS` forwarding unchanged. |
+| `autocode/impl/CLAUDE.md` | Feature-set doc. Reframe `impl` from "orchestrate one design unit" to "orchestrate an epic"; keep the per-phase-skill catalog. Leave the monitor unit room to add its workflow/skill entries. |
+| `autocode/_config/settings-schema.md` | Add the `impl.*` top-level namespace (shared) to the namespace table and an `impl.max-concurrent-units` row (integer, default 3) to the shared-keys table. Adding a namespace requires documenting its scope here per the file's own authoring rules. |
+| `plugins/autocode/skills/autocode-setup/scripts/write-settings.sh` | Emit `impl.max-concurrent-units` into the shared `settings.json` output. Add a `--max-concurrent-units=<n>` arg (default 3 when omitted) merged into the shared JSON alongside `provider`. |
+
+### Orchestrator behavior (in `impl/SKILL.md`)
+
+Arg routing, first step:
+- `--from-design <id|shortname>`, or a current worktree already set up for a unit -> epic mode (the orchestrator).
+- Bare `<ticket-id>` / `<type>: <description>` -> today's single-unit launch: one `impl-start` + one `impl-workflow`, no cascade, no archive. Unchanged contract.
+- A flat (no `units/`) design under `--from-design` -> epic mode collapsed to a wave of one; archive still runs.
+
+Discovery (re-run every turn, no caching):
+1. Resolve the epic from `.autocode/design/INDEX.md` (active rows) and the `--from-design` selector; glob the folder.
+2. `provider/run.sh issue-tracker issue-epic-list --epic <id>` -> per-unit `{key, summary, status, type, parent}` and the epic row, matched by marker. `issue-epic-list` does not return `depends-on`.
+3. Read each unit's `depends-on` from `.autocode/design/<id>-<short>/units/<slug>.md` frontmatter.
+
+Reconciliation (decision 10): classify each unit from the tracker status, an issue-key PR lookup, and this session's launched run ids ("live run" = a run id launched in the current session, not yet seen complete; the harness does not expose another session's runs). Resolve each unit's PR up front with `pr-find <issue-key>` (the `Closes`-link lookup), since the tracker status alone can lag a run that died between push and the status flip:
+- `done`: sub-issue closed.
+- `in-review`: an open PR exists for the sub-issue key (trust the PR, not just a possibly-stale `in-progress` status). Recover its worktree path from `git worktree list --porcelain` by matching the `/<key>/` segment of each worktree's branch (the issue key is embedded in the branch `<type>/<key>/<short>`; the shortname tail is a model-generated slug and is not reproducible), not from any stored launch output, so a fresh session can still locate it.
+- running: `in-progress`, no open PR, with a live run in this session.
+- needs-recovery: `in-progress`, no open PR, no live run in this session. Within the same session this is a genuine crash; on a fresh session or `--resume` it is expected (the run did not survive session exit). Offer `Workflow` `resumeFromRunId` only when the run id belongs to this session (the only case it works, same-session-only contract); otherwise restart. Restart is not a bare relaunch: `git-create-branch` hard-stops on the dead run's leftover branch and `impl-start` has no reuse path, so restart first removes the dead worktree (`git worktree remove --force <path>`), deletes the leftover branch, and transitions the sub-issue back to `todo`; the unit then re-enters the ready set and launches fresh in the next wave (partial pre-push work is discarded; note this in the surfaced choice). Never silently relaunch over a run still live in this session.
+
+Ready set: `todo` units whose every `depends-on` slug maps to a `done` unit.
+
+Capped wave launch:
+- Read `impl.max-concurrent-units` (default 3) from the shared settings via the config dir.
+- Slots = cap minus running count, where running count is the run ids this session launched and not yet seen complete. The cap is per-session-orchestrator: if one session drives two epics, their running units share the one cap (contend); this matches the session-scoped run tracking and is acceptable.
+- Launch up to `slots` ready units; for each: `impl-start --unit <slug> --auto` (capture the structured block: worktree path, branch, slug, unit_key, epic_key, design_id), then a background `Workflow` over `impl-workflow.mjs` with `args: { homeDir, worktree, slug, base, dims }` exactly as the current launcher does (`homeDir` from `echo "$HOME"`; `base` = default branch via `git symbolic-ref --short refs/remotes/origin/HEAD` stripped of `origin/`). The per-unit `impl-workflow` is unchanged by this unit.
+- Report the launched wave and the queued remainder; never silently truncate.
+
+Self-sustaining refill (decision 2): each per-unit workflow returns a run id immediately and runs in the background; record that run id in working context (it is the running-set evidence and is session-scoped). On its completion the harness re-invokes the main loop via `<task-notification>` within the session (the refill relies on this idle-loop re-invocation; the `Workflow` tool contract asserts it, the public docs do not document an idle-REPL wake guarantee). On re-entry the orchestrator re-runs discovery + reconciliation and refills empty slots from the ready set, with no user input, until the cap cannot be filled (all remaining units blocked or in-flight).
+
+Merge-driven cascade (the merge gate itself is the monitor unit's; this unit owns the post-merge cascade it triggers): when a unit's PR merges (unit -> `done`), in the same turn recompute the ready set over newly-unblocked units, prune each merged unit's worktree, and launch the next wave under the cap.
+
+Worktree pruning: prefer the worktree tool (`ExitWorktree`); a merged unit's worktree is typically not the current session's, so the tool-unavailable fallback is `git worktree remove <path>` per `autocode/_config/guides/worktree.md`. Note the nuance in the skill: `ExitWorktree` only removes worktrees it created this session, so a worktree merged from another session falls to the bare-git path.
+
+Archive trigger: when every unit is `done`, invoke `impl-archive` passing the epic id explicitly so its multiple-active-epic `AskUserQuestion` never fires. `impl-archive` already self-merges its PR and closes the epic; no change there.
+
+### Monitoring seam (deferred to the dependent unit)
+
+This unit launches and cascades but does not monitor or merge. Name a `## Monitoring` section in `impl/SKILL.md` as the integration point and stop there: the `impl-orchestrator-monitor` unit (depends on this) adds `monitor-workflow`, the user-gated merge, notifications, and opt-in cron. Because that unit branches after this one merges, the two never edit `impl/SKILL.md` or `impl/CLAUDE.md` in parallel.
+
+### Settings key
+
+`impl.max-concurrent-units`: integer, default 3, shared (`settings.json`). New top-level namespace `impl.*` -> shared. Two edits required and both in scope here:
+- `settings-schema.md`: add the namespace-scope row and the key row.
+- `write-settings.sh`: accept `--max-concurrent-units=<n>` (default 3) and emit `{"impl": {"max-concurrent-units": n}}` into the shared object.
+
+### Tests
+
+- `scripts/check-plugin-shape.sh`: shim/source shape for `impl/SKILL.md` (real body-only, shim frontmatter-only) stays green.
+- `write-settings.sh`: shell test asserting `--scope=shared` output includes `impl.max-concurrent-units` defaulting to 3 and honoring an explicit `--max-concurrent-units`, alongside the existing `provider` assertions.
+- Manual end-to-end dry run on a small two-unit epic (one dependent): assert the first wave launches under the cap, the dependent stays queued, refill fires on the first workflow's completion, a merge cascades into the dependent, the merged worktree is pruned, and archive runs once both units are done. No automated harness exists for full skill runs; this dry run is the acceptance gate.
+
+### Out of scope
+
+`monitor-workflow`, the `pr-status`/`pr-find` provider scripts, the `--auto` remediation modes, the user-gated merge mechanics, `PushNotification`, and cron: all owned by sibling units. This unit consumes `pr-find <issue-key>` for reconciliation (hence the `pr-status-provider` dependency) but does not build it. It leaves the merge step as the seam the monitor unit fills.

--- a/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-monitor.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-monitor.md
@@ -1,0 +1,108 @@
+---
+depends-on: [impl-orchestrator-core, pr-status-provider, pr-rebase-auto, pr-ci-review-auto]
+type: story
+---
+
+# Monitor workflow, user-gated merge, notifications, and opt-in cron
+
+## Summary
+
+The launch/cascade orchestrator (`impl-orchestrator-core`) opens unit PRs but does nothing about them once open: PRs drift out of date, CI goes red, and review comments pile up with no unattended remediation, and there is no surface to tell the user which PRs are merge-ready. This unit adds the monitoring layer. A new `monitor-workflow.mjs` background workflow (sibling of `impl-workflow.mjs`) fans out one checker agent per in-review PR; each checker reads the normalized `pr-status` provider, runs the matching `--auto` remediation skill when blocked (`pr-rebase` on conflict, `pr-fix-ci` on red CI, `pr-review` on review comments), and returns a typed per-PR verdict. The workflow never merges. The orchestrator (`impl` `SKILL.md`) gains the monitoring/merge/cron layer on top: launch the monitor on user command or an opt-in cron tick, read the typed report, surface `needs_human` cases, present merge-ready PRs, and merge only on explicit user approval (`pr-merge <pr> --admin`), handing each merge back to the core cascade. Merge-ready PRs (and every cron tick) emit a `PushNotification` so the user knows to give the merge command. Cron is off by default, offered at launch via a plain prompt or a `--watch` flag, runs remediation and notification but never merges, and is documented as a local-session-only path.
+
+## Implementation
+
+A new background workflow script plus an extension of the orchestrator skill and its docs. The monitor is the read/remediate half; merge stays in the main session behind user approval (DESIGN.md decisions 4, 5). This unit branches after `impl-orchestrator-core` merges, so the `SKILL.md` extension does not conflict with the core rewrite.
+
+### Files to create
+
+- `autocode/impl/skills/impl/scripts/monitor-workflow.mjs`: the monitoring background workflow.
+
+### Files to modify
+
+- `autocode/impl/skills/impl/SKILL.md`: extend the orchestrator (rewritten by `impl-orchestrator-core`) with the monitoring trigger, the typed-report read, the user-gated merge, the merge-ready notification, and the opt-in cron. Add `--watch` to `## Args`.
+- `autocode/impl/CLAUDE.md`: document `monitor-workflow` alongside `impl-workflow` (the second background-workflow type), the user-gated merge, and the opt-in cron.
+- `plugins/autocode/skills/impl/SKILL.md` (shim): only if the `description` needs the monitoring/`--watch` capability surfaced; the shim forwards `$ARGUMENTS`, so no arg edit is required (mirrors the sibling skill-unit findings). Confirm at implementation time; do not edit if the description already reads accurately.
+
+```
+ main session: impl orchestrator
+   |  user command / cron tick
+   v
+ launch monitor-workflow.mjs (Workflow tool, background)
+   |
+   |  in-review PRs = issue-epic-list rows with an open PR (pr-find <issue-key> per unit)
+   v
+ parallel( one checker agent per in-review PR )
+   |        each: pr-status -> branch on state
+   |          conflicting           -> pr-rebase  --auto
+   |          ci=failing            -> pr-fix-ci  --auto
+   |          changes_requested     -> pr-review  --auto
+   |          mergeable+green+approved -> merge_ready
+   v
+ typed report: [{ pr, slug, state, action_taken, merge_ready, needs_human, reason }]
+   |
+   v  (back in main session, on workflow completion)
+ surface needs_human  ·  present merge-ready  ·  PushNotification
+   |
+   |  USER approves specific PRs
+   v
+ pr-merge <pr> --admin  ->  hand back to core cascade (recompute ready set, launch next wave)
+```
+
+### `monitor-workflow.mjs` shape
+
+Mirror `impl-workflow.mjs` (`autocode/impl/skills/impl/scripts/impl-workflow.mjs`): an exported `meta` object, the `args`-derived constants, the `skill()` / `inWt` / `follow()` / `readOnly` helpers (lines 29-32), and the `agent()` / `parallel()` / `phase()` / `log()` workflow globals. Plain JS, not TS. The runtime forbids `Date.now()`, `Math.random()`, and argless `new Date()`; resolve all paths from `args.homeDir` (research finding; the same constraints the existing script obeys). Subagents cannot spawn subagents, so all fan-out lives in this workflow runtime, as in `impl-workflow.mjs:26`.
+
+Args from the orchestrator launcher: `{ homeDir, prs }`, where `prs` is the in-review set the orchestrator already computed, each entry `{ pr, slug, branch, worktree }`. The orchestrator owns discovery (`issue-epic-list` + `pr-find` per unit, `pr-status-provider` contract); the workflow receives the resolved list so it does not re-derive epic state off the main context. Each unit worktree persists while its PR is open (`ExitWorktree action: keep`, DESIGN.md / `worktree.md`), so `pr-rebase --auto` has a worktree to `cd` into. The orchestrator resolves `worktree` from `git worktree list --porcelain` keyed by `branch` (the worktree dir name is `EnterWorktree`-internal and not reconstructable from the slug), so the path is recovered even for PRs opened by a prior session, not read from any stored launch output. If no worktree is found for an open PR (e.g. pruned out of band), the orchestrator recreates one for that branch before launching the monitor, or the checker returns `needs_human` rather than `cd`-ing into a missing path.
+
+Per-PR checker (fanned out via `parallel(prs.map((p) => () => agent(...)))`, mirroring `impl-workflow.mjs:139`):
+
+1. Read `pr-status` for the PR via `provider/run.sh git-remote pr-status <pr>` (the `pr-status-provider` unit's typed object: `state`, `mergeable`, `ci`, `reviewDecision`, `isDraft`, ...).
+2. Short-circuit on `state` `merged`/`closed` (already gone) and on `isDraft` (not ready): no action, not merge-ready.
+3. Branch on the first applicable blocked condition and run exactly that one `--auto` remediation as the checker's action this pass (re-checked next pass; one remediation per checker keeps the verdict unambiguous):
+   - `mergeable == "conflicting"` -> `pr-rebase --auto` in the unit worktree; consume its `{ rebased, conflicts_resolved, verify, needs_human, reason }` (`pr-rebase-auto` contract).
+   - `ci == "failing"` -> `pr-fix-ci --auto`; consume its `{ pr, fixed, ci, needs_human, reason }` (`pr-ci-review-auto` contract).
+   - `reviewDecision == "changes_requested"` -> `pr-review --auto`; consume its `{ pr, applied, deferred, needs_human, reason }` (`pr-ci-review-auto` contract).
+4. Compute `merge_ready`: `state == "open"`, not draft, `mergeable == "mergeable"`, `ci == "passing"`, `reviewDecision` in `{approved, none}`, and no remediation was needed this pass. The workflow never merges (DESIGN.md decision 4).
+5. Return the typed verdict via a JSON `schema` on the `agent()` call (mirror how `impl-workflow.mjs` pins `PREP_SCHEMA` / `FINDINGS_SCHEMA` etc., lines 34-126):
+
+   ```
+   { pr: int, slug: string, state: string,
+     action_taken: "none" | "rebase" | "fix-ci" | "review",
+     merge_ready: bool, needs_human: bool, reason: string }
+   ```
+
+   `needs_human` is the OR of the chosen remediation's `needs_human` (a >5-file conflict, a non-trivial verify failure, a missing build convention, a deferred low-confidence review comment); `reason` carries that skill's reason. A checker that errors out (e.g. `pr-status` non-zero) returns `needs_human: true` with the failure in `reason` rather than throwing, so one bad PR does not sink the batch (`impl-workflow.mjs:150` filters falsy results; match that resilience).
+
+The workflow returns the array of verdicts (and a short tally) as its final value. Over zero in-review PRs it returns an empty report (DESIGN.md edge case); the orchestrator reports nothing actionable.
+
+### Orchestrator extension (`SKILL.md`)
+
+Layer onto the core orchestrator (does not re-specify launch/cascade, owned by `impl-orchestrator-core`):
+
+- Trigger: monitoring runs on an explicit user command (e.g. the user asks to check the PRs) or an opt-in cron tick, not automatically on every turn (DESIGN.md decision 2: the merge loop is human-paced).
+- Launch: compute the in-review set (`issue-epic-list` rows whose unit PR is open, via `pr-find <issue-key>` per unit, the `Closes`-link lookup, not a reconstructed branch), read each open PR's head branch from the `pr-find`/`pr-status` result, map it to a `worktree` via `git worktree list --porcelain` on the `/<key>/` segment, and launch `monitor-workflow.mjs` through the Workflow tool with `args { homeDir, prs }`. The workflow runs background; its completion re-invokes the orchestrator (same mechanism as `impl-workflow`).
+- Read the report: surface every `needs_human` verdict with its `reason` (the cases a person must handle); list `merge_ready` PRs.
+- User-gated merge: present the merge-ready PRs and wait for explicit approval. Only on approval, merge the named PRs via `provider/run.sh git-remote pr-merge <pr> --admin` (`pr-merge.sh` exists and takes `--admin`). Never merge without approval; the workflow never merges (DESIGN.md decision 5).
+- Hand back to the core cascade: each merge flips its unit to `done`; the orchestrator recomputes the ready set and launches the next wave (logic owned by `impl-orchestrator-core`; this unit invokes it, does not duplicate it).
+- Notifications: emit a `PushNotification` when PRs become merge-ready, and on every cron tick, so the user knows to give the merge command. Keep the message under 200 chars, one line, lead with the actionable fact (e.g. `2 PRs merge-ready: <slug>, <slug>`). The tool is Anthropic-hosted desktop/phone (Remote Control); a "not sent" result is expected on Bedrock/Vertex/Foundry and is non-fatal (verified tool contract this session). Do not block on it.
+
+### Opt-in cron (`--watch`)
+
+- Off by default; the launch pipeline self-sustains without it (DESIGN.md decision 9).
+- Offer at launch via a plain prompt (NOT `AskUserQuestion`), or accept a `--watch` flag on `impl`. On opt-in, schedule a periodic monitoring tick with `CronCreate` (verified this session): session-scoped (in-memory, `durable` left default false), standard 5-field cron, fires only while the REPL is idle, min 1-minute period. Pick an off-`:00`/`:30` minute when the period allows. The cron prompt re-launches `monitor-workflow` (remediation + `PushNotification`) and never crosses the merge gate.
+- Tell the user the recurring cron auto-expires after 7 days (tool contract), that it is session-scoped (it stops when the session exits and is restored only on `--resume`/`--continue` within the 7-day window, per harness research), and that it fires only while the session is open and idle between turns with no catch-up for missed fires. Provide the `CronCreate` job id so it can be cancelled via `CronDelete`.
+- Document that local-session cron is the supported path: headless contexts and cloud Routines lose local `gh` auth and the stdio providers, so a tick there fails fast (the monitor pass surfaces the failure and notifies); do not schedule a Routine for this (DESIGN.md decision 9, edge case).
+
+### Tests that prove it
+
+Per DESIGN.md testing strategy (the `monitor-workflow` row and the orchestrator dry run):
+
+- `check-plugin-shape.sh` passes (shim/source shape unchanged for the skill; the workflow script is not a shim).
+- Manual end-to-end dry run on the small two-unit epic from the core unit's gate, extended so one PR needs a rebase and one is merge-ready: assert the monitor returns the two typed verdicts (`action_taken: "rebase"` for the first, `merge_ready: true` for the second), and that no merge happens without explicit approval.
+- After approving the merge-ready PR, assert `pr-merge --admin` runs and the cascade launches the now-unblocked dependent unit (exercises the hand-back to core).
+- Cron opt-in: assert the plain-prompt offer (not `AskUserQuestion`), that declining schedules nothing, and that accepting creates exactly one session-scoped `CronCreate` job whose prompt runs the monitor and never merges.
+- Notification: assert a `PushNotification` fires when a PR becomes merge-ready and on a cron tick; a "not sent" result does not abort the flow.
+
+No automated harness runs full workflow/skill bodies; the dry run is the acceptance gate (DESIGN.md testing strategy).
+</content>
+</invoke>

--- a/.autocode/design/0002-impl-epic-orchestrator/units/pr-ci-review-auto.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/pr-ci-review-auto.md
@@ -1,0 +1,75 @@
+---
+depends-on: []
+type: task
+---
+
+# Unattended --auto modes for pr-fix-ci and pr-review
+
+## Summary
+
+`pr-fix-ci` and `pr-review` today run interactively and return prose only: each stops for the user at a decision point (a missing build convention, a low-confidence comment) and reports a human-readable triage rather than a machine-readable verdict. The monitor workflow (epic decision 4) fans out one checker per in-review PR and cannot accept that: its agents cannot call `AskUserQuestion`, and it needs a typed result to branch on. This unit adds an `--auto` flag to both skills. Under `--auto` each skill suppresses every user-facing stop, applies only the actions it can take unattended, and ends with a single structured result block carrying a `needs_human` signal so the monitor surfaces only the cases that genuinely need a person. Non-`--auto` invocation keeps today's interactive behavior verbatim, preserving manual invocability (decision 11). The two skills are independent files; this unit edits both and touches no other skill (`pr-rebase` is a separate unit).
+
+## Implementation
+
+Edit the two real skill bodies (frontmatter lives in the shims, which already forward `$ARGUMENTS`, so no shim edit is needed):
+
+- `autocode/pr/skills/pr-fix-ci/SKILL.md`
+- `autocode/pr/skills/pr-review/SKILL.md`
+
+Both shims (`plugins/autocode/skills/pr-fix-ci/SKILL.md:6`, `plugins/autocode/skills/pr-review/SKILL.md:6`) end with `$ARGUMENTS` is forwarded, so `--auto` reaches the body unchanged. Confirmed: no shim frontmatter update required.
+
+Follow the existing `--auto` contract from `impl-start` (`autocode/impl/skills/impl-start/SKILL.md:16,30`): an `## Args` entry documenting `--auto` as "run unattended (no `AskUserQuestion`) and end with a structured result", and a final step that emits a structured result block in place of the human report.
+
+### pr-fix-ci --auto
+
+Today's body (`autocode/pr/skills/pr-fix-ci/SKILL.md:17`) reads the verify command from `$AUTOCODE_CONFIG_DIR/conventions/build.md` and, if that file is missing, stops with a user-facing "run `/autocode-setup`" message. Other halt points: a non-branch-caused failure (flaky/infra, line 25), and CI still `pending` (line 12).
+
+Under `--auto`, replace each user-facing stop with a `needs_human` outcome rather than a prose halt:
+
+- Missing `build.md` convention -> `needs_human: true`, `reason` naming the missing convention. Do not infer the verify command.
+- Non-branch-caused failure (flaky network, infra outage) -> `needs_human: true`, `reason` describing it. Do not guess a fix.
+- A verify failure the skill cannot minimally fix -> `needs_human: true`.
+
+Preserve all existing rules under `--auto`: still verify locally before pushing, never `--no-verify`, one commit per logical fix.
+
+Final structured result (the proposed shape from the epic research, decision 6):
+
+```
+{ pr, fixed: bool, ci: "green" | "red" | "pending", needs_human: bool, reason }
+```
+
+`ci` reflects the post-fix check rollup the skill already computes from `provider/run.sh ci pr-check-list` (`SKILL.md:12`): `green` when every bucket is `pass`/`skipping`, `pending` while running, `red` otherwise. `fixed` is true when a fix was committed and pushed this run.
+
+### pr-review --auto
+
+Today's body (`autocode/pr/skills/pr-review/SKILL.md:21-24`) triages each comment confidence-weighted; the 20-49 human-reviewer band replies asking for clarification (an interactive, human-facing stop), and the rules require an explanation comment before resolving any thread (line 45).
+
+Under `--auto`, the only change is the discussion band: low-confidence items that would otherwise prompt for clarification become deferred and counted toward `needs_human` instead of opening an interactive back-and-forth. High-confidence fixes still apply and their threads still resolve; spurious items still resolve with an explanation. Concretely:
+
+- 50-100 (human) / 70-100 (bot): fix and resolve, as today.
+- 20-49 (human) / 30-69 (bot): defer. Do not block on clarification; count toward `deferred`. Leave the thread for a human; `needs_human` becomes true.
+- 0-19 (human) / 0-29 (bot): resolve as spurious with the existing explanation comment.
+
+Preserve the rule that no thread is resolved without an explanation comment, and never `--no-verify`.
+
+Final structured result (proposed shape, decision 6):
+
+```
+{ pr, applied: int, deferred: int, needs_human: bool, reason }
+```
+
+`applied` counts comments fixed-and-resolved this run; `deferred` counts comments left for a human; `needs_human` is `deferred > 0`; `reason` summarizes the deferred set.
+
+### Shared contract
+
+`needs_human` is the branch signal the monitor reads (epic runtime flow step 5: each checker returns `{pr, slug, state, action_taken, merge_ready, needs_human}`); these two per-skill returns feed that aggregation. The block must be the skill's terminal output under `--auto`, machine-parseable, mirroring how `impl-start --auto` emits its block instead of the human next-step (`autocode/impl/skills/impl-start/SKILL.md:30`).
+
+### Tests
+
+Per the epic testing strategy: dry-run each skill with `--auto` on a scratch branch and assert the structured result block.
+
+- `pr-fix-ci --auto`: against a PR with green CI, assert `{ ci: "green", needs_human: false }`; with the `build.md` convention forced missing, assert `needs_human: true` with a reason naming the convention; with a forced verify failure, assert `needs_human: true`.
+- `pr-review --auto`: against a PR with one high-confidence and one low-confidence comment, assert the high-confidence one is in `applied`, the low-confidence one in `deferred`, and `needs_human: true`.
+- Non-`--auto` regression: invoke each skill without the flag and confirm the interactive path (clarification reply, missing-convention halt message) is unchanged.
+
+No automated harness runs full skill bodies; these are manual dry runs, the acceptance gate per the epic.

--- a/.autocode/design/0002-impl-epic-orchestrator/units/pr-rebase-auto.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/pr-rebase-auto.md
@@ -1,0 +1,80 @@
+---
+depends-on: []
+type: task
+---
+
+# pr-rebase --auto with structured return and PROGRESS.md union resolution
+
+## Summary
+
+`pr-rebase` gains an `--auto` flag that suppresses its three `AskUserQuestion` gates (the >5-file conflict guardrail, the ambiguous-conflict pause, and the non-trivial verify failure) in favor of a single structured result carrying a `needs_human` signal, so the epic monitor can auto-rebase unattended and branch on the cases that genuinely need a person. It also adds an explicit `PROGRESS.md` union resolution that mirrors the existing `.autocode/design/INDEX.md` id-collision special-case: when the conflicted file is a `.autocode/design/**/PROGRESS.md`, the rebase keeps both sides' appended blocks (no markers, single `# Progress:` header) as a skill-level backstop for repos whose `.gitattributes` lacks the `merge=union` driver. All interactive behavior is preserved when `--auto` is absent; `--force-with-lease` and verify-before-push are unchanged.
+
+## Implementation
+
+Deliverable: edit one source file, the canonical skill body. The shim needs no change.
+
+Files to modify:
+
+- `autocode/pr/skills/pr-rebase/SKILL.md` (the real, body-only skill at `autocode/pr/skills/pr-rebase/SKILL.md:1`): add the `--auto` arg, the suppressed-gate branches, the structured return, and the `PROGRESS.md` union resolution step.
+
+Files NOT modified (note for the implementer):
+
+- `plugins/autocode/skills/pr-rebase/SKILL.md` (`plugins/autocode/skills/pr-rebase/SKILL.md:6`) already forwards `$ARGUMENTS`, so `--auto` flows through with no edit. Its `description` (line 3) carries no mode list and stays accurate, so leave it. The shim is unchanged.
+
+### `--auto` mode
+
+Add `--auto` to the `## Args` section (currently `(none; operates on the current branch)`, `autocode/pr/skills/pr-rebase/SKILL.md:6`). Default (flag absent) keeps every current `AskUserQuestion` gate and the prose report verbatim (decision 11, manual fallback preserved).
+
+When `--auto` is set, the three existing human gates become structured `needs_human` returns instead of prompts:
+
+| Current gate (`SKILL.md` line) | Default behavior | `--auto` behavior |
+|---|---|---|
+| >5 files conflict in one rebase step (`:16`) | `AskUserQuestion` continue/abort | `git rebase --abort`, return `needs_human: true` with `reason` naming the file count |
+| Ambiguous/incompatible conflict, intent unclear (`:23`) | `AskUserQuestion` | `git rebase --abort`, return `needs_human: true` with `reason` |
+| Non-trivial verify failure (`:26`) | stop and ask | leave the branch unpushed, return `needs_human: true`, `verify: "fail"`, `reason` from the failing command |
+
+The small-obvious-failure auto-fix path (lint/typo amend, `:25`) and the trivial-conflict resolutions stay automatic in both modes. Verify-before-push and `--force-with-lease` (`:27`, `:33`) are unchanged: `--auto` never pushes a branch that failed verify or needs a human.
+
+Structured result (the contract `impl-orchestrator-monitor` consumes, per DESIGN.md decision 6 and runtime-flow step 5):
+
+```
+{ rebased: bool,
+  conflicts_resolved: int,
+  verify: "pass" | "fail" | "skip",
+  needs_human: bool,
+  reason: string }
+```
+
+`verify: "skip"` covers the up-to-date no-op (`:13`, rebase did nothing) and the case where `build.md` defines no verify command. On a clean rebase: `rebased: true, needs_human: false`, `reason: ""`. The skill emits this block as its final output in `--auto` mode in place of the step-8 prose report; background hygiene (`:28`) still dispatches unless the rebase was a no-op.
+
+### PROGRESS.md union resolution
+
+Add a conflict-resolution branch alongside the existing INDEX.md special-case (`autocode/pr/skills/pr-rebase/SKILL.md:18-22`), inside the per-file loop (step 4). It applies in both default and `--auto` modes.
+
+Trigger: the conflicted file matches `.autocode/design/**/PROGRESS.md`.
+
+Resolution: union the two sides' appended blocks. The file format is a single `# Progress: <shortname>` header followed by one `## <slug> — <date>` block per merged unit (`design-folder.md:122-135`). Keep the single header once; concatenate base-side and incoming-side unit blocks with no conflict markers; `git add` the file. This never merges two blocks onto one slug the way INDEX.md never merges two rows onto one id (the stated principle, research finding); distinct units append distinct blocks, so the union is the correct merge.
+
+This is the skill-level backstop for the `.gitattributes merge=union` driver scaffolded by the `progress-union-gitattributes` sibling unit (DESIGN.md decision 8): on a repo whose `.gitattributes` predates that scaffolding, git surfaces the conflict and this branch resolves it; on a current repo the driver resolves it before the file ever enters the conflicted set, so this branch is a no-op.
+
+```
+conflicted file
+  ├─ .autocode/design/INDEX.md + same id  -> renumber losing branch (existing)
+  ├─ .autocode/design/**/PROGRESS.md      -> union both sides' blocks (new)
+  └─ anything else                        -> existing per-file resolution / gates
+```
+
+### Rules section
+
+Extend `## Rules` (`autocode/pr/skills/pr-rebase/SKILL.md:32-36`): state that `--auto` suppresses all three `AskUserQuestion` gates and returns the structured result with `needs_human` instead, and that a `PROGRESS.md` conflict resolves by union (keep both blocks, single header), mirroring the INDEX.md renumber rule. The existing `--force-with-lease`-never-`--force`, 5-file-guardrail, and verify-before-push rules are unchanged in wording; the guardrail still fires, it just returns rather than prompts under `--auto`.
+
+### Tests that prove it
+
+Per DESIGN.md testing strategy (`--auto` skill modes, and the union construction):
+
+- Forced large conflict on a scratch branch with `--auto`: assert the structured block has `needs_human: true`, `rebased: false`, and a `reason` naming the file count; assert no push and no `AskUserQuestion`.
+- Forced verify failure with `--auto`: assert `verify: "fail"`, `needs_human: true`, branch unpushed.
+- Clean rebase with `--auto`: assert `rebased: true, needs_human: false, verify: "pass"|"skip"`.
+- Up-to-date no-op with `--auto`: assert `verify: "skip"`, no push.
+- Two branches each appending a distinct `PROGRESS.md` block, rebase one onto the other on a repo with no `merge=union` `.gitattributes`: assert both blocks survive, single `# Progress:` header, zero conflict markers.
+- Default mode (no `--auto`): the three gates still prompt; the prose report is unchanged (regression guard for decision 11).

--- a/.autocode/design/0002-impl-epic-orchestrator/units/pr-status-provider.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/pr-status-provider.md
@@ -1,0 +1,94 @@
+---
+depends-on: []
+type: task
+---
+
+# Normalized PR-status and PR-find provider scripts
+
+## Summary
+
+The orchestrator's monitor needs one typed PR-state call and a unit-to-PR lookup, but the only PR-state surface today is `provider/git-remote/github/pr-view.sh`, a raw `gh pr view "$@"` passthrough with no normalized contract. Scattering raw `gh pr view --json ...` parsing into the orchestrator and monitor would duplicate git-host knowledge and leak it past the provider boundary. This unit adds two `git-remote` provider scripts: `pr-status <pr>` returns one typed JSON object the monitor branches on (state, mergeable, merge-state, CI rollup, review decision, draft, url, number), and `pr-find <issue-key>` maps a unit to its PR number via the PR's `Closes #<key>` link (the branch shortname is a non-reproducible slug, so the issue key is the durable handle; a `--branch` mode is kept as a secondary). Both follow the existing provider script contract (env/positional args, `jq`-built JSON on stdout, stderr progress, `-g <owner/repo>` override) and are reached only through `provider/run.sh git-remote <feature> [args]`.
+
+## Implementation
+
+Two new provider scripts under the existing `git-remote/github` provider, plus a `provider/CLAUDE.md` doc note for the new features. No skill changes; consumers are the monitor unit (`impl-orchestrator-monitor`), which calls these via the dispatcher.
+
+### Files to create
+
+- `provider/git-remote/github/pr-status.sh`
+- `provider/git-remote/github/pr-find.sh`
+
+### Files to modify
+
+- `provider/CLAUDE.md`: the `<feature>` examples list is illustrative, not exhaustive (`run.sh` resolves any `<feature>.sh` by name), so no registry edit is strictly required; add `pr-status` and `pr-find` to the git-remote feature examples only if the existing doc enumerates per-provider features. Confirm at implementation time; do not invent a registry that does not exist.
+
+### Plugin shim / settings
+
+None. Provider scripts are not shims (the shim rule in root `CLAUDE.md` and `.claude/rules/prompt-engineering.md` covers skills and agents only); `provider/` has no plugin mirror. No new settings key. No `settings-schema.md` edit: `github` is already a valid `provider.git-remote` value and these are new features of an existing provider, not a new provider (`provider/CLAUDE.md:30-35`).
+
+### `pr-status.sh` contract
+
+```
+Usage: pr-status.sh <pr-number> [-g <owner/repo>]
+Stdout: one JSON object (typed PR state)
+```
+
+Source fields in a single `gh pr view <n> --json state,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,isDraft,url,number` call (research finding; `reviewDecision` is the native GitHub field carrying `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED`, preferred over re-deriving from raw `reviews`). Normalize via `jq` to:
+
+```json
+{
+  "number":          <int>,
+  "url":             "<string>",
+  "state":           "open" | "merged" | "closed",
+  "isDraft":         <bool>,
+  "mergeable":       "mergeable" | "conflicting" | "unknown",
+  "mergeStateStatus":"<gh mergeStateStatus, lowercased>",
+  "ci":              "passing" | "failing" | "pending" | "none",
+  "reviewDecision":  "approved" | "changes_requested" | "review_required" | "none"
+}
+```
+
+Normalization rules the implementer owns:
+
+- `state`: lowercase the gh enum (`OPEN`/`MERGED`/`CLOSED`).
+- `ci` rollup: derive from `statusCheckRollup`. Reuse the bucket vocabulary already established by `provider/ci/github/pr-check-list.sh:6` (`{name,bucket,state,link,workflow}`): any failing bucket -> `failing`; else any pending/in-progress -> `pending`; all passing -> `passing`; empty rollup -> `none`. Pick whether to compute inline from `statusCheckRollup` or to call `pr-check-list` and roll up; inline keeps it one `gh` call (preferred), but either is acceptable. State the choice in a comment.
+- `reviewDecision`: lowercase; GitHub returns empty string when no review is required, map empty -> `none`.
+- `mergeable`: lowercase the gh enum (`MERGEABLE`/`CONFLICTING`/`UNKNOWN`).
+
+A merged or closed PR still returns a well-formed object; the monitor uses `state` to short-circuit. This is the single call the monitor branches on per DESIGN.md decision 7 and runtime-flow step 5.
+
+### `pr-find.sh` contract
+
+```
+Usage: pr-find.sh <issue-key> [-g <owner/repo>]
+       pr-find.sh --branch <branch> [-g <owner/repo>]   # secondary
+Stdout: { "number": <int>, "state": "open"|"merged"|"closed" }  on a match
+        {} (empty object)                                       on no match
+```
+
+Map a unit to its PR by the SUB-ISSUE KEY, the only durable cross-session handle. The branch is NOT a reliable key: `git-create-branch` builds the `<short>` segment as a model-generated slug of the issue summary (`git-create-branch/SKILL.md:34`), so it is not reproducible across sessions and can diverge if the title is edited (research finding). Resolve by the `Closes #<key>` link the PR body already carries (`design-folder.md` lifecycle: `impl-push` writes `Closes #<unit>`): use the GitHub closing-reference link, `gh api graphql` on the issue's `closedByPullRequestsReferences` (or the PR's `closingIssuesReferences`); a `gh pr list --search "in:body #<key>" --state all --json number,state` is an acceptable simpler fallback, eventually-consistent. Keep a secondary `--branch <branch>` mode (`gh pr list --head <branch> --state all`) for callers that already hold an exact branch (e.g. inside a worktree); document it as secondary. On multiple matches, return the first non-closed (the live PR); on none, emit `{}` and exit `0` (absence is not an error, the monitor treats empty as "no PR yet").
+
+### Conventions both scripts follow
+
+Mirror `provider/issue-tracker/github/issue-epic-list.sh:17-45` and `provider/git-remote/github/pr-merge.sh`:
+
+- `#!/usr/bin/env bash` + `set -euo pipefail`; header comment with usage and `Depends on: gh, jq`.
+- `gh` presence guard exiting `2` when absent (`issue-epic-list.sh:17-20`).
+- Required positional via `:?` guard (`pr-merge.sh:9`); `-g <owner/repo>` parsed in the same arg loop as `issue-epic-list.sh:25-31`, passed to `gh` as `--repo "${owner}/${name}"` when set so the scripts work outside a checkout.
+- JSON to stdout via `jq` only; progress/errors to stderr, no ANSI. Exit `0` success, `1` bad input / missing PR-as-error, `2` unexpected (`provider/CLAUDE.md:18-28`).
+- `run.sh` already `exec`s any `git-remote/github/<feature>.sh` by name (`provider/run.sh:46-56`); no dispatcher change.
+
+### Tests
+
+DESIGN.md testing strategy calls for "unit-level shell tests with mocked `gh` output (fixture JSON), asserting the normalized shape and the unit->PR mapping; follow the existing `provider/` test conventions." There is no existing `provider/` test harness in the repo (no `provider/**/tests`, no test runner found this session), so "existing conventions" do not exist to follow. Implementer decision, in priority order:
+
+1. Run `shellcheck` on both new scripts (mandated by `provider/CLAUDE.md:35`).
+2. Manual fixture check: shim `gh` on `PATH` (a stub printing canned `--json` output) and assert `pr-status.sh` emits each normalized variant: open+passing+approved, conflicting, failing CI, draft, merged, empty rollup; assert `pr-find.sh` returns the live PR on match and `{}` on no match.
+
+If the epic wants a committed test harness, that is a separate concern not scoped to this unit; flag it rather than scaffolding a repo-wide convention here.
+
+```
+monitor checker ──> provider/run.sh git-remote pr-find  <issue-key> ──> { number, state }
+                └─> provider/run.sh git-remote pr-status <number>    ──> typed PR-state object
+                                                                       (state | mergeable | ci | reviewDecision)
+```

--- a/.autocode/design/0002-impl-epic-orchestrator/units/progress-union-gitattributes.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/units/progress-union-gitattributes.md
@@ -1,0 +1,67 @@
+---
+depends-on: []
+type: task
+---
+
+# Scaffold a union merge driver for PROGRESS.md
+
+## Summary
+
+During a parallel epic every dependent unit's rebase touches the shared, append-only `PROGRESS.md`, so the append conflict is the one high-frequency structural collision of the whole run. Git's built-in `union` low-level merge driver resolves append conflicts by keeping both sides with no markers, so a `.gitattributes` rule binding `PROGRESS.md` to `merge=union` makes that conflict auto-resolve at the git layer and a rebase never stops on it. One caveat makes this correct only with a seed: `union` is line-based, so it resolves cleanly only when `PROGRESS.md` already exists at the merge-base. Today the file is first created by the first unit's `impl-push` (`impl-push/SKILL.md`), so if two first-wave units each create it from scratch, `union` concatenates two `# Progress: <short>` headers into a duplicate with no conflict and no stop (the skill backstop never fires because `union` suppresses the conflict). This unit therefore does two things: (1) seed the `PROGRESS.md` header at design-folder creation so it is a common ancestor before any unit branches, and (2) scaffold the `.gitattributes` `merge=union` rule into the `/autocode-setup` and `/autocode-update` flows, modeled on the existing `<repo-root>/.autocode/.gitignore` reconciliation: create-if-missing, append-the-line-if-absent, idempotent. It is the git-layer half of decision 8; the `pr-rebase-auto` unit adds the complementary skill-level backstop for repos whose setup predates the rule, and the two touch disjoint files.
+
+## Implementation
+
+Deliverable: a `.gitattributes` `merge=union` rule for `PROGRESS.md` scaffolded idempotently by both bootstrap-inline skills, plus a seeded `PROGRESS.md` header at design-folder creation, so any repo gets append conflicts auto-resolved at the git layer with a common-ancestor file that keeps `union` clean.
+
+### Seed the PROGRESS.md header at design-folder creation
+
+For `union` to resolve cleanly, `PROGRESS.md` must exist at the epic's merge-base before any unit branches. Seed it where the design folder is authored, so it rides the design PR to `main`:
+
+- `autocode/design/skills/design-plan/` (folder authoring): when creating `.autocode/design/<id>-<short>/`, also write `.autocode/design/<id>-<short>/PROGRESS.md` containing exactly the `# Progress: <short>` header (the canonical format, `design-folder.md:125`) and nothing else. It merges to `main` with the design PR, becoming the common ancestor for every unit.
+- `autocode/design/skills/design-fanout/` (backfill): when fanning out a multi-unit epic, create the same header-only `PROGRESS.md` if absent (idempotent), covering epics whose folder predates this change. Flat single-unit designs need no seed (one unit, no concurrent append), so the seed is a no-op there.
+- `impl-push` is unchanged: it already creates `PROGRESS.md` if missing then appends; with the seed present it only ever appends, so its create branch becomes the backstop for repos on an older design layer.
+
+Confirm at implementation time whether `design-fanout` commits to the base or only creates issues; if it cannot commit to `main`, the `design-plan` seed (riding the design PR) is sufficient and the fanout backfill applies only to in-worktree authoring. State the single canonical header string once and reference it from both call sites so they cannot drift.
+
+### The rule and its location
+
+Land one line at `<repo-root>/.gitattributes`:
+
+```
+.autocode/design/**/PROGRESS.md merge=union
+```
+
+- Repo-root `.gitattributes` is where git looks for path-attribute rules that apply across the worktree; it is the simplest correct location and matches git's own lookup. The `.autocode/design/**/PROGRESS.md` glob is anchored to the repo root (not `AUTOCODE_CONFIG_DIR`), matching the design-folder spec: `PROGRESS.md` lives at `.autocode/design/<id>-<shortname>/PROGRESS.md` (`design-folder.md:7-9,42`), always under repo-root `.autocode/`, independent of where `AUTOCODE_CONFIG_DIR` points (`design-folder.md:53`). Same anchoring rationale the existing gitignore step uses for the repo-root artifact dir.
+- The repo currently has no `.gitattributes` (confirmed: no such file at the worktree root), so the rule is additive and never collides with an existing attribute line.
+- `union` is a git built-in driver requiring no `[merge "..."]` config in `.git/config`; the `.gitattributes` line alone is sufficient. Nothing else (no driver registration) is scaffolded.
+
+### Setup flow (`plugins/autocode/skills/autocode-setup/SKILL.md`)
+
+Extend the gitignore reconciliation step (currently the block at `SKILL.md:70-73`, "After writing, reconcile two ignore rules"). The reconciliation is model-driven inline prose, not a helper script (the `scripts/` dir holds only `clone.sh`, `init-config-dir.sh`, `write-settings.sh`; none touch `.gitignore`), so the `.gitattributes` rule is scaffolded the same way: an additional inline, idempotent reconcile step.
+
+- Add reconciliation of the `.autocode/design/**/PROGRESS.md merge=union` line in `<repo-root>/.gitattributes`: create the file with the line if missing; append the line only when absent; report unchanged otherwise. Same create-if-missing / append-if-absent shape as the existing `.gitignore` rules.
+- This is always the repo-root `.gitattributes`, unconditional on `AUTOCODE_CONFIG_DIR`, because `PROGRESS.md` always lives under repo-root `.autocode/`. Unlike the relocated-config-dir caveat on the `<repo-root>/.autocode/.gitignore` rule, there is no "only if the dir exists" guard: the repo root always exists.
+
+### Update flow (`plugins/autocode/skills/autocode-update/SKILL.md`)
+
+Extend the Gitignore reconcile step (currently step 2 item 3, `SKILL.md:53-55`) with the same `.gitattributes` line check, idempotent (append the line if missing), reporting only when changed. This keeps already-set-up repos current when they run `/autocode-update` after this change ships.
+
+### Single source for the rule text
+
+Both skill bodies must spell the identical glob and attribute (`.autocode/design/**/PROGRESS.md merge=union`). State it once as the canonical line and have the update flow reference the same string the setup flow writes, so the two cannot drift. Cite the design-folder `PROGRESS.md` location as the justification for the glob in both places.
+
+### Out of scope
+
+- The `pr-rebase` skill-level `PROGRESS.md` union resolution: owned by the `pr-rebase-auto` unit (decision 8, second half). This unit only scaffolds `.gitattributes`.
+- No change to `scripts/check-plugin-shape.sh`: its allowlist gates only skill/agent shim-vs-real shape and shellchecks `*.sh`; a `.gitattributes` data file is neither a skill, an agent, nor a shell script, so no allowlist entry is needed (`check-plugin-shape.sh:13-14,90-131`).
+- No change to `.github/workflows/ci.yml`: it has no `paths:` globs (runs `shape-check` on every PR and push) and the shape check does not inspect `.gitattributes`, so the new file needs no CI wiring (`ci.yml:3-25`).
+
+### Tests that prove it
+
+Per the design testing strategy (`DESIGN.md:110`):
+
+- Seeded common ancestor (the supported path): start from a base that already has the seeded header-only `PROGRESS.md` (the `design-plan`/`design-fanout` seed), construct two branches that each append a distinct timestamped block under `.autocode/design/<id>-<shortname>/PROGRESS.md`, with the `.gitattributes merge=union` rule present, rebase one onto the other, and assert both blocks survive with no `<<<<<<<` conflict markers, a single `# Progress: <shortname>` header, and the rebase does not stop. The header is unchanged common-ancestor context on both sides, so `union` keeps it once.
+- No-seed regression (the failure the seed prevents): with no `PROGRESS.md` at the base, two branches each create it (header + block) and rebase under `union`; assert the header appears twice. This documents why the seed is required and guards against dropping it.
+- Seed idempotency: running the `design-plan`/`design-fanout` seed twice writes the header exactly once and never clobbers an existing `PROGRESS.md` with appended blocks.
+
+Follow the existing `provider/` shell-test conventions for the harness shape.

--- a/.autocode/design/INDEX.md
+++ b/.autocode/design/INDEX.md
@@ -3,3 +3,4 @@
 | id | shortname | created | status |
 |------|-------------------|------------|----------|
 | 0001 | auto-archive-epics | 2026-06-04 | active |
+| 0002 | impl-epic-orchestrator | 2026-06-08 | active |


### PR DESCRIPTION
**Rendered design**

- [DESIGN.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/DESIGN.md)
- [units/impl-orchestrator-core.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-core.md)
- [units/impl-orchestrator-monitor.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/impl-orchestrator-monitor.md)
- [units/pr-status-provider.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/pr-status-provider.md)
- [units/pr-rebase-auto.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/pr-rebase-auto.md)
- [units/pr-ci-review-auto.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/pr-ci-review-auto.md)
- [units/progress-union-gitattributes.md](https://github.com/hhoikoo/autocode/blob/docs/design-impl-epic-orchestrator/.autocode/design/0002-impl-epic-orchestrator/units/progress-union-gitattributes.md)

## Overview

Turn `impl` from a one-unit launcher into a stateless, re-entrant epic orchestrator. Given a fanned-out design epic, it computes the dependency-ready set, launches a capped wave of per-unit background workflows (default 3 concurrent), refills as workflows finish, runs a separate monitoring pass that auto-rebases / fixes CI / triages reviews on the open PRs, and cascades into newly-unblocked units on each user-approved merge until the epic archives.

## Problem Statement

- The per-unit machinery exists, but nothing launches many units in parallel, keeps a concurrency cap full, or monitors the resulting PRs; each next unit is started by hand.
- There is no single provider call for PR mergeability/CI/review state, and the remediation skills (`pr-rebase`, `pr-fix-ci`, `pr-review`) stop for the user and return prose, so they cannot run unattended.
- `PROGRESS.md` is an append-only shared write that every dependent unit's rebase touches, with no mechanical conflict resolution.

## Architecture

```
main session: impl orchestrator (stateless, re-entrant)
  reconstruct state each turn from: issue tracker (unit/epic status)
  + this-session workflow-run tracking + INDEX.md
        |  ready set = todo units whose deps are all done
        v
  launch wave (cap=3, refill as slots free)
        |  impl-start --unit --auto -> impl-workflow.mjs (bg) -> opens unit PR -> in-review
        v
  on user command / cron: monitor-workflow.mjs (bg) -> one checker per in-review PR
        |  pr-status + --auto rebase / fix-ci / review (never merges)
        v
  present merge-ready PRs -> USER approves -> gh pr merge --admin
        |  unit done -> cascade: recompute ready set, launch unblocked
        v
  all units done -> impl-archive -> epic closed
```

Six units: `pr-status-provider` (normalized `pr-status`/`pr-find`), `pr-rebase-auto` and `pr-ci-review-auto` (`--auto` structured-return remediation modes), `progress-union-gitattributes` (union merge driver + header seed), `impl-orchestrator-core` (launch/cascade/archive + cap setting), and `impl-orchestrator-monitor` (monitor workflow, user-gated merge, notifications, opt-in cron). The `## Critique log` in DESIGN.md records the two refinement passes (cross-session re-entrancy bounds, restart safety, issue-key PR mapping, PROGRESS.md seeding).

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
```
n/a: this PR is a design document (text only); test cases land with each unit's implementation PR.
```
