### PR TITLE
feat(#19): Add --auto flag to pr-fix-ci and pr-review

### DIFF
--- a/.autocode/design/0002-impl-epic-orchestrator/PROGRESS.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/PROGRESS.md
@@ -5,3 +5,9 @@
 PR: TBD  Unit: #21
 
 Added two GitHub provider scripts: `pr-find.sh` (resolves a PR URL from a branch name via the GitHub API) and `pr-status.sh` (polls a PR's merge status and CI check rollup, blocking until all checks are complete or a timeout is hit). Fixed a bug where `StatusContext` entries (commit-status API, `.state` field only) were misclassified as pending because the guard did not require `.status != null`, causing the monitor to wait indefinitely for legacy checks.
+
+## pr-ci-review-auto — 2026-06-08
+
+PR: TBD  Unit: #19
+
+Added `--auto` flag to both `pr-fix-ci` and `pr-review` skills. Under `--auto`, each skill runs unattended (no `AskUserQuestion`), handles discussion-band comments by deferring them instead of prompting, and emits a structured terminal result block (`{ pr, fixed, ci, needs_human, reason }` for `pr-fix-ci`; `{ pr, applied, deferred, needs_human, reason }` for `pr-review`) so an orchestrator can branch on the outcome without parsing prose output.

--- a/.autocode/design/0002-impl-epic-orchestrator/progress/pr-ci-review-auto.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/progress/pr-ci-review-auto.md
@@ -1,0 +1,3 @@
+# pr-ci-review-auto
+
+Epic: 0002-impl-epic-orchestrator  Branch: feat/19/pr-ci-review-auto  Started: 2026-06-08

--- a/autocode/pr/skills/pr-fix-ci/SKILL.md
+++ b/autocode/pr/skills/pr-fix-ci/SKILL.md
@@ -5,16 +5,17 @@ Diagnose failing CI checks and apply minimal fixes.
 ## Args
 
 `[PR number]` (default: detect from current branch).
+- `--auto`: run unattended (no `AskUserQuestion`) and end with a structured result block instead of the human report.
 
 ## Workflow
 
 1. Resolve PR (arg or `provider/run.sh git-remote pr-view --json number`).
-2. List checks: `provider/run.sh ci pr-check-list <pr>`. Green when every check's `bucket` is `pass` or `skipping`; if so, report and stop. A `pending` bucket means CI is still running, not failing.
+2. List checks: `provider/run.sh ci pr-check-list <pr>`. Green when every check's `bucket` is `pass` or `skipping`; if so, report and stop. A `pending` bucket means CI is still running, not failing. (Under `--auto`, a `pending` rollup does not halt with prose; it ends the run with the terminal block `ci: "pending"`, `fixed: false`, `needs_human: false`.)
 3. For each failing check:
    - Fetch the failure log: `provider/run.sh ci run-view-failed <run-id>`. The script already caps to the last 200 lines of the failing step.
    - Diagnose: classify as lint / build / test / workflow. Read the source or config files referenced in the failure.
 4. Apply the minimal fix.
-5. Verify locally: read the verify command from `$AUTOCODE_CONFIG_DIR/conventions/build.md`. Run it. If the convention file is missing, stop and instruct the user to run `/autocode-setup`. Do not infer the command from `package.json` or `Makefile`; if the convention says nothing, halt.
+5. Verify locally: read the verify command from `$AUTOCODE_CONFIG_DIR/conventions/build.md`. Run it. If the convention file is missing, stop and instruct the user to run `/autocode-setup`. Do not infer the command from `package.json` or `Makefile`; if the convention says nothing, halt. (Under `--auto`, a missing `build.md` does not stop with the `/autocode-setup` message; it ends the run with the terminal block `needs_human: true`, `reason` naming the missing convention.)
 6. Delegate commit to `git-commit` (handles push too if upstream tracks).
 7. Watch CI start: `provider/run.sh ci run-list --branch <branch> --limit 1`. Report.
 
@@ -22,7 +23,17 @@ Diagnose failing CI checks and apply minimal fixes.
 
 - Don't skip local verification before pushing.
 - One commit per logical fix (group lint fixes together, but separate from test fixes).
-- If a failure is not branch-caused (flaky network, infra outage), report and stop. Don't guess at a fix.
-- Never `--no-verify`.
+- If a failure is not branch-caused (flaky network, infra outage), report and stop. Don't guess at a fix. (Under `--auto`, instead of stopping with prose, end with the terminal block `needs_human: true`, `reason` describing the flaky/infra cause. Same for a verify failure the skill cannot minimally fix.)
+- Never `--no-verify`. This rule holds under `--auto`.
+
+## Terminal step (--auto only)
+
+Under `--auto`, emit the structured result as the skill's terminal output, replacing the step-7 human report:
+
+```
+{ pr, fixed: bool, ci: "green" | "red" | "pending", needs_human: bool, reason }
+```
+
+`ci`: the post-fix rollup from `provider/run.sh ci pr-check-list` (`green` when every bucket is `pass`/`skipping`, `pending` while running, `red` otherwise). `fixed`: true when a fix was committed and pushed this run. `needs_human`/`reason` per the stops above (`reason` empty/omitted when `needs_human` is false).
 
 $ARGUMENTS

--- a/autocode/pr/skills/pr-review/SKILL.md
+++ b/autocode/pr/skills/pr-review/SKILL.md
@@ -5,6 +5,7 @@ Triage and apply PR review comments.
 ## Args
 
 `[PR number]` (default: detect from current branch via `provider/run.sh git-remote pr-view --json number,url`).
+- `--auto`: run unattended (no `AskUserQuestion`) and end with a structured result block instead of the human report.
 
 ## Workflow
 
@@ -30,6 +31,8 @@ Triage and apply PR review comments.
    | 30-69 | Optional; fix if trivial, else resolve with explanation |
    | 0-29 | Resolve as spurious |
 
+   Under `--auto`, the discussion band (`20-49` human / `30-69` bot) does not reply asking for clarification: defer it. Count it toward `deferred`, leave the thread for a human, and set `needs_human`. The fix band and the spurious-resolve band are unchanged: high-confidence items still fix-and-resolve, low-confidence items still resolve with an explanation comment.
+
 4. Apply valid fixes. Group related fixes. Delegate commits to the `git-commit` skill. Never `--no-verify`.
 5. Reply and resolve threads:
    - `provider/run.sh git-remote pr-comment-reply <pr> <comment-id> "<text>"` for each comment that needs a reply.
@@ -43,5 +46,16 @@ Triage and apply PR review comments.
 - Bots are skeptical by default; Copilot suggestions often miss context.
 - Never `--no-verify` on commits.
 - Never resolve a thread without an explanation comment.
+- Under `--auto`, the no-explanation-before-resolve and never-`--no-verify` rules still hold.
+
+## Terminal step (--auto only)
+
+Under `--auto`, emit the structured result as the skill's terminal output, replacing the step-6 triage table:
+
+```
+{ pr, applied: int, deferred: int, needs_human: bool, reason }
+```
+
+`applied`: comments fixed-and-resolved this run. `deferred`: comments left for a human. `needs_human`: `deferred > 0`. `reason` summarizes the deferred set (empty/omitted when none).
 
 $ARGUMENTS


### PR DESCRIPTION
## Overview

Adds `--auto` flag to both `pr-fix-ci` and `pr-review` skills so an orchestrator can drive them unattended. Each skill now emits a structured terminal result block instead of a human-readable report when `--auto` is passed.

## Problem Statement

- The impl epic orchestrator runs `pr-fix-ci` and `pr-review` as sub-phases and needs machine-parseable output to branch on outcomes without parsing prose.
- Under `--auto`, discussion-band comments must defer instead of prompting; infra failures must set `needs_human` rather than halting with instructions.
- Both skills must still enforce all safety rules (`--no-verify` ban, explain-before-resolve) under `--auto`.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #19