### PR TITLE
ci: add design-doc issue autocreate action

### DIFF
--- a/.github/actions/design-fanout/action.yml
+++ b/.github/actions/design-fanout/action.yml
@@ -1,0 +1,81 @@
+name: 'Design fanout'
+description: 'Fan one merged design folder out into an epic issue plus a native sub-issue per unit (or a single issue for a flat design). Idempotent via body markers.'
+
+inputs:
+  design-dir:
+    description: 'Path to the design folder (.autocode/design/<id>-<short>).'
+    required: true
+  repo:
+    description: 'owner/name of the repository.'
+    required: true
+  sha:
+    description: 'Commit SHA for the Design: permalink (the merge commit).'
+    required: true
+  github-token:
+    description: 'Token for gh issue/label/GraphQL calls. Pass the workflow github.token.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Render issue bodies
+      id: render
+      shell: bash
+      env:
+        REPO: ${{ inputs.repo }}
+        SHA: ${{ inputs.sha }}
+        DIR: ${{ inputs.design-dir }}
+      run: |
+        set -euo pipefail
+        kind=$("${{ github.action_path }}/render-design-issues.sh" "${DIR}" "${REPO}" "${SHA}" "${RUNNER_TEMP}/issues")
+        echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+        echo "rendered ${kind} design ${DIR}:"
+        cat "${RUNNER_TEMP}/issues/manifest.tsv"
+
+    - name: Create or find epic issue
+      id: epic
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repo }}
+      run: |
+        set -euo pipefail
+        manifest="${RUNNER_TEMP}/issues/manifest.tsv"
+        IFS=$'\t' read -r _role _slug title type marker body \
+          < <(awk -F'\t' '$1=="epic" || $1=="flat"{print; exit}' "${manifest}")
+        num=$(gh api --paginate "/repos/${REPO}/issues?state=all&per_page=100" \
+          | jq -r --arg m "${marker}" \
+              '[ .[] | select(.pull_request | not) | select(.body != null and (.body | contains($m))) | .number ][0] // empty')
+        if [[ -n "${num}" ]]; then
+          echo "epic already exists: #${num}"
+        else
+          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}")
+          echo "created epic #${num}"
+        fi
+        node=$(gh api graphql -H "GraphQL-Features:sub_issues" \
+          -f query='query($o:String!,$n:String!,$num:Int!){repository(owner:$o,name:$n){issue(number:$num){id}}}' \
+          -f o="${REPO%%/*}" -f n="${REPO##*/}" -F num="${num}" --jq '.data.repository.issue.id')
+        echo "number=${num}" >> "$GITHUB_OUTPUT"
+        echo "node=${node}" >> "$GITHUB_OUTPUT"
+
+    - name: Create and link unit sub-issues
+      if: steps.render.outputs.kind == 'multi'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repo }}
+        EPIC_NUM: ${{ steps.epic.outputs.number }}
+        EPIC_NODE: ${{ steps.epic.outputs.node }}
+      run: |
+        set -euo pipefail
+        manifest="${RUNNER_TEMP}/issues/manifest.tsv"
+        linked=$(gh api --paginate "/repos/${REPO}/issues/${EPIC_NUM}/sub_issues" --jq '.[].body' 2>/dev/null || true)
+        while IFS=$'\t' read -r _role slug title type marker body; do
+          if printf '%s' "${linked}" | grep -qF "${marker}"; then
+            echo "unit ${slug} already linked; skip"
+            continue
+          fi
+          num=$("${{ github.action_path }}/create-design-issue.sh" "${REPO}" "${title}" "${type}" "${body}" "${EPIC_NODE}")
+          echo "created and linked unit ${slug} as #${num}"
+          sleep 1
+        done < <(awk -F'\t' '$1=="unit"' "${manifest}")

