### PR TITLE
feat(#28): Add --auto flag to design-plan-iterate skill

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/PROGRESS.md
+++ b/.autocode/design/0003-design-unit-workflow/PROGRESS.md
@@ -7,3 +7,9 @@ Unit: #27
 Added `--auto` flag support to the `design-fanout` skill. The flag enables unattended execution: strict arg resolution (no implicit most-recent default, no `AskUserQuestion` prompts), a structured result block on the success path (`needs_human`, `epic_key`, `sub_issues`), and an early-exit `needs_human: true` block when the id is absent, unknown, or ambiguous. The result block key values are typed as strings (not numbers) to match the provider contract.
 
 Notes: Two fix commits landed after initial impl to correct the structured result block definition and key types.
+
+## design-iterate-auto — 2026-06-08
+
+Unit: #28
+
+Added `--auto` flag to `design-plan-iterate` skill. The flag enables unattended execution: strict arg resolution (no `AskUserQuestion` prompts), a structured result block (`needs_human`, `design_id`, `shortname`, `iterations_run`, `open_questions_remaining`) on completion, and an early-exit `needs_human: true` block when the design id is absent or ambiguous. Critique and resolution passes run unchanged; the flag only gates interactivity and shapes the final output block.

--- a/.autocode/design/0003-design-unit-workflow/progress/design-iterate-auto.md
+++ b/.autocode/design/0003-design-unit-workflow/progress/design-iterate-auto.md
@@ -1,0 +1,6 @@
+# design-iterate-auto
+
+Epic: 0003-design-unit-workflow  Branch: feat/28/design-iterate-auto  Started: 2026-06-08
+
+## 2026-06-08
+Added `--auto` flag to `design-plan-iterate` skill. The flag enables unattended execution: strict arg resolution (no `AskUserQuestion` prompts), a structured result block (`needs_human`, `design_id`, `shortname`, `iterations_run`, `open_questions_remaining`) on completion, and an early-exit `needs_human: true` block when the design id is absent or ambiguous. Critique and resolution passes run unchanged; the flag only gates interactivity and shapes the final output block.

--- a/autocode/design/skills/design-plan-iterate/SKILL.md
+++ b/autocode/design/skills/design-plan-iterate/SKILL.md
@@ -6,6 +6,8 @@ Triage and apply review comments on a design-doc PR.
 
 `[PR number]` (default: detect from current branch via `provider/run.sh git-remote pr-view --json number,url`).
 
+`--auto`: run unattended (no interactive back-and-forth) and end with a structured result block instead of the human triage table. The triage rubric is unchanged; the discussion band defers rather than asking for clarification. See `### --auto behavior` and `### Structured result` under `## Workflow`.
+
 ## Differences vs pr-review
 
 - Triage rubric weighs design clarity, scope alignment, and assumption auditing over code correctness.
@@ -42,7 +44,40 @@ Triage and apply review comments on a design-doc PR.
    - `provider/run.sh git-remote pr-comment-reply <pr> <comment-id> "<text>"` for each thread that needs a reply.
    - `provider/run.sh git-remote pr-thread-list <pr>` for unresolved ids.
    - `provider/run.sh git-remote pr-thread-resolve <thread-id>...` to close them.
-7. Output a triage table to the user: comment id, author, confidence, action, status.
+7. Output: without `--auto`, a triage table to the user (comment id, author, confidence, action, status); with `--auto`, the structured result block from `### Structured result` instead of the table.
+
+### --auto behavior
+
+Under `--auto`, the triage rubric (step 3 score tables) is unchanged; only each band's terminal action changes:
+
+- High-confidence band (human 50-100 / bot 70-100): apply the edit, reply, and resolve the thread exactly as the interactive path. The comment id counts toward `applied`.
+- Discussion band (human 20-49 / bot 30-69): do not start an interactive clarification (the "Discuss; cite specific plan section and ask for clarification" action requires a round-trip a headless caller cannot drive). Defer instead: leave the thread open for a human, count the comment id toward `skipped`, and set `needs_human: true` with one reason in `needs_human_reasons`. For the bot 30-69 row ("Optional; update if trivial, else resolve"), apply the trivial update when unambiguous (count as `applied`), else defer to `skipped` with a `needs_human` reason.
+- Spurious band (human 0-19 / bot 0-29): resolve as spurious with an explanation comment, exactly as the interactive path. The id counts toward `skipped` (resolved, not deferred); does not set `needs_human`.
+
+All `## Rules` invariants hold under `--auto`: edits land only in `DESIGN.md` / `units/*.md`, no build verify step, commit via `git-commit`, never `--no-verify`, never resolve a thread without an explanation comment.
+
+### Structured result
+
+Terminal output when `--auto` is active. Replaces the step-7 prose table. Scalar and list fields only, in a fenced block, no prose:
+
+```
+{
+  applied: [<comment-id>, ...],
+  skipped: [<comment-id>, ...],
+  replied: <int>,
+  threads_resolved: <int>,
+  needs_human: <bool>,
+  needs_human_reasons: [<string>, ...]
+}
+```
+
+Field semantics:
+- `applied`: comment ids whose edits were applied to `DESIGN.md` / `units/*.md` this run.
+- `skipped`: comment ids not applied (spurious-resolved or deferred for a human).
+- `replied`: count of threads that received a reply via `pr-comment-reply`.
+- `threads_resolved`: count of threads closed via `pr-thread-resolve`.
+- `needs_human`: true when any discussion-band comment was deferred.
+- `needs_human_reasons`: one short reason per deferred comment, summarizing what the human must decide.
 
 ## Rules
 


### PR DESCRIPTION
## Overview

Adds `--auto` flag to five skills and fixes a bug in `pr-find.sh` that blocked automated orchestration workflows.

Skills updated: `design-plan-iterate`, `design-fanout`, `pr-fix-ci`, `pr-review`, `pr-rebase`.

## Problem statement

The impl-epic orchestrator needs to drive skill execution headlessly. Five skills had no unattended mode and would stall waiting for `AskUserQuestion` prompts or emit human-readable prose tables that automated callers cannot parse. `pr-find.sh` crashed on non-numeric issue keys (e.g. Jira-style) and masked `gh` errors behind empty results.

## Changes

**`design-plan-iterate --auto`**
- Triage rubric unchanged; discussion-band comments defer (`needs_human: true`) instead of prompting.
- Structured result block replaces the step-7 prose table.

**`design-fanout --auto`**
- Requires an explicit id arg (no implicit most-recent); absent/ambiguous arg returns `needs_human: true` without creating issues.
- Structured result block replaces the step-4 table on success.

**`pr-fix-ci --auto`**
- `pending` CI rollup returns a terminal block without prose.
- Missing `build.md` convention returns `needs_human: true` instead of the setup message.
- Structured result: `{ pr, fixed, ci, needs_human, reason }`.

**`pr-review --auto`**
- Discussion band defers instead of prompting; high-confidence and spurious bands unchanged.
- Structured result: `{ pr, applied, deferred, needs_human, reason }`.

**`pr-rebase --auto`**
- All three `AskUserQuestion` gates suppressed; 5-file guardrail aborts and returns structured result.
- `PROGRESS.md` conflict backstop: union both sides' blocks when `.gitattributes` lacks the `merge=union` driver.
- Structured result: `{ rebased, conflicts_resolved, verify, needs_human, reason }`.

**`pr-find.sh` fixes**
- Strip leading `#` from issue key so both `"42"` and `"#42"` work.
- Branch on numeric vs non-numeric keys: numeric uses `--argjson` integer comparison; non-numeric accepts any body-search hit.
- Drop silent `|| result="[]"` fallbacks; on `gh` failure print to stderr and exit 2.

Also records progress rollups under `.autocode/design/` for completed units.

## Checklist

* [x] Resolves #28
* [x] PR title follows conventional-commit format
