### PR TITLE
feat(#30): Add design-plan-workflow.mjs and orchestrator-ready --auto mode

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/PROGRESS.md
+++ b/.autocode/design/0003-design-unit-workflow/PROGRESS.md
@@ -13,3 +13,10 @@ Notes: Two fix commits landed after initial impl to correct the structured resul
 Unit: #28
 
 Added `--auto` flag to `design-plan-iterate` skill. The flag enables unattended execution: strict arg resolution (no `AskUserQuestion` prompts), a structured result block (`needs_human`, `design_id`, `shortname`, `iterations_run`, `open_questions_remaining`) on completion, and an early-exit `needs_human: true` block when the design id is absent or ambiguous. Critique and resolution passes run unchanged; the flag only gates interactivity and shapes the final output block.
+## design-plan-orchestrator-ready — 2026-06-08
+
+Unit: #30
+
+Added `design-plan-workflow.mjs` as a background workflow script that owns research fan-out, `DESIGN.md` synthesis, shortname derivation, worktree + branch + `INDEX.md` creation, and the `design-unit-author` fan-out with a bounded research-backed retry. Updated `design-plan/SKILL.md` to add `--auto` as a thin launcher over this workflow (non-`--auto` interactive path unchanged). Updated `design-unit-author.md` to replace the in-band underspecified signal with the three-field contract (`underspecified`, `file`, `summary`) usable both via `schema` and as inline prose.
+
+Notes: Two fixes followed the initial commit to thread `--temp` end to end and route `Synthesize` worktree creation through `worktree.md`.

--- a/.autocode/design/0003-design-unit-workflow/progress/design-plan-orchestrator-ready.md
+++ b/.autocode/design/0003-design-unit-workflow/progress/design-plan-orchestrator-ready.md
@@ -1,0 +1,3 @@
+# design-plan-orchestrator-ready
+
+Epic: 0003-design-unit-workflow  Branch: feat/30/design-plan-orchestrator-ready  Started: 2026-06-08

--- a/autocode/design/agents/design-unit-author.md
+++ b/autocode/design/agents/design-unit-author.md
@@ -38,4 +38,8 @@ The prompt carries:
 
 ## Output
 
-Report the unit file path and a one-line summary of the deliverable. The file is the deliverable, not the message.
+Report these three fields — in prose when invoked inline (manual path), as the typed object when the workflow passes `schema`:
+
+- `underspecified` (boolean): true when the unit cannot name concrete files or the deliverable is too vague to implement.
+- `file` (string): the `units/<slug>.md` path written, or the path it would write when underspecified.
+- `summary` (string): one-line deliverable.

--- a/autocode/design/skills/design-plan/SKILL.md
+++ b/autocode/design/skills/design-plan/SKILL.md
@@ -6,12 +6,23 @@ Layout authority: `@~/.autocode/autocode/design/design-folder.md`. Read it; this
 
 ## Args
 
-- Freeform user description (typical), or
+- `--auto`: run unattended. Thin launcher over `scripts/design-plan-workflow.mjs`. Emits a structured result block; no `AskUserQuestion`.
 - `--temp` (or `--temporary`): write the folder to a temp directory instead of the repo. Same structure; for throwaway critique only.
+- Freeform user description (typical).
 
 ## Workflow
 
-1. Treat `$ARGUMENTS` as the seed. If empty, ask via `AskUserQuestion` for a one-paragraph description.
+1. Treat `$ARGUMENTS` as the seed (strip `--auto` / `--temp` flags). If empty and not `--auto`, ask via `AskUserQuestion` for a one-paragraph description.
+
+   **If `--auto` is present:** skip the in-session steps below and run as a thin launcher:
+   - Resolve `homeDir` via `echo "$HOME"` and `repoRoot` via `git rev-parse --show-toplevel`.
+   - Take the seed non-interactively from `$ARGUMENTS` (strip `--auto`; the orchestrator never invokes plan with an empty seed).
+   - Launch the Workflow with `scriptPath: <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs` and `args: { homeDir, repoRoot, seed }`.
+   - Wait for the workflow to complete, then emit the structured result block:
+     ```
+     { folder: string, id: string, units: [{ slug, file }], underspecified: [{ slug, file }], open_qs: string[] }
+     ```
+   - Surface any `underspecified` units or `open_qs` from the result. Stop; do not proceed to the steps below.
 2. Rough sketch from conversation context only. No research yet. Surface what the model already thinks so gaps are easier to identify.
 3. Gap identification. List every assumption, every unknown library/API, every "I'm guessing X". Decide per gap:
    - dispatch `codebase-researcher` (current repo) in background,
@@ -35,7 +46,7 @@ Layout authority: `@~/.autocode/autocode/design/design-folder.md`. Read it; this
    - Per unit, decide only the assignment, not the prose: `slug` (kebab-case, unique in the folder), one-line deliverable, `depends-on` (sibling slugs), and `type` (an issue type from `$AUTOCODE_CONFIG_DIR/conventions/issue-types.md`, typically `task`, `story`, or `bug`). The `units/<slug>.md` file itself (`## Summary` + `## Implementation`) is authored by the `design-unit-author` agent in step 5, one instance per unit; you do not write unit files inline. The unit-file shape is in `design-folder.md`.
    - Flat designs (single unit): omit the `## Units` section and the `units/` directory. `DESIGN.md` instead carries frontmatter `type: <issue-type>` and its own `## Implementation` section (same shape as a unit). It is its own unit, slug `<shortname>`. The conditional sections (diagram, design decisions, runtime flow) still apply, but stay lean: a one-PR design rarely needs all of them.
 5. Write the folder.
-   - Ask the user for `<shortname>` via `AskUserQuestion`. Kebab-case, lowercase, 2-4 words. (`<id>` is allocated from `INDEX.md` in the without-temp branch below; temp designs have no id.)
+   - Derive `<shortname>` from the `# <Title>` H1 of the composed `DESIGN.md`: kebab-case, lowercase, 2-4 keywords, strip filler words (`the`, `a`, `an`, `is`, `of`, `for`, `to`, `in`, `on`, `with`). Dedup against `INDEX.md` rows and existing `.autocode/design/*` folder names: on collision append `-2`, then `-3`, etc. (`<id>` is allocated from `INDEX.md` in the without-temp branch below; temp designs have no id.)
    - Resolve and create the target folder `<folder>` (with a `units/` subdir when multi-unit):
      - With `--temp`: `dir=$(mktemp -d -t autocode-design)`; `<folder>=$dir`. No worktree (the temp dir is outside the repo), no id, never touch `INDEX.md`.
      - Without `--temp`: the folder is a repo change, so isolate it in a worktree first. Ensure a worktree per `@~/.autocode/autocode/_config/guides/worktree.md`, then delegate `git-create-branch "docs: design <shortname>"` inside it. `repo_root=$(git rev-parse --show-toplevel)` (now the worktree). Allocate `<id>` from the index: read `$repo_root/.autocode/design/INDEX.md` (create it with the header from the design-folder spec if absent); `<id>` = highest id in the table + 1, zero-padded to 4 digits (`0001` if empty). `<folder>=$repo_root/.autocode/design/<id>-<shortname>/`. Append a row to `INDEX.md`: `<id>`, `<shortname>`, today's UTC date (`date -u +%Y-%m-%d`), `active`.

--- a/autocode/design/skills/design-plan/SKILL.md
+++ b/autocode/design/skills/design-plan/SKILL.md
@@ -16,8 +16,8 @@ Layout authority: `@~/.autocode/autocode/design/design-folder.md`. Read it; this
 
    **If `--auto` is present:** skip the in-session steps below and run as a thin launcher:
    - Resolve `homeDir` via `echo "$HOME"` and `repoRoot` via `git rev-parse --show-toplevel`.
-   - Take the seed non-interactively from `$ARGUMENTS` (strip `--auto`; the orchestrator never invokes plan with an empty seed).
-   - Launch the Workflow with `scriptPath: <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs` and `args: { homeDir, repoRoot, seed }`.
+   - Take the seed non-interactively from `$ARGUMENTS` (strip `--auto` and `--temp`; the orchestrator never invokes plan with an empty seed). Set `temp = true` if `--temp` (or `--temporary`) was present.
+   - Launch the Workflow with `scriptPath: <homeDir>/.autocode/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs` and `args: { homeDir, repoRoot, seed, temp }`.
    - Wait for the workflow to complete, then emit the structured result block:
      ```
      { folder: string, id: string, units: [{ slug, file }], underspecified: [{ slug, file }], open_qs: string[] }

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -10,12 +10,13 @@ export const meta = {
 }
 
 // args (from the design-plan --auto launcher or the /design orchestrator):
-//   { homeDir, repoRoot, seed }
+//   { homeDir, repoRoot, seed, temp }
 // The workflow owns the entire heavy plan phase: research, synthesis, worktree creation,
-// unit-author fan-out, and the bounded retry. The launcher passes only paths + the seed.
+// unit-author fan-out, and the bounded retry. The launcher passes paths + seed + temp.
 const HOME = args.homeDir
 const REPO = args.repoRoot
 const SEED = String(args.seed || '')
+const TEMP = Boolean(args.temp)
 
 // Path helpers — agents read canonical bodies by absolute path;
 // the skill/agent catalog is not reliably visible to workflow agents.
@@ -141,8 +142,19 @@ const researchSummary = researched
 // ── Phase: Synthesize ────────────────────────────────────────────────────────
 // Compose DESIGN.md, derive shortname, create worktree + branch + id + INDEX.md,
 // decide multi-unit vs flat, assign units (deliverable, depends-on, type, research snippet).
+// When TEMP: write to a mktemp-d folder only; skip worktree/branch/id/INDEX entirely.
 
 phase('Synthesize')
+
+const synthTempInstructions = TEMP
+  ? `3. This is a --temp run. Create a temp folder with \`mktemp -d -t autocode-design\`. ` +
+    `Write DESIGN.md into that folder. Do NOT run git-create-branch, do NOT allocate an id, do NOT touch INDEX.md. ` +
+    `Return worktree:"", id:"" in the result.\n`
+  : `3. Create a worktree+branch by running git-create-branch "docs: design <shortname>" inside ${REPO}. ` +
+    `Allocate <id>: read ${REPO}/.autocode/design/INDEX.md (create with the header from design-folder.md if absent); ` +
+    `id = highest existing id + 1, zero-padded 4 digits (0001 if empty). ` +
+    `Write DESIGN.md into ${REPO}/.autocode/design/<id>-<shortname>/DESIGN.md (create the folder). ` +
+    `Append a row to INDEX.md: <id>, <shortname>, today's UTC date (date -u +%Y-%m-%d), active.\n`
 
 const synth = await agent(
   `Read ${designSkill('design-plan')} for DESIGN.md composition rules and section guidance. ` +
@@ -153,11 +165,7 @@ const synth = await agent(
   `1. Compose the full DESIGN.md text following the section guidance in design-plan/SKILL.md and design-folder.md.\n` +
   `2. Derive <shortname> from the # <Title> H1: kebab-case, lowercase, 2-4 keywords, strip filler (the/a/an/is/of/for/to/in/on/with). ` +
   `Dedup against ${REPO}/.autocode/design/INDEX.md rows and existing ${REPO}/.autocode/design/* folder names: on collision append -2, -3.\n` +
-  `3. Without --temp: create a worktree+branch by running git-create-branch "docs: design <shortname>" inside ${REPO}. ` +
-  `Allocate <id>: read ${REPO}/.autocode/design/INDEX.md (create with the header from design-folder.md if absent); ` +
-  `id = highest existing id + 1, zero-padded 4 digits (0001 if empty). ` +
-  `Write DESIGN.md into ${REPO}/.autocode/design/<id>-<shortname>/DESIGN.md (create the folder). ` +
-  `Append a row to INDEX.md: <id>, <shortname>, today's UTC date (date -u +%Y-%m-%d), active.\n` +
+  synthTempInstructions +
   `4. Decide flat vs multi-unit per design-folder.md rules. ` +
   `If multi-unit, compute per-unit assignments: slug (kebab-case unique), one-line deliverable, depends-on (sibling slugs), issue type, and the relevant research snippet. ` +
   `If flat: no units array, return flat:true.\n` +
@@ -165,6 +173,20 @@ const synth = await agent(
   `Return the SYNTH_SCHEMA object.`,
   { label: 'synthesize', phase: 'Synthesize', model: 'opus', schema: SYNTH_SCHEMA },
 )
+
+// --temp: no worktree created; skip Author/Resolve and return immediately.
+if (TEMP) {
+  const remainingGapsTmp = researched
+    .filter(Boolean)
+    .flatMap((r) => r.gaps_remaining ?? [])
+  return {
+    folder: synth.folder,
+    id: '',
+    units: [],
+    underspecified: [],
+    open_qs: [...synth.open_qs, ...remainingGapsTmp],
+  }
+}
 
 const inWt = makeInWt(synth.worktree)
 

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -1,0 +1,257 @@
+export const meta = {
+  name: 'design-plan',
+  description: 'Plan phase off-context: research, DESIGN.md synthesis, worktree/branch/id/INDEX.md, unit-author fan-out with structured contract and bounded retry',
+  phases: [
+    { title: 'Research', detail: 'opus: interpret seed, fan-out codebase researchers for each gap', model: 'opus' },
+    { title: 'Synthesize', detail: 'opus: compose DESIGN.md, derive shortname, create worktree/branch/id/INDEX.md, assign units', model: 'opus' },
+    { title: 'Author', detail: 'opus: unit-author fan-out (one per unit)', model: 'opus' },
+    { title: 'Resolve', detail: 'opus: bounded research-backed retry for underspecified units (cap one per unit)', model: 'opus' },
+  ],
+}
+
+// args (from the design-plan --auto launcher or the /design orchestrator):
+//   { homeDir, repoRoot, seed }
+// The workflow owns the entire heavy plan phase: research, synthesis, worktree creation,
+// unit-author fan-out, and the bounded retry. The launcher passes only paths + the seed.
+const HOME = args.homeDir
+const REPO = args.repoRoot
+const SEED = String(args.seed || '')
+
+// Path helpers — agents read canonical bodies by absolute path;
+// the skill/agent catalog is not reliably visible to workflow agents.
+// Mirroring impl-workflow.mjs:19,29.
+const designAgent = (name) => `${HOME}/.autocode/autocode/design/agents/${name}.md`
+const designSkill = (name) => `${HOME}/.autocode/autocode/design/skills/${name}/SKILL.md`
+const designFolder = `${HOME}/.autocode/autocode/design/design-folder.md`
+
+// inWt: built from a worktree path returned by Synthesize (not from args, since the worktree
+// does not exist at launch — Synthesize creates it). Available only to Author/Resolve phases.
+const makeInWt = (wt) => `Work in the git worktree at ${wt}: cd into it before doing anything. `
+
+// ── Schemas ─────────────────────────────────────────────────────────────────
+
+// Gaps identified by the planning sub-agent in the Research phase.
+const GAPS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    gaps: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          label: { type: 'string' },
+          question: { type: 'string' },
+        },
+        required: ['label', 'question'],
+      },
+    },
+  },
+  required: ['gaps'],
+}
+
+// Per-gap researcher return.
+const RESEARCH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    label: { type: 'string' },
+    findings: { type: 'string' },
+    gaps_remaining: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['label', 'findings', 'gaps_remaining'],
+}
+
+// Synthesize agent return: folder, id, shortname, worktree path, unit assignments, open_qs.
+const SYNTH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    folder: { type: 'string' },
+    id: { type: 'string' },
+    shortname: { type: 'string' },
+    worktree: { type: 'string' },
+    units: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          slug: { type: 'string' },
+          deliverable: { type: 'string' },
+          dependsOn: { type: 'array', items: { type: 'string' } },
+          type: { type: 'string' },
+          research: { type: 'string' },
+        },
+        required: ['slug', 'deliverable', 'dependsOn', 'type', 'research'],
+      },
+    },
+    open_qs: { type: 'array', items: { type: 'string' } },
+    flat: { type: 'boolean' },
+  },
+  required: ['folder', 'id', 'shortname', 'worktree', 'units', 'open_qs', 'flat'],
+}
+
+// design-unit-author contract (DESIGN.md decision 6).
+// Usable via schema (typed object) or inline prose (same three fields).
+const UNIT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    underspecified: { type: 'boolean' },
+    file: { type: 'string' },
+    summary: { type: 'string' },
+  },
+  required: ['underspecified', 'file', 'summary'],
+}
+
+// ── Phase: Research ──────────────────────────────────────────────────────────
+// Interpret the seed, list research gaps, fan-out one codebase-researcher per gap.
+
+phase('Research')
+
+// Sub-agent: interpret the seed and list concrete research gaps.
+const gapResult = await agent(
+  `Read ${designSkill('design-plan')} for planning heuristics. ` +
+  `The user's seed is: "${SEED}". ` +
+  `Identify every assumption, unknown library/API, unknown codebase shape, and unclear deliverable boundary. ` +
+  `For each gap, write a short label (kebab-case, unique) and a one-sentence research question targeting the codebase. ` +
+  `Return the gaps array.`,
+  { label: 'plan-gaps', phase: 'Research', model: 'opus', schema: GAPS_SCHEMA },
+)
+
+// Fan-out: one researcher per gap. Pass { phase: 'Research' } as option (never call global phase() here).
+const researched = await parallel(
+  gapResult.gaps.map((gap) => () =>
+    agent(
+      `Read ${designAgent('codebase-researcher')} and follow it. ` +
+      `Research question: "${gap.question}". Label: "${gap.label}". ` +
+      `Return label, verbatim findings, and any remaining gaps you could not resolve.`,
+      { label: `research:${gap.label}`, phase: 'Research', model: 'opus', schema: RESEARCH_SCHEMA },
+    )
+  )
+)
+
+const researchSummary = researched
+  .filter(Boolean)
+  .map((r) => `[${r.label}]\n${r.findings}`)
+  .join('\n\n')
+
+// ── Phase: Synthesize ────────────────────────────────────────────────────────
+// Compose DESIGN.md, derive shortname, create worktree + branch + id + INDEX.md,
+// decide multi-unit vs flat, assign units (deliverable, depends-on, type, research snippet).
+
+phase('Synthesize')
+
+const synth = await agent(
+  `Read ${designSkill('design-plan')} for DESIGN.md composition rules and section guidance. ` +
+  `Read ${designFolder} for folder layout, INDEX.md schema, and flat-vs-multi-unit rules. ` +
+  `Seed: "${SEED}". ` +
+  `Research findings:\n${researchSummary || '(no research gaps identified)'}\n\n` +
+  `Tasks (do all of these):\n` +
+  `1. Compose the full DESIGN.md text following the section guidance in design-plan/SKILL.md and design-folder.md.\n` +
+  `2. Derive <shortname> from the # <Title> H1: kebab-case, lowercase, 2-4 keywords, strip filler (the/a/an/is/of/for/to/in/on/with). ` +
+  `Dedup against ${REPO}/.autocode/design/INDEX.md rows and existing ${REPO}/.autocode/design/* folder names: on collision append -2, -3.\n` +
+  `3. Without --temp: create a worktree+branch by running git-create-branch "docs: design <shortname>" inside ${REPO}. ` +
+  `Allocate <id>: read ${REPO}/.autocode/design/INDEX.md (create with the header from design-folder.md if absent); ` +
+  `id = highest existing id + 1, zero-padded 4 digits (0001 if empty). ` +
+  `Write DESIGN.md into ${REPO}/.autocode/design/<id>-<shortname>/DESIGN.md (create the folder). ` +
+  `Append a row to INDEX.md: <id>, <shortname>, today's UTC date (date -u +%Y-%m-%d), active.\n` +
+  `4. Decide flat vs multi-unit per design-folder.md rules. ` +
+  `If multi-unit, compute per-unit assignments: slug (kebab-case unique), one-line deliverable, depends-on (sibling slugs), issue type, and the relevant research snippet. ` +
+  `If flat: no units array, return flat:true.\n` +
+  `5. Surface any open questions research could not resolve.\n` +
+  `Return the SYNTH_SCHEMA object.`,
+  { label: 'synthesize', phase: 'Synthesize', model: 'opus', schema: SYNTH_SCHEMA },
+)
+
+const inWt = makeInWt(synth.worktree)
+
+// ── Phase: Author ────────────────────────────────────────────────────────────
+// Fan-out design-unit-author for each unit. Flat designs skip.
+// CRITICAL: pass { phase: 'Author' } as agent option; never call global phase() inside a parallel map.
+
+phase('Author')
+
+let unitResults = []
+if (!synth.flat && synth.units.length > 0) {
+  unitResults = await parallel(
+    synth.units.map((unit) => () =>
+      agent(
+        inWt +
+        `Read ${designAgent('design-unit-author')} and follow it exactly. ` +
+        `Design folder: ${synth.folder}. The full DESIGN.md is at ${synth.folder}/DESIGN.md (read it). ` +
+        `Unit assignment: slug=${unit.slug}, deliverable="${unit.deliverable}", ` +
+        `depends-on=[${unit.dependsOn.join(', ')}], type=${unit.type}. ` +
+        `Research findings for this unit:\n${unit.research || '(none)'}`,
+        { label: `author:${unit.slug}`, phase: 'Author', model: 'opus', schema: UNIT_SCHEMA },
+      )
+    )
+  )
+}
+
+// ── Phase: Resolve ───────────────────────────────────────────────────────────
+// Bounded research-backed retry for underspecified units (cap: one retry per unit).
+// CRITICAL: pass { phase: 'Resolve' } as agent option; never call global phase() inside a parallel map.
+
+phase('Resolve')
+
+const underspecifiedIdxs = synth.units
+  .map((unit, i) => ({ unit, i }))
+  .filter(({ i }) => unitResults[i]?.underspecified === true)
+
+let resolvedResults = []
+if (underspecifiedIdxs.length > 0) {
+  resolvedResults = await parallel(
+    underspecifiedIdxs.map(({ unit, i }) => async () => {
+      // First: targeted researcher for the gap
+      const reResearch = await agent(
+        inWt +
+        `Read ${designAgent('codebase-researcher')} and follow it. ` +
+        `Research the specific gap that makes unit "${unit.slug}" underspecified. ` +
+        `Deliverable: "${unit.deliverable}". ` +
+        `Focus on which concrete files exist and what interfaces they expose.`,
+        { label: `resolve-research:${unit.slug}`, phase: 'Resolve', model: 'opus', schema: RESEARCH_SCHEMA },
+      )
+      // Then: re-author with additional findings
+      return agent(
+        inWt +
+        `Read ${designAgent('design-unit-author')} and follow it exactly. ` +
+        `Design folder: ${synth.folder}. The full DESIGN.md is at ${synth.folder}/DESIGN.md (read it). ` +
+        `Unit assignment: slug=${unit.slug}, deliverable="${unit.deliverable}", ` +
+        `depends-on=[${unit.dependsOn.join(', ')}], type=${unit.type}. ` +
+        `Additional research findings:\n${reResearch.findings}`,
+        { label: `resolve-author:${unit.slug}`, phase: 'Resolve', model: 'opus', schema: UNIT_SCHEMA },
+      )
+    })
+  )
+}
+
+// Merge: resolved result overwrites the original for retried units.
+const resultMap = new Map(synth.units.map((unit, i) => [unit.slug, unitResults[i] ?? null]))
+underspecifiedIdxs.forEach(({ unit }, ri) => {
+  if (resolvedResults[ri]) resultMap.set(unit.slug, resolvedResults[ri])
+})
+
+const allUnits = synth.units.map((unit) => ({
+  slug: unit.slug,
+  file: resultMap.get(unit.slug)?.file ?? '',
+}))
+
+const finalUnderspecified = synth.units
+  .filter((unit) => resultMap.get(unit.slug)?.underspecified === true)
+  .map((unit) => ({ slug: unit.slug, file: resultMap.get(unit.slug)?.file ?? '' }))
+
+// Collect open_qs from Synthesize + any remaining gaps from Research
+const remainingGaps = researched
+  .filter(Boolean)
+  .flatMap((r) => r.gaps_remaining ?? [])
+
+return {
+  folder: synth.folder,
+  id: synth.id,
+  units: allUnits,
+  underspecified: finalUnderspecified,
+  open_qs: [...synth.open_qs, ...remainingGaps],
+}

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -150,11 +150,14 @@ const synthTempInstructions = TEMP
   ? `3. This is a --temp run. Create a temp folder with \`mktemp -d -t autocode-design\`. ` +
     `Write DESIGN.md into that folder. Do NOT run git-create-branch, do NOT allocate an id, do NOT touch INDEX.md. ` +
     `Return worktree:"", id:"" in the result.\n`
-  : `3. Create a worktree+branch by running git-create-branch "docs: design <shortname>" inside ${REPO}. ` +
-    `Allocate <id>: read ${REPO}/.autocode/design/INDEX.md (create with the header from design-folder.md if absent); ` +
+  : `3. Ensure a worktree per @~/.autocode/autocode/_config/guides/worktree.md (EnterWorktree / git worktree add under .claude/worktrees/). ` +
+    `Then delegate git-create-branch "docs: design <shortname>" inside that worktree. ` +
+    `Inside the worktree, derive repo_root=$(git rev-parse --show-toplevel). ` +
+    `Allocate <id>: read <repo_root>/.autocode/design/INDEX.md (create with the header from design-folder.md if absent); ` +
     `id = highest existing id + 1, zero-padded 4 digits (0001 if empty). ` +
-    `Write DESIGN.md into ${REPO}/.autocode/design/<id>-<shortname>/DESIGN.md (create the folder). ` +
-    `Append a row to INDEX.md: <id>, <shortname>, today's UTC date (date -u +%Y-%m-%d), active.\n`
+    `Write DESIGN.md into <repo_root>/.autocode/design/<id>-<shortname>/DESIGN.md (create the folder). ` +
+    `Append a row to INDEX.md: <id>, <shortname>, today's UTC date (date -u +%Y-%m-%d), active. ` +
+    `Return the worktree path as SYNTH_SCHEMA.worktree.\n`
 
 const synth = await agent(
   `Read ${designSkill('design-plan')} for DESIGN.md composition rules and section guidance. ` +
@@ -164,7 +167,7 @@ const synth = await agent(
   `Tasks (do all of these):\n` +
   `1. Compose the full DESIGN.md text following the section guidance in design-plan/SKILL.md and design-folder.md.\n` +
   `2. Derive <shortname> from the # <Title> H1: kebab-case, lowercase, 2-4 keywords, strip filler (the/a/an/is/of/for/to/in/on/with). ` +
-  `Dedup against ${REPO}/.autocode/design/INDEX.md rows and existing ${REPO}/.autocode/design/* folder names: on collision append -2, -3.\n` +
+  `Dedup against <repo_root>/.autocode/design/INDEX.md rows and existing <repo_root>/.autocode/design/* folder names: on collision append -2, -3 (use repo_root derived in step 3).\n` +
   synthTempInstructions +
   `4. Decide flat vs multi-unit per design-folder.md rules. ` +
   `If multi-unit, compute per-unit assignments: slug (kebab-case unique), one-line deliverable, depends-on (sibling slugs), issue type, and the relevant research snippet. ` +


### PR DESCRIPTION
## Overview

Adds `design-plan-workflow.mjs` as a background workflow script for the `design-plan` phase, making it orchestrator-ready. `design-plan --auto` becomes a thin launcher over this workflow; the non-`--auto` interactive path is unchanged.

## Problem Statement

- `design-plan` ran its entire heavy phase (research fan-out, synthesis, unit authoring) inline, blocking the orchestrator context.
- No structured result block existed for the orchestrator to consume after a plan phase.
- `design-unit-author` used an in-band signal for underspecified units instead of a typed contract.

## Implementation Notes

- New `design-plan-workflow.mjs`: four phases (`Research`, `Synthesize`, `Author`, `Resolve`) mirroring `impl-workflow.mjs` structure. Owns shortname derivation, worktree creation, `INDEX.md` allocation, and a bounded research-backed retry for underspecified units.
- `design-plan/SKILL.md`: `--auto` arg added as thin launcher; interactive path unchanged except shortname prompt dropped (auto-derived from title H1 in both modes, per DESIGN.md decision 7).
- `design-unit-author.md`: three-field output contract (`underspecified`, `file`, `summary`) usable via `schema` in workflow or as inline prose.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
* [x] `scripts/check-plugin-shape.sh` passes (workflow script carries no frontmatter)
* [x] Static structure matches `impl-workflow.mjs`: `args.homeDir` path resolution, `{ phase }` as option inside `parallel`, top-level `phase()` only

Closes #30

<!-- Issue linking (auto-added by tooling): -->