--- a/.github/actions/design-fanout/create-design-issue.sh
+++ b/.github/actions/design-fanout/create-design-issue.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Create one tracker issue from a rendered body, set its type, and optionally
+# link it as a native sub-issue of a parent epic. The design-fanout action calls
+# this once per epic and once per unit, passing the rendered body and (for units)
+# the epic's GraphQL node id.
+#
+# Type: set as a native Issue Type by name via a repo-scoped REST write, then
+# confirmed by reading it back. If the type did not take (the org defines no such
+# type, or none at all), a `type:<x>` label is applied as a fallback. Avoids the
+# org-scoped issue-types read, which the workflow GITHUB_TOKEN cannot perform.
+#
+# Usage:
+#   create-design-issue.sh <repo> <title> <type> <body-file> [parent-node-id]
+#
+# Prints the created issue number on stdout.
+
+set -euo pipefail
+
+repo="$1"
+title="$2"
+type="$3"
+body_file="$4"
+parent_node="${5:-}"
+
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+# Opaque GraphQL node id (I_kwDO...) for a given issue number; the REST integer id
+# is not a valid GraphQL ID and will not resolve in addSubIssue.
+node_id() {  # $1=issue number
+  # shellcheck disable=SC2016  # $-tokens are GraphQL variables, not shell expansions
+  gh api graphql -H "GraphQL-Features:sub_issues" \
+    -f query='query($o:String!,$n:String!,$num:Int!){repository(owner:$o,name:$n){issue(number:$num){id}}}' \
+    -f o="${owner}" -f n="${name}" -F num="$1" --jq '.data.repository.issue.id'
+}
+
+type_lower=$(printf '%s' "${type}" | tr '[:upper:]' '[:lower:]')
+# Issue Types are named in Title case (Bug, Task, ...); match that when setting.
+type_name=$(printf '%s' "${type_lower}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+
+num=$(gh issue create --repo "${repo}" --title "${title}" --body-file "${body_file}" | grep -oE '[0-9]+$')
+
+# Set the native Issue Type by name (repo-scoped); an unknown name is silently
+# dropped, so confirm by reading it back and fall back to a type:<x> label.
+gh api -X PATCH "/repos/${repo}/issues/${num}" -f type="${type_name}" >/dev/null 2>&1 || true
+applied=$(gh api "/repos/${repo}/issues/${num}" --jq '.type.name // empty' 2>/dev/null || true)
+if [[ -z "${applied}" ]]; then
+  gh label create "type:${type_lower}" --repo "${repo}" --force >/dev/null 2>&1 || true
+  gh issue edit "${num}" --repo "${repo}" --add-label "type:${type_lower}" >/dev/null
+fi
+
+if [[ -n "${parent_node}" ]]; then
+  child=$(node_id "${num}")
+  # shellcheck disable=SC2016  # $-tokens are GraphQL variables, not shell expansions
+  gh api graphql -H "GraphQL-Features:sub_issues" \
+    -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){subIssue{number}}}' \
+    -f p="${parent_node}" -f c="${child}" >/dev/null 2>&1 \
+    || echo "warning: created #${num} but could not link to parent epic" >&2
+fi
+
+printf '%s\n' "${num}"

