### PR TITLE
feat(#17): Rewrite impl as stateless epic orchestrator

### DIFF
--- a/.autocode/design/0002-impl-epic-orchestrator/PROGRESS.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/PROGRESS.md
@@ -26,3 +26,11 @@ Added two GitHub provider scripts: `pr-find.sh` (resolves a PR URL from a branch
 PR: TBD  Unit: #19
 
 Added `--auto` flag to both `pr-fix-ci` and `pr-review` skills. Under `--auto`, each skill runs unattended (no `AskUserQuestion`), handles discussion-band comments by deferring them instead of prompting, and emits a structured terminal result block (`{ pr, fixed, ci, needs_human, reason }` for `pr-fix-ci`; `{ pr, applied, deferred, needs_human, reason }` for `pr-review`) so an orchestrator can branch on the outcome without parsing prose output.
+
+## impl-orchestrator-core — 2026-06-08
+
+PR: TBD  Unit: #17
+
+Rewrote the `impl` skill from a single-unit launcher into a stateless, re-entrant epic orchestrator. The orchestrator reconstructs all state each turn from the tracker (done / in-review / todo) and the session's live run ids; reconciles by PR existence via `pr-find` rather than tracker status alone; launches a capped wave of per-unit background workflows under `impl.max-concurrent-units`; refills empty slots on completion; prunes merged worktrees; and triggers `impl-archive` when every unit is done. Single-unit invocations retain their existing contract unchanged. Added the `impl.max-concurrent-units` setting to `settings-schema.md` and updated `autocode/impl/CLAUDE.md` with the new epic-orchestrator entry point and routing rules.
+
+Notes: The monitoring, merge-gating, and cron sub-units (`impl-orchestrator-monitor`, `impl-orchestrator-notify`, `impl-cron`) are separate units in this epic and depend on this one.

--- a/.autocode/design/0002-impl-epic-orchestrator/progress/impl-orchestrator-core.md
+++ b/.autocode/design/0002-impl-epic-orchestrator/progress/impl-orchestrator-core.md
@@ -1,0 +1,3 @@
+# impl-orchestrator-core
+
+Epic: 0002-impl-epic-orchestrator  Branch: feat/17/impl-orchestrator-core  Started: 2026-06-08

--- a/autocode/_config/settings-schema.md
+++ b/autocode/_config/settings-schema.md
@@ -11,6 +11,7 @@ Each key has exactly one home. No merging, no precedence rules. Scope is determi
 |---|---|---|
 | `provider.*` | shared | `settings.json` |
 | `paths.*` | local | `settings.local.json` |
+| `impl.*` | shared | `settings.json` |
 
 `/autocode-setup` writes `AUTOCODE_CONFIG_DIR` into a Claude Code settings file (`.claude/settings.json` for the in-repo default, `.claude/settings.local.json` otherwise) so readers can locate the config dir from any session.
 
@@ -21,6 +22,7 @@ Each key has exactly one home. No merging, no precedence rules. Scope is determi
 | `provider.issue-tracker` | string | (required) | Which issue-tracker provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/issue-tracker/<value>/<feature>.sh`. Supported values: `github`. |
 | `provider.git-remote` | string | (required) | Which git-remote provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/git-remote/<value>/<feature>.sh`. Supported values: `github`. |
 | `provider.ci` | string | value of `provider.git-remote` | Which ci provider scripts to dispatch to. Resolved by `provider/run.sh` as `provider/ci/<value>/<feature>.sh`. When unset or empty, the dispatcher falls back to `provider.git-remote`. Supported values: `github`. |
+| `impl.max-concurrent-units` | integer | `3` | Max concurrently-running per-unit workflows the epic orchestrator launches. Lower on constrained machines. Read by the `impl` orchestrator skill. |
 
 ## Local keys (`settings.local.json`)
 

--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -1,8 +1,8 @@
 # impl/
 
-Implementation phase. Worktree-bound skills drive a single unit of work from an approved design to a pushed branch.
+Implementation phase. Worktree-bound skills drive a fanned-out design epic to completion; each per-unit worktree still carries one unit from design to pushed branch.
 
-`impl` is the orchestrator. It sets up the worktree via `impl-start` (the one interactive step), then launches a background workflow (`skills/impl/scripts/impl-workflow.mjs`, run via the Workflow tool) that carries the unit through plan -> execute -> review -> challenge -> decide -> fix -> push -> hygiene, each phase its own agent with a per-phase model (opus for reasoning and review, sonnet for mechanical work). The workflow does the fan-out the per-phase skills cannot, since subagents cannot spawn subagents. The heavy work stays out of the launching session.
+`impl` is the stateless, re-entrant epic orchestrator. Given a fanned-out epic it reconstructs unit state from the tracker each turn, computes the dependency-ready set, launches per-unit background workflows (`skills/impl/scripts/impl-workflow.mjs`, run via the Workflow tool) under a concurrency cap (`impl.max-concurrent-units`, default 3), refills as they finish, cascades on user merge, prunes merged worktrees, and triggers `impl-archive` when every unit is done. A bare ticket / `<type>: <desc>` keeps the single-unit launch. Each workflow carries its unit through plan -> execute -> review -> challenge -> decide -> fix -> push -> hygiene, each phase its own agent with a per-phase model (opus for reasoning and review, sonnet for mechanical work). The workflow does the fan-out the per-phase skills cannot, since subagents cannot spawn subagents. The heavy work stays out of the launching session. The `## Monitoring` seam is filled by the `impl-orchestrator-monitor` unit (room for its workflow/skill entries).
 
 The per-phase skills are also usable on their own:
 - `impl-start`: pick a DAG-ready unit, set up the worktree + branch + `.impl-context`.

--- a/autocode/impl/skills/impl/SKILL.md
+++ b/autocode/impl/skills/impl/SKILL.md
@@ -1,34 +1,80 @@
 # Impl
 
-Orchestrate one design unit end to end: set up the worktree, then run plan -> execute -> review -> fix -> push -> hygiene as a background workflow, keeping the heavy work out of this session. Thin launcher: the phase logic lives in the delegated skills and the workflow script, not here.
-
-The workflow runs each phase as its own agent with a per-phase model (opus for reasoning and review, sonnet for mechanical work) and does the fan-out the per-phase skills cannot (subagents cannot spawn subagents). Design-folder layout, `.impl-context` keys, and the unit DAG: `@~/.autocode/autocode/design/design-folder.md`.
+Stateless, re-entrant epic orchestrator. Holds no durable state; reconstructs all state each turn from the tracker (cross-session source of truth for done / in-review / todo) and this session's launched run ids (session-scoped running set). Given a fanned-out design epic it launches a capped wave of per-unit background workflows, refills as they finish, cascades on user merge, prunes merged worktrees, and archives when every unit is done. Bare-ticket invocations keep the single-unit launch. Per-phase skills stay individually invocable. Design-folder layout, `.impl-context` keys, and the unit DAG: `@~/.autocode/autocode/design/design-folder.md`.
 
 ## Args
 
-- A unit selector forwarded to `impl-start`: `--from-design <id|shortname>`, a `<ticket-id>`, or `<type>: <description>`. Optional when the current directory is already a set-up unit worktree.
-- `--dims <list>`: review dimensions, forwarded to the review phase.
+- `--from-design <id|shortname>`: epic mode. Resolves the design folder and drives the full wave/cascade/archive cycle.
+- Bare `<ticket-id>` / `<type>: <description>`: single-unit launch (unchanged contract). Optional when cwd is already a set-up unit worktree (epic mode if its `.impl-context` resolves an epic; else single-unit).
+- `--dims <list>`: review dimensions, forwarded to each launched `impl-workflow`.
 
 ## Workflow
 
-1. Set up the unit. If the current directory is already an autocode worktree on a feature branch with `.autocode/.impl-context`, reuse it. Otherwise delegate to `impl-start` (interactive: it presents the ready units and creates the worktree + branch + context). This is the only interactive step; capture the worktree path, `slug`, `unit_key`, and `design_id` from its report.
+### Route args
 
-2. Resolve the workflow inputs:
-   - `homeDir`: `echo "$HOME"`.
-   - `base`: the repo's default branch (`git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/` prefix stripped; fall back to the local default branch).
-   - `worktree` and `slug` from step 1; `dims` from `--dims` when given. The `unit_key` and `design_id` are not passed: every phase runs inside the worktree and reads them from `.autocode/.impl-context` (written by `impl-start`).
+First: classify the invocation.
 
-3. Launch the workflow. Call the Workflow tool with:
-   - `scriptPath`: `<homeDir>/.autocode/autocode/impl/skills/impl/scripts/impl-workflow.mjs` (resolve `<homeDir>` from step 2).
-   - `args`: `{ homeDir, worktree, slug, base, dims }`.
-   The script runs every phase in the background with per-phase models. This session does not run the implementation, review, or PR work; it waits for the workflow to finish.
+- `--from-design <id|shortname>` -> epic mode.
+- Cwd is an autocode worktree on a feature branch with `.autocode/.impl-context` -> epic mode when `.impl-context` resolves an epic; else single-unit.
+- Bare `<ticket-id>` / `<type>: <description>` -> single-unit launch.
 
-4. Report the workflow's final result: PR URL, branch, number of fix rounds, any remaining `Important` findings, and the review tally. Next step: `/pr-review` when reviews land.
+A flat design (no `units/`) under `--from-design` collapses to a wave of one; archive still runs when it is done.
+
+### Single-unit branch
+
+Retain today's contract. `impl-start` (interactive) -> capture worktree path, `slug`, `unit_key`, `design_id`. Resolve `homeDir` (`echo "$HOME"`); resolve `base` (`git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/` prefix stripped; fall back to the local default branch). Launch one `Workflow` over `impl-workflow.mjs` with `args: { homeDir, worktree, slug, base, dims }`. Report the PR URL on completion. No cascade, no archive.
+
+### Epic discovery (re-run every turn, no caching)
+
+1. Resolve the epic from `.autocode/design/INDEX.md` active rows plus the `--from-design` selector; glob the folder `.autocode/design/<id>-<short>/`.
+2. `provider/run.sh issue-tracker issue-epic-list --epic <id>` -> per-unit `{key, summary, status, type, parent}` plus the epic row, matched by marker. `issue-epic-list` does not return `depends-on`.
+3. Read each unit's `depends-on` from `.autocode/design/<id>-<short>/units/<slug>.md` frontmatter.
+
+### Reconciliation
+
+Resolve each unit's PR up front with `provider/run.sh git-remote pr-find <issue-key>` (the `Closes`-link lookup), because tracker status can lag a run that died between push and the status flip. Classify each unit:
+
+- `done`: sub-issue closed.
+- `in-review`: an open PR exists for the sub-issue key (trust the PR over a stale `in-progress` status). Recover the worktree path from `git worktree list --porcelain` by matching the `/<key>/` segment of each branch (`<type>/<key>/<short>`; the shortname tail is a non-reproducible slug).
+- `running`: `in-progress`, no open PR, with a live run id launched this session and not yet seen complete.
+- `needs-recovery`: `in-progress`, no open PR, no live run this session. Surface with a restart choice. `Workflow` `resumeFromRunId` only when the run id belongs to this session (same-session-only contract); otherwise restart. Restart cleans up: `git worktree remove --force <path>`, delete the leftover branch, transition the sub-issue back to `todo`; the unit re-enters the ready set and launches fresh next wave. Never silently relaunch over a run still live this session.
+
+### Ready set
+
+`todo` units whose every `depends-on` slug maps to a `done` unit.
+
+### Capped wave launch
+
+Read `impl.max-concurrent-units` (default `3`) from `$AUTOCODE_CONFIG_DIR/settings.json`. Slots = cap minus running count (run ids this session launched and not yet seen complete). Cap is per-session-orchestrator; two epics in one session contend on the same cap.
+
+For each ready unit up to `slots`: `impl-start --unit <slug> --auto` capturing the structured block (worktree path, branch, slug, unit_key, epic_key, design_id), then a background `Workflow` over `impl-workflow.mjs` with `args: { homeDir, worktree, slug, base, dims }`. Record each returned run id in working context (the session-scoped running-set evidence). Report the launched wave and queued remainder; never silently truncate.
+
+### Self-sustaining refill
+
+Each per-unit workflow runs in the background. On completion the harness re-invokes the main loop via `<task-notification>`; on re-entry re-run discovery + reconciliation and refill empty slots from the ready set, no user input, until the cap cannot be filled (all remaining units blocked or in-flight). Refill relies on idle-loop re-invocation (the `Workflow` tool contract asserts it).
+
+### Merge-driven cascade
+
+When a unit's PR merges (unit -> `done`), in the same turn recompute the ready set over newly-unblocked units, prune each merged unit's worktree, and launch the next wave under the cap.
+
+### Worktree pruning
+
+Prefer `ExitWorktree`; a merged unit's worktree is typically not the current session's, so the fallback is `git worktree remove <path>` per `@~/.autocode/autocode/_config/guides/worktree.md`. `ExitWorktree` only removes worktrees it created this session; a worktree merged from another session falls to the bare-git path.
+
+### Archive trigger
+
+When every unit is `done`, invoke `impl-archive` passing the epic id explicitly so its multiple-active-epic `AskUserQuestion` never fires. `impl-archive` self-merges its PR and closes the epic.
+
+## Monitoring
+
+This unit launches and cascades but does not monitor or merge. The `impl-orchestrator-monitor` unit (depends on this) fills this section with `monitor-workflow`, the user-gated merge, notifications, and opt-in cron. This heading is the integration point.
 
 ## Rules
 
-- Thin launcher. Do not implement, review, or open PRs inline; the workflow's agents run the delegated skills (`impl-plan`, `impl-execute`, the `impl-critique-*` skills, `impl-push`).
-- Unit selection and worktree setup are `impl-start`'s job and run interactively in this session. Everything after is the workflow's job: background, model-pinned, out of this context.
-- One unit per invocation. Re-run to start the next ready unit.
+- Stateless and re-entrant. Reconstruct state each turn from the tracker (done / in-review / todo) and this session's run ids (running); never from durable orchestrator storage.
+- Reconcile by PR existence (`pr-find <issue-key>`), not tracker status alone, before any worktree/branch deletion. Never relaunch over a run live in this session.
+- Cross-session `in-progress` with no live run -> restart (clean up worktree + branch, reset sub-issue to `todo`), not resume. `resumeFromRunId` only same-session.
+- Thin orchestration: launch and cascade only; the per-phase skills (`impl-start`, `impl-plan`, `impl-execute`, `impl-critique-*`, `impl-push`, `pr-rebase`, `pr-fix-ci`, `pr-review`, `impl-archive`) stay individually invocable. `impl-workflow.mjs` and per-unit phase logic are unchanged.
+- Monitoring and merge are out of scope here; they belong to `impl-orchestrator-monitor`.
 
 $ARGUMENTS

--- a/plugins/autocode/skills/autocode-setup/scripts/write-settings.sh
+++ b/plugins/autocode/skills/autocode-setup/scripts/write-settings.sh
@@ -9,7 +9,8 @@ set -euo pipefail
 #   write-settings.sh --scope=shared \
 #     --issue-tracker=<value> \
 #     --git-remote=<value> \
-#     [--ci=<value>]
+#     [--ci=<value>] \
+#     [--max-concurrent-units=<n>]
 #
 #   write-settings.sh --scope=local \
 #     --projects-dir=<path>
@@ -18,6 +19,9 @@ set -euo pipefail
 # dispatcher's fallback to `provider.git-remote` applies. See
 # `autocode/_config/settings-schema.md` for the canonical schema, including
 # which top-level namespaces are shared vs local.
+#
+# `--max-concurrent-units=<n>` is optional (default 3 when omitted): sets the
+# `impl.max-concurrent-units` cap read by the `impl` epic orchestrator skill.
 
 scope=""
 issue_tracker=""
@@ -25,14 +29,16 @@ git_remote=""
 ci=""
 ci_provided=0
 projects_dir=""
+max_concurrent_units="3"
 
 for arg in "$@"; do
   case "${arg}" in
-    --scope=*)         scope="${arg#*=}" ;;
-    --issue-tracker=*) issue_tracker="${arg#*=}" ;;
-    --git-remote=*)    git_remote="${arg#*=}" ;;
-    --ci=*)            ci="${arg#*=}"; ci_provided=1 ;;
-    --projects-dir=*)  projects_dir="${arg#*=}" ;;
+    --scope=*)                scope="${arg#*=}" ;;
+    --issue-tracker=*)        issue_tracker="${arg#*=}" ;;
+    --git-remote=*)           git_remote="${arg#*=}" ;;
+    --ci=*)                   ci="${arg#*=}"; ci_provided=1 ;;
+    --projects-dir=*)         projects_dir="${arg#*=}" ;;
+    --max-concurrent-units=*) max_concurrent_units="${arg#*=}" ;;
     *) echo "write-settings.sh: unknown arg: ${arg}" >&2; exit 1 ;;
   esac
 done
