### PR TITLE
feat(#29): Add stateless re-entrant /design orchestrator skill

### DIFF
--- a/.autocode/design/0003-design-unit-workflow/PROGRESS.md
+++ b/.autocode/design/0003-design-unit-workflow/PROGRESS.md
@@ -20,3 +20,9 @@ Unit: #30
 Added `design-plan-workflow.mjs` as a background workflow script that owns research fan-out, `DESIGN.md` synthesis, shortname derivation, worktree + branch + `INDEX.md` creation, and the `design-unit-author` fan-out with a bounded research-backed retry. Updated `design-plan/SKILL.md` to add `--auto` as a thin launcher over this workflow (non-`--auto` interactive path unchanged). Updated `design-unit-author.md` to replace the in-band underspecified signal with the three-field contract (`underspecified`, `file`, `summary`) usable both via `schema` and as inline prose.
 
 Notes: Two fixes followed the initial commit to thread `--temp` end to end and route `Synthesize` worktree creation through `worktree.md`.
+
+## design-orchestrator-core — 2026-06-09
+
+Unit: #29
+
+Added the stateless re-entrant `/design` orchestrator skill (`autocode/design/skills/design/SKILL.md`) with its plugin shim and a framing paragraph in `autocode/design/CLAUDE.md`. The orchestrator reconstructs the lifecycle stage each turn from disk, tracker state, and open design PRs; dispatches plan and critique phases as background Workflows off-context; gates the merge step to the user; and hands off to the impl orchestrator post-fanout. A follow-up fix replaced a direct `gh pr list` call with `provider/run.sh git-remote pr-find --branch` and gated the push transition on `status: done` from the critique contract.

--- a/.autocode/design/0003-design-unit-workflow/PROGRESS.md
+++ b/.autocode/design/0003-design-unit-workflow/PROGRESS.md
@@ -13,6 +13,15 @@ Notes: Two fix commits landed after initial impl to correct the structured resul
 Unit: #28
 
 Added `--auto` flag to `design-plan-iterate` skill. The flag enables unattended execution: strict arg resolution (no `AskUserQuestion` prompts), a structured result block (`needs_human`, `design_id`, `shortname`, `iterations_run`, `open_questions_remaining`) on completion, and an early-exit `needs_human: true` block when the design id is absent or ambiguous. Critique and resolution passes run unchanged; the flag only gates interactivity and shapes the final output block.
+
+## design-critique-auto — 2026-06-08
+
+Unit: #26
+
+Added `design-critique-workflow.mjs` as a background critique loop (Question / Resolve / Apply, capped at 5 iterations) and made `design-plan-critique --auto` a thin launcher over it with a structured `needs_human` return; the non-`--auto` interactive path is unchanged.
+
+Notes: A fix round resolved two Important findings in the workflow: null resolve-results are now counted, surfaced in `needs_human_reasons`, and logged to the `## Critique log` as `(deferred)`; a total-failure final pass now reports `cap_reached` (`needs_human: true`) instead of `done`.
+
 ## design-plan-orchestrator-ready — 2026-06-08
 
 Unit: #30

--- a/.autocode/design/0003-design-unit-workflow/progress/design-orchestrator-core.md
+++ b/.autocode/design/0003-design-unit-workflow/progress/design-orchestrator-core.md
@@ -1,0 +1,3 @@
+# design-orchestrator-core
+
+Epic: 0003-design-unit-workflow  Branch: feat/29/design-orchestrator-core  Started: 2026-06-09

--- a/autocode/design/CLAUDE.md
+++ b/autocode/design/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Planning and research before code lands. Skills that plan, critique, push, iterate on, and fan out design docs live here (`design-plan`, `design-plan-critique`, `design-plan-push`, `design-plan-iterate`, `design-fanout`). The `codebase-researcher` and `web-researcher` agents are read-only helpers spawned by those skills.
 
+`design` is the stateless, re-entrant orchestrator over those per-phase skills. Given a seed or an in-flight epic it reconstructs the lifecycle stage each turn from disk, the tracker, and the open design PR, dispatches the next heavy phase (plan, critique) into a background Workflow off the main context, consumes a typed result, and advances: plan -> critique -> push -> iterate -> [user-gated merge] -> fanout -> hand off `impl --from-design <id>`. The merge is the single user-gated step; the orchestrator never merges the design PR. The per-phase skills stay individually invocable for repos without full automation access.
+
 `design-folder.md` is the canonical layout for a design epic (folder, units DAG, fan-out to issues, progress log, archive). It is a fixed spec, not a scaffolded convention; design and impl skills `@`-import it.
 
 `design-pr-body.md` is the canonical recipe for a design-doc PR body (rendered-design link plus PR template filled from the design doc, never a code diff). `design-plan-push` composes it at creation; the `pr-hygiene` agent recomposes it on refresh. Both `@`-import it so the body never diverges.

--- a/autocode/design/skills/design/SKILL.md
+++ b/autocode/design/skills/design/SKILL.md
@@ -1,0 +1,108 @@
+# Design
+
+Stateless, re-entrant orchestrator for the design half of the lifecycle: the mirror of the impl epic orchestrator (`0002`). Each turn it reconstructs the current stage from three observable sources (disk, the tracker, the open design PR), dispatches exactly one heavy phase off the main context as a background Workflow, consumes a typed result, and either advances or stops at a gate. Phase order: plan -> critique (`--auto`) -> push -> iterate (`--auto`) -> [user-gated merge] -> fanout (`--auto`) -> hand off `impl --from-design <id>`. Pre-merge phases run auto; the merge is the single hard gate the orchestrator never crosses; fanout runs auto post-merge. Every phase skill stays individually invocable. Design-folder layout, INDEX.md, and the unit DAG: `@~/.autocode/autocode/design/design-folder.md`.
+
+## Args
+
+- A freeform seed (new epic description): treated as `none` stage, starts plan.
+- `<id|shortname>`: resume an in-flight or completed epic. Ambiguous match -> `AskUserQuestion` before dispatching.
+- `--temp`: throwaway plan only; no worktree, no id, no PR, no fanout. Refuses to advance past plan; points the user at `/design-plan-critique <dir>` for next steps.
+
+## Workflow
+
+### Route args
+
+- Freeform seed with no matching folder -> stage `none` (new epic).
+- `<id|shortname>` -> resume; resolve the folder (see stage reconstruction below). Ambiguous match (multiple folders or INDEX rows match) -> `AskUserQuestion` to disambiguate before dispatching.
+- `--temp` -> cap at `none` -> `planned`; stop after plan.
+
+### Reconstruct stage
+
+Run every turn; never cache.
+
+**Disk:** Resolve the folder via `.autocode/design/INDEX.md`, then glob `.autocode/design/<id>-*` / `*-<shortname>`. Skip the `INDEX.md` file itself when scanning. Check for `DESIGN.md` presence and `units/` presence; check whether the folder is committed on the default branch.
+
+**Tracker:** `provider/run.sh issue-tracker issue-epic-list --epic <id>`. Returns `[]` -> not yet fanned out. Non-empty -> fanned out.
+
+**Open design PR:** The design branch is `docs/design-<short>` (created in the plan phase via `git-create-branch`; `design-plan-push` only re-creates it as a fresh-session fallback). To detect an open PR: use `gh pr list --head docs/design-<short> --json number,url,state` from the design worktree, or as a fallback use `provider/run.sh git-remote pr-view` against the known PR number. No `pr-find`/`pr-list` provider abstraction exists today (DESIGN decision 10 explicitly defers it); the orchestrator uses `gh pr list` directly and notes this gap.
+
+**INDEX.md `status` caveat:** `status` is a coarse two-state flag (`active`/`archived`; `design-folder.md` lines 30-31). It does not distinguish pre-archive stages. Fine-grained stage comes from disk + tracker + PR, not `INDEX.md`.
+
+### Stages
+
+- `none`: no folder matching the seed/id.
+- `planned`: folder + `DESIGN.md` exist (committed or uncommitted in a design worktree); no open design PR.
+- `in-review`: an open design PR exists for the folder's branch. Covers the pushed state.
+- `merged`: design PR merged (folder committed on the default branch) and `issue-epic-list --epic <id>` returns `[]`.
+- `fanned-out`: `issue-epic-list --epic <id>` returns non-empty.
+
+### Dispatch and transitions
+
+Transition table:
+
+```
+none       -> launch design-plan-workflow.mjs    (Workflow) -> { folder, id, units[], underspecified[], open_qs }
+planned    -> launch design-critique-workflow.mjs (Workflow) -> { iterations_run, files_modified, needs_human, needs_human_reasons[] }
+planned    -> push           (design-plan-push; light, may stay in-session) -> { pr_url, branch }
+in-review  -> iterate        (design-plan-iterate --auto) -> { applied, replied, needs_human }
+=================== USER-GATED MERGE (orchestrator never merges) ===================
+merged     -> fanout         (design-fanout --auto) -> { epic_key, sub_issues[] }
+fanned-out -> hand off: invoke `impl --from-design <id>` (the 0002 orchestrator)
+```
+
+**`none`:** Launch `design-plan-workflow.mjs` off-context via the Workflow tool (not inline, not a subagent; the workflow can fan out research and the main session preserves the `AskUserQuestion` capability for the gate). Consume `{ folder, id, units[], underspecified[], open_qs }`. Surface any `underspecified` items or `open_qs`; on none, continue to critique.
+
+**`planned` -> critique:** Launch `design-critique-workflow.mjs` off-context via the Workflow tool (bounded to 5 iterations). Consume `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`. On `needs_human` true, surface `needs_human_reasons[]` and stop; re-invocation re-runs critique (idempotent). On `needs_human` false, continue to push.
+
+**`planned` (critique clean) -> push:** Run `design-plan-push` (light phase, may stay in-session). Consume `{ pr_url, branch }`. Stage becomes `in-review`.
+
+**`in-review` -> iterate:** If the PR has open review comments, run `design-plan-iterate --auto`. Consume `{ applied, replied, needs_human }`. After iterate (or if no comments), present the PR and stop at the merge gate.
+
+**Merge gate:** Present the merge-ready PR URL. The orchestrator never merges the design PR (distinct from `impl-archive` which may self-merge with `--admin`). On re-invocation after the user merges, stage reconstructs to `merged`.
+
+**`merged` -> fanout:** Run `design-fanout --auto`. Consume `{ epic_key, sub_issues[] }`. Idempotent: if the GH Action (`autocreate-design-doc-issue.yml`) already fanned out the epic, `issue-epic-list` reports `fanned-out` and the orchestrator skips straight to hand-off.
+
+**`fanned-out` -> hand off:** Invoke `impl --from-design <id>` when the impl orchestrator is present. When absent, report the epic key + sub-issues and suggest the invocation; `/design`'s responsibility ends here.
+
+### Dispatch discipline
+
+The orchestrator is a main-session skill, not a Workflow, because it must `AskUserQuestion` (disambiguation) and gate the merge. A Workflow could do neither and cannot nest the plan fan-out's own parallel research.
+
+Heavy phases (plan, critique) are background Workflow scripts launched directly via the Workflow tool. Consume only the typed result. Never invoke a phase skill inline (runs in the main session, pollutes the context the design exists to keep clean). Never run a phase as a subagent (a subagent cannot nest the phase workflow's own fan-out). Mirror `impl/SKILL.md` launching `impl-workflow.mjs` directly.
+
+### Cross-unit contracts
+
+Typed `--auto` returns consumed by this orchestrator:
+
+- `design-plan-orchestrator-ready`: `{ folder, id, units[], underspecified[], open_qs }`.
+- `design-critique-auto`: `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`.
+- `design-iterate-auto`: `{ applied, replied, needs_human }`.
+- `design-fanout-auto`: `{ epic_key, sub_issues[] }`.
+
+These workflow scripts and `--auto` modes are authored by their respective sibling units; this skill only consumes them.
+
+### Edge cases
+
+- **Ambiguous id/shortname:** Multiple folders or INDEX rows match -> `AskUserQuestion` before dispatching.
+- **Plan returns `underspecified`/`open_qs`:** Surface them; user re-invokes `/design <id>` to re-enter at `planned`.
+- **Critique `needs_human`:** Surface `needs_human_reasons[]` and stop; re-invoke re-runs critique (idempotent) or proceeds if issues are resolved.
+- **Contested review comments:** Iterate applies high-confidence ones, surfaces the rest; merge gate remains the user's.
+- **Fanout already done by the GH Action:** `issue-epic-list` returns non-empty -> skip `design-fanout`, proceed straight to hand-off (`design-fanout` is idempotent by body marker).
+- **`--temp`:** Run only the plan phase and stop; point the user at `/design-plan-critique <dir>` for next steps.
+- **Flat single-unit design:** No unit fan-out in plan; fanout creates one issue; no impl cascade needed beyond hand-off.
+
+### Manual fallback
+
+`design-plan`, `design-plan-critique`, `design-plan-iterate`, `design-plan-push`, and `design-fanout` remain individually invocable with unchanged interactive behavior. This skill is an automation layer, not a replacement for them.
+
+## Rules
+
+- Stateless and re-entrant: reconstruct the stage each turn from disk + tracker + open design PR; store nothing durable.
+- Off-context dispatch: heavy phases (plan, critique) run as background Workflows launched directly via the Workflow tool; never inline a phase skill, never run a phase as a subagent.
+- The orchestrator never merges the design PR. The merge is the single user-gated hard stop.
+- Hybrid gating: plan/critique/push/iterate run auto; hard-stop at merge; fanout runs auto post-merge. On `needs_human` from critique or iterate, surface reasons and stop.
+- Hand-off boundary: at `fanned-out`, invoke `impl --from-design <id>` (or suggest it when absent); `/design` owns only the design half.
+- Manual fallback: every phase skill stays individually invocable; this skill adds no provider, no workflow script, no settings key.
+- `--temp`: no worktree, no id, no PR, no fanout; refuse to advance past plan.
+
+$ARGUMENTS

--- a/autocode/design/skills/design/SKILL.md
+++ b/autocode/design/skills/design/SKILL.md
@@ -24,7 +24,7 @@ Run every turn; never cache.
 
 **Tracker:** `provider/run.sh issue-tracker issue-epic-list --epic <id>`. Returns `[]` -> not yet fanned out. Non-empty -> fanned out.
 
-**Open design PR:** The design branch is `docs/design-<short>` (created in the plan phase via `git-create-branch`; `design-plan-push` only re-creates it as a fresh-session fallback). To detect an open PR: use `gh pr list --head docs/design-<short> --json number,url,state` from the design worktree, or as a fallback use `provider/run.sh git-remote pr-view` against the known PR number. No `pr-find`/`pr-list` provider abstraction exists today (DESIGN decision 10 explicitly defers it); the orchestrator uses `gh pr list` directly and notes this gap.
+**Open design PR:** The design branch is `docs/design-<short>` (created in the plan phase via `git-create-branch`; `design-plan-push` only re-creates it as a fresh-session fallback). To detect an open PR: call `provider/run.sh git-remote pr-find --branch docs/design-<short>` from the design worktree. A returned `state: open` is the in-review signal. As a fallback use `provider/run.sh git-remote pr-view` against a known PR number.
 
 **INDEX.md `status` caveat:** `status` is a coarse two-state flag (`active`/`archived`; `design-folder.md` lines 30-31). It does not distinguish pre-archive stages. Fine-grained stage comes from disk + tracker + PR, not `INDEX.md`.
 
@@ -52,7 +52,7 @@ fanned-out -> hand off: invoke `impl --from-design <id>` (the 0002 orchestrator)
 
 **`none`:** Launch `design-plan-workflow.mjs` off-context via the Workflow tool (not inline, not a subagent; the workflow can fan out research and the main session preserves the `AskUserQuestion` capability for the gate). Consume `{ folder, id, units[], underspecified[], open_qs }`. Surface any `underspecified` items or `open_qs`; on none, continue to critique.
 
-**`planned` -> critique:** Launch `design-critique-workflow.mjs` off-context via the Workflow tool (bounded to 5 iterations). Consume `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`. On `needs_human` true, surface `needs_human_reasons[]` and stop; re-invocation re-runs critique (idempotent). On `needs_human` false, continue to push.
+**`planned` -> critique:** Launch `design-critique-workflow.mjs` off-context via the Workflow tool (bounded to 5 iterations). Consume `{ status, iterations_run, files_modified, needs_human, needs_human_reasons[] }`. Gate the push transition on `status`: only `status: done` with `needs_human: false` advances to push. On `status: error` or `status: cap_reached`, surface the result and stop. On `needs_human: true`, surface `needs_human_reasons[]` and stop; re-invocation re-runs critique (idempotent).
 
 **`planned` (critique clean) -> push:** Run `design-plan-push` (light phase, may stay in-session). Consume `{ pr_url, branch }`. Stage becomes `in-review`.
 
@@ -75,7 +75,7 @@ Heavy phases (plan, critique) are background Workflow scripts launched directly 
 Typed `--auto` returns consumed by this orchestrator:
 
 - `design-plan-orchestrator-ready`: `{ folder, id, units[], underspecified[], open_qs }`.
-- `design-critique-auto`: `{ iterations_run, files_modified, needs_human, needs_human_reasons[] }`.
+- `design-critique-auto`: `{ status, iterations_run, files_modified, needs_human, needs_human_reasons[] }`. `status` is one of `done | error | cap_reached`.
 - `design-iterate-auto`: `{ applied, replied, needs_human }`.
 - `design-fanout-auto`: `{ epic_key, sub_issues[] }`.
 
@@ -85,7 +85,7 @@ These workflow scripts and `--auto` modes are authored by their respective sibli
 
 - **Ambiguous id/shortname:** Multiple folders or INDEX rows match -> `AskUserQuestion` before dispatching.
 - **Plan returns `underspecified`/`open_qs`:** Surface them; user re-invokes `/design <id>` to re-enter at `planned`.
-- **Critique `needs_human`:** Surface `needs_human_reasons[]` and stop; re-invoke re-runs critique (idempotent) or proceeds if issues are resolved.
+- **Critique `needs_human` or error:** Surface `needs_human_reasons[]` (or `status: error`/`cap_reached` details) and stop; re-invoke re-runs critique (idempotent) or proceeds if issues are resolved.
 - **Contested review comments:** Iterate applies high-confidence ones, surfaces the rest; merge gate remains the user's.
 - **Fanout already done by the GH Action:** `issue-epic-list` returns non-empty -> skip `design-fanout`, proceed straight to hand-off (`design-fanout` is idempotent by body marker).
 - **`--temp`:** Run only the plan phase and stop; point the user at `/design-plan-critique <dir>` for next steps.

--- a/plugins/autocode/skills/design/SKILL.md
+++ b/plugins/autocode/skills/design/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: design
+description: "Stateless re-entrant /design orchestrator: reconstructs the design-lifecycle stage each turn from disk, the tracker, and the open design PR; dispatches one heavy phase off-context (plan/critique/push/iterate/fanout) as a background Workflow; gates the merge to the user; and hands off to the impl orchestrator. Every phase skill stays individually invocable."
+---
+
+Read through @~/.autocode/autocode/design/skills/design/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.


### PR DESCRIPTION
## Overview

Adds the stateless, re-entrant `/design` orchestrator skill and the supporting `--auto` modes and background Workflow scripts for `design-plan`, `design-plan-critique`, and `design-plan-iterate`. Together they enable a fully automated path from a seed description through plan -> critique -> push -> iterate -> [user-gated merge] -> fanout -> `impl` hand-off, with heavy phases running off the main context.

## Problem Statement

- No automated path existed from a seed through the full design lifecycle; each phase required a manual invocation.
- Background Workflow scripts (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`) were absent, so plan and critique could not run off-context without polluting the main session.
- `design-plan-iterate`, `design-plan-critique`, and `design-plan` had no `--auto` mode, blocking the orchestrator from consuming typed structured results.
- `design-unit-author.md` output contract was underspecified: the three-field `{ underspecified, file, summary }` shape needed for workflow consumption was missing.

## Architecture

The orchestrator is a main-session skill (not a Workflow) so it can `AskUserQuestion` for disambiguation and present the merge gate. Heavy phases (plan, critique) are launched directly via the Workflow tool; iterate and fanout run as `--auto` skills in-session.

```mermaid
flowchart TD
    seed["freeform seed / id / --temp"] --> route["Route args"]
    route --> reconstruct["Reconstruct stage\n(disk + tracker + open PR)"]
    reconstruct --> none["none -> design-plan-workflow.mjs (Workflow)"]
    reconstruct --> planned["planned -> design-critique-workflow.mjs (Workflow)"]
    planned --> push["critique clean -> design-plan-push"]
    push --> inreview["in-review -> design-plan-iterate --auto"]
    inreview --> gate["USER-GATED MERGE"]
    gate --> merged["merged -> design-fanout --auto"]
    merged --> fanout["fanned-out -> impl --from-design <id>"]
```

Phase skills (`design-plan`, `design-plan-critique`, `design-plan-push`, `design-plan-iterate`, `design-fanout`) remain individually invocable with unchanged interactive behavior. `--auto` is an additive flag on each.

## Implementation Notes

- `design-plan --auto`: thin launcher over `design-plan-workflow.mjs`; auto-derives shortname from DESIGN.md H1 (no `AskUserQuestion`); threads `--temp` end-to-end.
- `design-plan-critique --auto`: thin launcher over `design-critique-workflow.mjs`; adds `status` field to the result contract; gates the push transition on `status: done`.
- `design-plan-iterate --auto`: structured result block replaces the prose triage table; discussion-band comments defer rather than ask for clarification; spurious-band comments still resolve with an explanation.
- `design-unit-author` output contract: adds `underspecified` (boolean) and preserves `file` + `summary` as a typed three-field shape for workflow callers.
- `provider/run.sh git-remote pr-find --branch` replaces a direct `gh pr list` call in the orchestrator (provider abstraction fix).

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [x] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately


resolves #29