--- a/.github/actions/design-fanout/render-design-issues.sh
+++ b/.github/actions/design-fanout/render-design-issues.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Render a merged design folder into tracker-issue body files plus a manifest,
+# with no API calls. The design-fanout action runs this before any issue is
+# published, so body rendering and issue creation stay separate stages.
+# Prints the design kind (flat | multi) on stdout.
+#
+# Usage: render-design-issues.sh <design-dir> <repo> <sha> <out-dir>
+#
+# Writes <out-dir>/manifest.tsv, one row per issue to create:
+#   role<TAB>slug<TAB>title<TAB>type<TAB>marker<TAB>body-file
+# role is epic | flat | unit. Body files live alongside the manifest.
+
+set -euo pipefail
+
+dir="$1"
+repo="$2"
+sha="$3"
+out="$4"
+
+mkdir -p "${out}"
+manifest="${out}/manifest.tsv"
+: > "${manifest}"
+
+base=$(basename "${dir}")
+id="${base%%-*}"
+short="${base#*-}"
+
+# ## Summary paragraph, stripped of leading/trailing blank lines.
+summary() {
+  awk '
+    /^## Summary[[:space:]]*$/ {f=1; next}
+    /^## / {f=0}
+    f {
+      if ($0 ~ /^[[:space:]]*$/) { if (seen) blanks++; next }
+      for (; blanks>0; blanks--) print ""
+      seen=1; print
+    }
+  ' "$1"
+}
+
+# Issue type from the file's `type:` frontmatter; empty if absent.
+fm_type() { awk 'NR==1 && $0=="---"{i=1;next} i && $0=="---"{exit} i && /^type:/{sub(/^type:[[:space:]]*/,"");print;exit}' "$1"; }
+
+# First `# ` H1 (the natural-language title); empty if the file has none.
+title() { awk '/^# /{sub(/^#[[:space:]]+/,"");print;exit}' "$1"; }
+
+# Body = summary paragraph, blank, Design: permalink, blank, marker.
+render_body() {  # $1=source-file $2=marker $3=out-file
+  {
+    summary "$1"
+    printf '\nDesign: https://github.com/%s/blob/%s/%s\n\n%s\n' "${repo}" "${sha}" "$1" "$2"
+  } > "$3"
+}
+
+row() { printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" >> "${manifest}"; }
+
+epic_marker="<!-- autocode:epic=${id} -->"
+
+if [[ -d "${dir}/units" ]]; then
+  etitle=$(title "${dir}/DESIGN.md"); etitle="${etitle:-${short}}"
+  ebody="${out}/epic.md"
+  render_body "${dir}/DESIGN.md" "${epic_marker}" "${ebody}"
+  row epic "${short}" "${etitle}" epic "${epic_marker}" "${ebody}"
+
+  for unit in "${dir}"/units/*.md; do
+    [[ -f "${unit}" ]] || continue
+    slug=$(basename "${unit}" .md)
+    umarker="<!-- autocode:unit=${id}/${slug} -->"
+    utitle=$(title "${unit}"); utitle="${utitle:-${slug}}"
+    utype=$(fm_type "${unit}"); utype="${utype:-task}"
+    ubody="${out}/unit-${slug}.md"
+    render_body "${unit}" "${umarker}" "${ubody}"
+    row unit "${slug}" "${utitle}" "${utype}" "${umarker}" "${ubody}"
+  done
+  echo multi
+else
+  ftitle=$(title "${dir}/DESIGN.md"); ftitle="${ftitle:-${short}}"
+  ftype=$(fm_type "${dir}/DESIGN.md"); ftype="${ftype:-task}"
+  fbody="${out}/epic.md"
+  render_body "${dir}/DESIGN.md" "${epic_marker}" "${fbody}"
+  row flat "${short}" "${ftitle}" "${ftype}" "${epic_marker}" "${fbody}"
+  echo flat
+fi

--- a/.github/workflows/autocreate-design-doc-issue.yml
+++ b/.github/workflows/autocreate-design-doc-issue.yml
@@ -1,0 +1,107 @@
+# GitHub Action: autocreate tracker issues from a newly merged design doc.
+#
+# On a merged PR that ADDS a new .autocode/design/<id>-<short>/DESIGN.md, create
+# one epic issue plus a native sub-issue per unit (or a single issue for a flat
+# design with no units/). No AI. Bodies, markers, and native sub-issue links match
+# autocode/design/design-folder.md, so impl-start discovery matches the manual
+# /design-fanout skill. Idempotent: an epic/unit whose marker already exists is
+# skipped, so re-runs and edits never duplicate.
+#
+# Detection (dorny) and creation are separate jobs; each design folder is its own
+# matrix leg calling the .github/actions/design-fanout composite action, so
+# concurrent merges never cross-create.
+#
+# Install: copy this file to <repo>/.github/workflows/ and the
+# .github/actions/design-fanout/ directory to <repo>/.github/actions/. Requires
+# the default GITHUB_TOKEN.
+#
+# The <!-- autocode:epic=... --> / <!-- autocode:unit=... --> body markers are the
+# discovery contract; do not rename them.
+
+name: autocreate design doc issue
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Detect New Design Docs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    outputs:
+      any: ${{ steps.scan.outputs.any }}
+      dirs: ${{ steps.scan.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            design:
+              - '.autocode/design/**'
+
+      - name: List newly added design folders
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          DESIGN: ${{ steps.filter.outputs.design }}
+        run: |
+          set -euo pipefail
+          if [[ "${DESIGN}" != "true" ]]; then
+            echo "any=false" >> "${GITHUB_OUTPUT}"
+            echo "dirs=[]" >> "${GITHUB_OUTPUT}"
+            echo "no design files changed in this PR"
+            exit 0
+          fi
+          dirs=$(gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
+            --jq '.[] | select(.status=="added") | .filename' \
+            | sed -nE 's#^(\.autocode/design/[^/]+)/DESIGN\.md$#\1#p' | sort -u \
+            | jq -R . | jq -sc 'map(select(. != ""))')
+          if [[ "${dirs}" == "[]" ]]; then
+            echo "any=false" >> "${GITHUB_OUTPUT}"
+            echo "dirs=[]" >> "${GITHUB_OUTPUT}"
+            echo "no newly added design doc in this PR"
+          else
+            echo "any=true" >> "${GITHUB_OUTPUT}"
+            echo "dirs=${dirs}" >> "${GITHUB_OUTPUT}"
+            echo "new design folders: ${dirs}"
+          fi
+
+  create:
+    name: Create Design Doc Issues
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    # Serialize any two runs that touch the SAME design folder (e.g. a re-run of
+    # the same PR mid-flight) so the find_epic check can never race itself into a
+    # duplicate epic. Different folders keep running in parallel.
+    concurrency:
+      group: autocreate-design-doc-issue-${{ matrix.dir }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJSON(needs.changes.outputs.dirs) }}
+
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Fan out design folder into issues
+        uses: ./.github/actions/design-fanout
+        with:
+          design-dir: ${{ matrix.dir }}
+          repo: ${{ github.repository }}
+          sha: ${{ github.event.pull_request.merge_commit_sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Overview

Install the mechanical design-doc issue autocreate GitHub Action into autocode's own `.github/`, dogfooding the template that `/autocode-setup` copies into adopting repos.

## Problem Statement

- autocode ships the fan-out Action as a template but never installed it on itself, so merged design PRs (e.g. #11, #14) did not auto-create epic/unit issues.
- The manual `/design-fanout` skill was the only path; the Action removes that step for this repo.

## Implementation Notes

- Copied verbatim from `plugins/autocode/templates/autocreate-design-doc-issue/`:
  - workflow `.github/workflows/autocreate-design-doc-issue.yml`
  - composite action `.github/actions/design-fanout/` (`action.yml`, `render-design-issues.sh`, `create-design-issue.sh`)
- Triggers on any merged PR, gates on a newly-added `DESIGN.md`. Uses default `GITHUB_TOKEN`. Idempotent via `autocode:epic` / `autocode:unit` body markers.

## Checklist (if applicable)

* [x] PR name with proper formatting
* [ ] Test case(s): n/a, mechanical install of an existing template; verified via `scripts/check-plugin-shape.sh` + `shellcheck`
* [x] Documentation added or modified appropriately (install path already documented in `autocode-setup`)
