### PR TITLE
feat(#27): Add --auto flag to design-fanout skill

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/PROGRESS.md
+++ b/.autocode/design/0003-design-unit-workflow/PROGRESS.md
@@ -1,0 +1,9 @@
+# Progress: design-unit-workflow
+
+## design-fanout-auto — 2026-06-08
+
+Unit: #27
+
+Added `--auto` flag support to the `design-fanout` skill. The flag enables unattended execution: strict arg resolution (no implicit most-recent default, no `AskUserQuestion` prompts), a structured result block on the success path (`needs_human`, `epic_key`, `sub_issues`), and an early-exit `needs_human: true` block when the id is absent, unknown, or ambiguous. The result block key values are typed as strings (not numbers) to match the provider contract.
+
+Notes: Two fix commits landed after initial impl to correct the structured result block definition and key types.

--- a/.autocode/design/0003-design-unit-workflow/progress/design-fanout-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/progress/design-fanout-auto.md
@@ -1,0 +1,3 @@
+# design-fanout-auto
+
+Epic: 0003-design-unit-workflow  Branch: feat/27/design-fanout-auto  Started: 2026-06-08

--- a/autocode/design/skills/design-fanout/SKILL.md
+++ b/autocode/design/skills/design-fanout/SKILL.md
@@ -6,13 +6,18 @@ Layout, markers, and labels: `@~/.autocode/autocode/design/design-folder.md`. Th
 
 ## Args
 
-`<id | shortname>` (the design folder prefix or suffix). Default: the most recent folder under `.autocode/design/`. On ambiguity, ask via `AskUserQuestion`.
+- `<id | shortname>`: the design folder prefix or suffix. Default: the most recent folder under `.autocode/design/`. On ambiguity, ask via `AskUserQuestion`.
+- `--auto`: run unattended (no `AskUserQuestion`); the id is required (no implicit most-recent); an absent, unknown, or ambiguous arg returns `needs_human: true` and creates nothing; the final report is the structured result block (below) in place of the step-4 prose table. Interactive behavior is unchanged when `--auto` is absent.
 
 ## Discovery
 
 - Glob `.autocode/design/<id>-*` or `*-<shortname>`. Resolve to one folder; read its `DESIGN.md` and any `units/*.md`.
 - Derive `<id>` and `<shortname>` from the folder name.
 - Multi-unit if `units/` exists and is non-empty; flat otherwise.
+- Under `--auto`, resolution is strict. If the arg is absent, matches no folder, or matches more than one folder, do not prompt and do not glob a default; stop before the step-1 permalink base and step-2 idempotency call and emit `{ needs_human: true, epic_key: "", sub_issues: [], reason: <names the missing/unknown id or the candidate folders> }`. Default mode keeps the most-recent default and the `AskUserQuestion` disambiguation verbatim.
+
+   Success-path structured result block (emitted by step 4 under `--auto`):
+   `{ needs_human: false, epic_key: <number>, sub_issues: [{ slug: <slug>, number: <number>, status: "created" | "existing" }], reason: "" }`
 
 ## Workflow
 
@@ -28,7 +33,7 @@ Layout, markers, and labels: `@~/.autocode/autocode/design/design-folder.md`. Th
 
    Flat (no `units/`):
    - One issue (if `autocode:epic=<id>` marker absent): body from `DESIGN.md` `## Summary` + permalink + `<!-- autocode:epic=<id> -->`. `provider/run.sh issue-tracker issue-create -t <DESIGN.type> -s "<DESIGN.md H1>" -b "<body>"`. No parent. This issue is both epic and unit.
-4. Report a table: each issue's role (epic / unit slug), number, and created-or-existing.
+4. Report. Default: a table of each issue's role (epic / unit slug), number, and created-or-existing. With `--auto`: emit the success structured result block (`needs_human: false`, `epic_key`, `sub_issues`) in place of the table.
 
 ## Rules
 

--- a/autocode/design/skills/design-fanout/SKILL.md
+++ b/autocode/design/skills/design-fanout/SKILL.md
@@ -17,7 +17,7 @@ Layout, markers, and labels: `@~/.autocode/autocode/design/design-folder.md`. Th
 - Under `--auto`, resolution is strict. If the arg is absent, matches no folder, or matches more than one folder, do not prompt and do not glob a default; stop before the step-1 permalink base and step-2 idempotency call and emit `{ needs_human: true, epic_key: "", sub_issues: [], reason: <names the missing/unknown id or the candidate folders> }`. Default mode keeps the most-recent default and the `AskUserQuestion` disambiguation verbatim.
 
    Success-path structured result block (emitted by step 4 under `--auto`):
-   `{ needs_human: false, epic_key: <number>, sub_issues: [{ slug: <slug>, number: <number>, status: "created" | "existing" }], reason: "" }`
+   `{ needs_human: false, epic_key: <key>, sub_issues: [{ slug: <slug>, key: <key>, status: "created" | "existing" }], reason: "" }`
 
 ## Workflow
 


### PR DESCRIPTION
## Overview

Adds `--auto` flag to the `design-fanout` skill to support unattended orchestrated execution. When `--auto` is passed, the skill requires an explicit design id (no implicit most-recent default), uses strict resolution (no `AskUserQuestion` prompts), and emits a structured result block instead of a prose table.

## Problem Statement

- The `design-fanout` skill had no machine-friendly output mode, blocking orchestrators from driving it programmatically.
- Ambiguity resolution relied on interactive `AskUserQuestion`, which hangs unattended agents.
- No structured result block meant callers could not reliably extract `epic_key` and `sub_issues` for downstream chaining.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #27