### PR TITLE
feat(#26): Add --auto launcher and Workflow script for design-plan-critique

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/progress/design-critique-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/progress/design-critique-auto.md
@@ -1,0 +1,3 @@
+# design-critique-auto
+
+Epic: 0003-design-unit-workflow  Branch: feat/26/design-critique-auto  Started: 2026-06-08

--- a/autocode/design/skills/design-plan-critique/SKILL.md
+++ b/autocode/design/skills/design-plan-critique/SKILL.md
@@ -8,15 +8,45 @@ One of:
 - `<path>`: the temp folder returned by `design-plan --temp`.
 - `<id>` (the design folder zero-padded integer prefix, e.g. `0007`).
 - `<feature-shortname>` (the kebab-case suffix of a `.autocode/design/*/` directory).
-- nothing: defaults to the most recent `.autocode/design/*` dir (skip `INDEX.md`, the id registry, not an epic folder). On ambiguity, ask via `AskUserQuestion`.
+- nothing: defaults to the most recent `.autocode/design/*` dir (skip `INDEX.md`, the id registry, not an epic folder). On ambiguity, ask via `AskUserQuestion` (non-`--auto`) or fail-fast with `status: error` (`--auto`).
+- `--auto`: run unattended. The critique loop runs off-context via the Workflow tool, suppresses both `AskUserQuestion` gates, and ends with a structured result block instead of the prose summary.
 
 ## Discovery
 
 - If arg looks like a path to a folder, use it.
 - Else glob `.autocode/design/<id>-*` or `*-<shortname>`.
-- On no match, ask the user via `AskUserQuestion`.
+- On no match: without `--auto`, ask the user via `AskUserQuestion`; with `--auto`, emit `status: error` with a descriptive message and stop (do not launch the workflow).
 
-## Workflow
+## --auto launcher
+
+When invoked with `--auto`:
+
+1. Resolve `homeDir` via `echo "$HOME"`, `repoRoot` via `git rev-parse --show-toplevel`, and `folder` via the discovery glob above.
+2. On ambiguous or unresolvable arg: emit the structured block with `status: error` and a descriptive message. No `AskUserQuestion`. Do not launch the workflow.
+3. Launch the Workflow tool with `scriptPath: <homeDir>/.autocode/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs` and `args: { homeDir, repoRoot, folder }`. Wait for completion.
+4. Emit the workflow's return verbatim as the structured result block below. No surrounding prose.
+
+Structured result block:
+
+```
+status: done | cap_reached | error
+iterations_run: <int>
+questions_resolved: <int>
+needs_human: <bool>
+needs_human_reasons: [{ question, why }, ...]
+files_modified: [<path>, ...]
+critique_log_path: <path to DESIGN.md holding the ## Critique log>
+```
+
+Field semantics:
+- `status: done` = converged before the cap; `cap_reached` = stopped at 5 iterations with open questions remaining; `error` = fail-fast during discovery (other fields omitted or zeroed).
+- `needs_human: true` when any question was unresolvable by research or when `cap_reached` with open questions.
+- `files_modified` = DESIGN.md + any `units/*.md` edited this run.
+- `critique_log_path` = the DESIGN.md holding the `## Critique log`.
+
+## Workflow (non-`--auto`, interactive)
+
+The `--auto` path short-circuits to the launcher above; the following steps are the non-`--auto` in-session loop, preserved unchanged.
 
 1. Read the design: `DESIGN.md` and every `units/*.md` (multi-unit) or just `DESIGN.md` (flat).
 2. Generate follow-up questions per section and per unit. Bias toward: untested assumptions, interface shapes, error modes, concurrency, security, data shape, ordering invariants, and whether the unit decomposition and `depends-on` edges are right.
@@ -27,7 +57,9 @@ One of:
 
 ## Output
 
-Updates the design files in place. Final report is a summary of iterations and what changed (the critique log already captures detail; the report is a 2-3 line summary).
+Non-`--auto`: updates the design files in place. Final report is a summary of iterations and what changed (the critique log already captures detail; the report is a 2-3 line summary).
+
+`--auto`: emits the structured result block above. No surrounding prose.
 
 ## Rules
 
@@ -35,5 +67,6 @@ Updates the design files in place. Final report is a summary of iterations and w
 - Every resolution cites its source (research finding, user statement). Same source rule as `design-plan`.
 - Never delete sections; mark them as "(resolved)" or "(deferred)" if a question subsumes them.
 - Stop at 5 iterations or when no new questions emerge, whichever comes first.
+- Under `--auto`: the loop runs off-context (Workflow tool), no `AskUserQuestion` at any point, structured return only. The non-`--auto` interactive in-session loop is unchanged and is the only path that retains both `AskUserQuestion` gates.
 
 $ARGUMENTS

--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -96,12 +96,18 @@ while (iterations < MAX_ITERATIONS) {
     )))
 
   const usable = resolved.filter(Boolean)
+  const deferred = []        // questions left open this pass (resolve null or unresolved); logged as (deferred)
   for (let i = 0; i < resolved.length; i++) {
-    if (!resolved[i]) needsHumanReasons.push({ question: q.questions[i].question, why: 'resolve agent failed' })
+    if (!resolved[i]) {
+      needsHumanReasons.push({ question: q.questions[i].question, why: 'resolve agent failed' })
+      deferred.push({ ...q.questions[i], why: 'resolve agent failed' })
+    }
   }
   for (const r of usable) {
-    if (r.unresolved) needsHumanReasons.push({ question: r.question, why: r.why })
-    else resolvedCount += 1
+    if (r.unresolved) {
+      needsHumanReasons.push({ question: r.question, why: r.why })
+      deferred.push(r)
+    } else resolvedCount += 1
   }
   const applicable = usable.filter((r) => !r.unresolved)
 
@@ -134,17 +140,22 @@ while (iterations < MAX_ITERATIONS) {
   const designWrite = await agent(
     `In ${FOLDER}/DESIGN.md: apply any DESIGN-targeted resolutions in place, then append this iteration's block to the ` +
       `## Critique log (create the section at the bottom if absent), one line per question with its resolution. ` +
+      `Log each deferred question on its own line marked "(deferred)" with its \`why\` (never drop a question). ` +
       follow(CRITIQUE,
         'Apply its in-place edit + critique-log rules (SKILL step 4: ## Critique log lists each iteration\'s questions ' +
-        'and resolutions; preserve structure; never delete sections).') +
+        'and resolutions; preserve structure; never delete sections; mark unresolved questions deferred).') +
       `\nDESIGN-targeted resolutions JSON:\n${JSON.stringify(designResolutions)}` +
       `\nAll resolutions this pass (for the log) JSON:\n${JSON.stringify(applicable)}` +
+      `\nDeferred questions this pass (log each as (deferred)) JSON:\n${JSON.stringify(deferred)}` +
       `\nIteration number: ${iterations}`,
     { label: `apply-design-i${iterations}`, phase: 'Apply', model: 'sonnet', schema: APPLY_SCHEMA },
   )
   if (designWrite?.file) filesModified.add(designWrite.file)
 
-  if (iterations >= MAX_ITERATIONS && q.questions.length > 0) status = 'cap_reached'
+  // The cap stops an unconverged loop: any work this pass (applied or deferred) means a clean
+  // no-question pass was never reached. A final pass whose resolves were all null/unresolved
+  // leaves only deferred work, so it must surface here rather than report 'done'.
+  if (iterations >= MAX_ITERATIONS && (applicable.length > 0 || deferred.length > 0)) status = 'cap_reached'
 }
 
 const needsHuman = needsHumanReasons.length > 0 || status === 'cap_reached'

--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -141,7 +141,7 @@ while (iterations < MAX_ITERATIONS) {
   )
   if (designWrite?.file) filesModified.add(designWrite.file)
 
-  if (iterations >= MAX_ITERATIONS && q.questions.length) status = 'cap_reached'
+  if (iterations >= MAX_ITERATIONS && (needsHumanReasons.length > 0 || applicable.length > 0)) status = 'cap_reached'
 }
 
 const needsHuman = needsHumanReasons.length > 0 || status === 'cap_reached'

--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -1,0 +1,156 @@
+export const meta = {
+  name: 'design-critique',
+  description: 'Critique loop: generate questions, resolve via research, apply in place, cap 5',
+  phases: [
+    { title: 'Question', detail: "opus: generate this pass's follow-up questions", model: 'opus' },
+    { title: 'Resolve', detail: 'opus: research each question (researcher-only)', model: 'opus' },
+    { title: 'Apply', detail: 'sonnet: write resolutions into units + DESIGN + critique log', model: 'sonnet' },
+  ],
+}
+
+// args (from the design-plan-critique --auto launcher): { homeDir, repoRoot, folder }
+const HOME = args.homeDir
+const REPO = args.repoRoot
+const FOLDER = args.folder        // absolute path to the design folder
+const MAX_ITERATIONS = 5
+
+// Agents run skills by reading the canonical body by absolute path
+// (the skill catalog is not reliably visible to workflow agents).
+const skill = (name) => `${HOME}/.autocode/autocode/design/skills/${name}/SKILL.md`
+const follow = (path, extra) => `Read the skill at ${path} and follow it exactly. ${extra}`
+const readOnly = 'You are a read-only reviewer: never edit, write, or run mutating commands. '
+const CRITIQUE = skill('design-plan-critique')   // agents read this for heuristics (single-source)
+
+const QUESTION_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    questions: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        properties: {
+          id: { type: 'string' },           // stable within the pass, e.g. "Q1"
+          question: { type: 'string' },
+          target: { type: 'string' },        // 'DESIGN' or a unit slug
+        },
+        required: ['id', 'question', 'target'],
+      },
+    },
+  },
+  required: ['questions'],
+}
+
+const RESOLVE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    id: { type: 'string' },
+    question: { type: 'string' },
+    target: { type: 'string' },
+    resolution: { type: 'string' },      // the answer to write, with its source cited
+    source: { type: 'string' },          // research finding citation (every resolution cites its source)
+    unresolved: { type: 'boolean' },     // true when research could not close it
+    why: { type: 'string' },             // when unresolved: why research could not close it
+  },
+  required: ['id', 'question', 'target', 'resolution', 'source', 'unresolved', 'why'],
+}
+
+const APPLY_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { file: { type: 'string' } },
+  required: ['file'],
+}
+
+let iterations = 0
+let resolvedCount = 0
+const needsHumanReasons = []   // { question, why }
+const filesModified = new Set()
+let status = 'done'            // flips to 'cap_reached' if the cap stops an unconverged loop
+
+while (iterations < MAX_ITERATIONS) {
+  iterations += 1
+
+  // --- Question phase: one agent, reads FOLDER's DESIGN.md + units/*.md and the CRITIQUE body ---
+  phase('Question')
+  const q = await agent(
+    `Read the design at ${FOLDER} (DESIGN.md and every units/*.md, or just DESIGN.md if no units/). ` +
+      follow(CRITIQUE,
+        "Apply only its question-generation heuristics (SKILL step 2: untested assumptions, interface shapes, " +
+        'error modes, concurrency, security, data shape, ordering invariants, unit decomposition and depends-on edges). ' +
+        "Generate this pass's follow-up questions only. Account for resolutions already in the ## Critique log so you " +
+        'do not re-raise closed questions. Return [] when nothing new remains.'),
+    { label: `question-i${iterations}`, phase: 'Question', model: 'opus', schema: QUESTION_SCHEMA },
+  )
+  if (!q.questions.length) break   // converged: status stays 'done'
+
+  // --- Resolve phase: one agent per question, in parallel, researcher-only (never asks the user) ---
+  const resolved = await parallel(q.questions.map((item) => () =>
+    agent(
+      readOnly +
+        `Resolve this critique question against the design at ${FOLDER} and the codebase at ${REPO} by dispatching a ` +
+        `codebase-researcher (read-only research only; never ask the user). ` +
+        follow(CRITIQUE,
+          'Apply its resolution + source-citation rules (SKILL step 3 and Rules: every resolution cites its source). ' +
+          'If research cannot close the question, set unresolved=true and explain why in `why`; do not abort.') +
+        `\nQuestion JSON:\n${JSON.stringify(item)}`,
+      { label: `resolve-i${iterations}-${item.id}`, phase: 'Resolve', model: 'opus', schema: RESOLVE_SCHEMA },
+    )))
+
+  const usable = resolved.filter(Boolean)
+  for (const r of usable) {
+    if (r.unresolved) needsHumanReasons.push({ question: r.question, why: r.why })
+    else resolvedCount += 1
+  }
+  const applicable = usable.filter((r) => !r.unresolved)
+
+  // --- Apply phase ---
+  // Per-unit resolutions: one Apply agent per affected unit slug, in parallel (writes units/<slug>.md).
+  // DESIGN.md edits + the ## Critique log append: a single serial agent (shared file).
+  phase('Apply')
+  const byUnit = new Map()                     // slug -> resolutions[]
+  const designResolutions = []                 // target === 'DESIGN'
+  for (const r of applicable) {
+    if (r.target === 'DESIGN') designResolutions.push(r)
+    else {
+      if (!byUnit.has(r.target)) byUnit.set(r.target, [])
+      byUnit.get(r.target).push(r)
+    }
+  }
+
+  const unitWrites = await parallel([...byUnit.entries()].map(([slug, rs]) => () =>
+    agent(
+      `Write these resolutions in place into ${FOLDER}/units/${slug}.md. ` +
+        follow(CRITIQUE,
+          'Apply its in-place edit rules (SKILL step 4 and Rules: preserve section structure; never delete sections, ' +
+          "mark resolved/deferred; cite each resolution's source).") +
+        `\nResolutions JSON:\n${JSON.stringify(rs)}`,
+      { label: `apply-i${iterations}-${slug}`, phase: 'Apply', model: 'sonnet', schema: APPLY_SCHEMA },
+    )))
+  for (const w of unitWrites.filter(Boolean)) filesModified.add(w.file)
+
+  // Serial DESIGN.md + critique-log writer (always runs: appends the ## Critique log even when only units changed).
+  const designWrite = await agent(
+    `In ${FOLDER}/DESIGN.md: apply any DESIGN-targeted resolutions in place, then append this iteration's block to the ` +
+      `## Critique log (create the section at the bottom if absent), one line per question with its resolution. ` +
+      follow(CRITIQUE,
+        'Apply its in-place edit + critique-log rules (SKILL step 4: ## Critique log lists each iteration\'s questions ' +
+        'and resolutions; preserve structure; never delete sections).') +
+      `\nDESIGN-targeted resolutions JSON:\n${JSON.stringify(designResolutions)}` +
+      `\nAll resolutions this pass (for the log) JSON:\n${JSON.stringify(applicable)}` +
+      `\nIteration number: ${iterations}`,
+    { label: `apply-design-i${iterations}`, phase: 'Apply', model: 'sonnet', schema: APPLY_SCHEMA },
+  )
+  if (designWrite?.file) filesModified.add(designWrite.file)
+
+  if (iterations >= MAX_ITERATIONS && q.questions.length) status = 'cap_reached'
+}
+
+const needsHuman = needsHumanReasons.length > 0 || status === 'cap_reached'
+return {
+  status,                                  // 'done' | 'cap_reached'
+  iterations_run: iterations,
+  questions_resolved: resolvedCount,
+  needs_human: needsHuman,
+  needs_human_reasons: needsHumanReasons,  // [{ question, why }, ...]
+  files_modified: [...filesModified],
+  critique_log_path: `${FOLDER}/DESIGN.md`,
+}

--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -96,6 +96,9 @@ while (iterations < MAX_ITERATIONS) {
     )))
 
   const usable = resolved.filter(Boolean)
+  for (let i = 0; i < resolved.length; i++) {
+    if (!resolved[i]) needsHumanReasons.push({ question: q.questions[i].question, why: 'resolve agent failed' })
+  }
   for (const r of usable) {
     if (r.unresolved) needsHumanReasons.push({ question: r.question, why: r.why })
     else resolvedCount += 1
@@ -141,7 +144,7 @@ while (iterations < MAX_ITERATIONS) {
   )
   if (designWrite?.file) filesModified.add(designWrite.file)
 
-  if (iterations >= MAX_ITERATIONS && (needsHumanReasons.length > 0 || applicable.length > 0)) status = 'cap_reached'
+  if (iterations >= MAX_ITERATIONS && q.questions.length > 0) status = 'cap_reached'
 }
 
 const needsHuman = needsHumanReasons.length > 0 || status === 'cap_reached'


### PR DESCRIPTION
## Overview

Adds `--auto` mode to `design-plan-critique`: a Workflow-backed off-context critique loop with structured return. Adds `design-critique-workflow.mjs` as the off-context script.

## Problem Statement

- `design-plan-critique` had no unattended path; an orchestrator could not invoke it without blocking the main session or hitting `AskUserQuestion` gates.
- The background `impl` orchestration needs a critique phase that returns a structured result (status, iteration count, modified files) without interactive prompts.

## Implementation Notes

- `design-critique-workflow.mjs`: three-phase loop (Question / Resolve / Apply), capped at 5 iterations, parallel resolve per question, parallel apply per affected unit, serial DESIGN.md + critique-log writer.
- Two bugs fixed after initial implementation: `cap_reached` false positive when iteration 5 fully converges; null resolve-agent results not surfaced in `needs_human_reasons`.
- SKILL.md updated with `--auto` launcher section, updated discovery rules, and structured result block spec.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #26