### PR TITLE
chore: add .worktreeinclude for local settings

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,15 @@
+# Gitignored files to copy into new worktrees (gitignore syntax).
+# Only gitignored/untracked files matching these patterns are copied; tracked
+# files always come with the worktree. Applies to --worktree, subagent
+# isolation: worktree, and desktop parallel sessions.
+# Docs: https://code.claude.com/docs/en/worktrees
+
+# Local Claude Code + autocode settings (permissions, env overrides).
+# Per-worktree work breaks without them.
+.claude/settings.local.json
+.autocode/settings.local.json
+
+# Local environment / secrets for tooling, if present.
+.env
+.env.local
+.envrc


### PR DESCRIPTION
## Overview

Add a `.worktreeinclude` so Claude Code copies gitignored local config into new worktrees.

## Problem Statement

- Worktrees (`--worktree`, subagent `isolation: worktree`, desktop parallel sessions) start without gitignored files, so `.claude/settings.local.json` and `.autocode/settings.local.json` (permissions, env overrides) are missing and per-worktree work breaks.

## Implementation Notes

- `.worktreeinclude` at repo root, gitignore syntax (per docs: https://code.claude.com/docs/en/worktrees).
- Patterns: `.claude/settings.local.json`, `.autocode/settings.local.json`, plus `.env` / `.env.local` / `.envrc` (copied only if present).
- Only gitignored files are eligible; tracked files always come with the worktree.

## Checklist (if applicable)

* [x] PR name with proper formatting
* [ ] Test case(s): n/a, single config file
* [x] Documentation: self-documenting header in the file
