### PR TITLE
fix: Tolerate JSON-string args in impl-workflow

### DIFF
--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -16,11 +16,13 @@ export const meta = {
 
 // args (from the impl launcher): { homeDir, worktree, slug, base, dims }
 // unit_key/design_id are not passed: phases read them from .autocode/.impl-context in the worktree.
-const HOME = args.homeDir
-const WT = args.worktree
-const SLUG = args.slug
-const BASE = args.base
-const DIMS = args.dims ? String(args.dims).split(',').map((d) => d.trim()).filter(Boolean) : null
+// The runtime may deliver args as a JSON string rather than a parsed object.
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const HOME = A.homeDir
+const WT = A.worktree
+const SLUG = A.slug
+const BASE = A.base
+const DIMS = A.dims ? String(A.dims).split(',').map((d) => d.trim()).filter(Boolean) : null
 const MAX_FIX_ROUNDS = 2
 
 // Subagents cannot spawn subagents, so all fan-out lives here in the workflow


### PR DESCRIPTION
## Overview

Parse `args` when the Workflow runtime delivers it as a JSON string in `impl-workflow.mjs`, instead of assuming a parsed object.

## Problem Statement

- The Workflow tool can hand the script `args` as a JSON string rather than a parsed object.
- Reading `args.homeDir` (and `worktree`, `slug`, `base`, `dims`) off a string yields `undefined`, so every phase loses its inputs and the impl workflow breaks.
- The fix had been applied only to the installed mirror at `~/.autocode/`, which blocked updates; this lands it in the canonical source.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