@@ -64,7 +70,8 @@ if [[ "${scope}" == "shared" ]]; then
 
   jq -n \
     --argjson provider "${provider_json}" \
-    '{ provider: $provider }'
+    --argjson mcu "${max_concurrent_units}" \
+    '{ provider: $provider, impl: { "max-concurrent-units": $mcu } }'
 else
   if [[ -z "${projects_dir}" ]]; then
     echo "write-settings.sh: --projects-dir=<path> required for --scope=local" >&2

--- a/plugins/autocode/skills/impl/SKILL.md
+++ b/plugins/autocode/skills/impl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl
-description: Orchestrate one design unit end to end. Sets up the worktree via impl-start, then runs plan, execute, review (challenge/decide), fix, push, and hygiene as a background workflow with per-phase models, keeping the heavy work out of this session. Thin launcher; phase logic lives in the delegated skills.
+description: "Orchestrate a fanned-out design epic end to end: stateless and re-entrant, it reconstructs unit state from the tracker each turn, launches a capped wave of per-unit background workflows, refills as they finish, cascades into newly-unblocked units on merge, prunes merged worktrees, and archives when every unit is done. Bare-ticket invocations keep the single-unit launch. Per-phase skills stay individually invocable."
 ---
 
 Read through @~/.autocode/autocode/impl/skills/impl/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.


### PR DESCRIPTION
## Overview

Rewrites the `impl` skill from a single-unit launcher into a stateless, re-entrant epic orchestrator. Each turn, the orchestrator reconstructs state from the tracker and the session's live run ids, launches a capped wave of per-unit background workflows (`impl.max-concurrent-units`), refills on completion, cascades on merge, prunes merged worktrees, and triggers `impl-archive` when every unit is done. Single-unit invocations retain the existing contract unchanged.

## Problem Statement

- The previous `impl` skill launched one unit at a time and required manual re-invocation to advance the next ready unit, making multi-unit epics expensive to drive.
- No concurrency cap or DAG-aware wave meant blocked and ready units were not distinguished.
- No archive trigger meant epics accumulated indefinitely without a close signal.

## Architecture

```mermaid
flowchart TD
    A[impl --from-design id] --> B[Epic discovery: INDEX.md + issue-epic-list]
    B --> C[Reconcile: pr-find per unit]
    C --> D{Classify each unit}
    D -->|done| E[Skip / prune worktree]
    D -->|in-review| F[Monitor in background]
    D -->|running| G[Track run id]
    D -->|needs-recovery| H[Clean up + reset to todo]
    D -->|ready| I[Capped wave launch]
    I --> J[impl-start --unit slug --auto]
    J --> K[Workflow: impl-workflow.mjs]
    K -->|complete| L[task-notification re-entry]
    L --> B
    B -->|all done| M[impl-archive]
```

Key design decisions:
- Stateless: no durable orchestrator storage; state reconstructed from tracker + session run ids each turn.
- Reconcile by PR existence (`pr-find`), not tracker status alone, to survive stale `in-progress` states.
- `resumeFromRunId` only same-session; cross-session `in-progress` with no live run triggers a clean restart.
- Monitoring, merge-gating, and cron are a separate unit (`impl-orchestrator-monitor`) that depends on this one.

## Implementation Notes

- `impl.max-concurrent-units` added to `settings-schema.md` and written by `write-settings.sh` (default `3`).
- `autocode/impl/CLAUDE.md` updated to document epic vs. single-unit routing.
- `pr-fix-ci` and `pr-review` gained `--auto` flags (unit #19) enabling the orchestrator to drive them unattended.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately


resolves #17