### PR TITLE
docs: Design impl-fanout epic

### DIFF
--- a/.autocode/design/0004-impl-fanout/DESIGN.md
+++ b/.autocode/design/0004-impl-fanout/DESIGN.md
@@ -1,0 +1,148 @@
+# Fanout mode for heavy impl units
+
+## Summary
+
+The `impl` Execute phase runs one sonnet agent that carries a unit's entire plan (`impl-workflow.mjs:180-185`). On a heavy unit that single agent fills and compacts its context window repeatedly, degrading quality. This epic adds an opt-in fanout mode: `impl-plan` partitions the plan into a foundation set plus file-disjoint module groups; the workflow runs one fresh sonnet agent per module in parallel (small context each), then a single sequential commit step (parallel agents in one worktree would race on `.git/index`); and a new read-only `impl-gapcheck` leaf verifies every plan item was implemented, looping a bounded fix pass until the spec is covered. Fanout and the gapcheck gate trigger on heaviness, computed from the plan; light units keep the current single-agent path unchanged.
+
+## Background
+
+The implementation phase is a background Workflow (`impl-workflow.mjs`) of per-phase agents, each with a fixed model: opus for reasoning/review, sonnet for mechanical work. Today:
+
+| Piece | File | Current behavior |
+|---|---|---|
+| Plan format | `impl-plan/SKILL.md` | Flat per-file task list + test plan + order + out-of-scope, written to `.autocode/.impl-plan.md`. No module grouping. |
+| Execute | `impl-workflow.mjs:180-185` | One sonnet agent runs `impl-execute --auto` over the whole plan and commits via `git-commit`. |
+| Execute skill | `impl-execute/SKILL.md` | Default mode executes the plan and commits; `--fix <findings>` applies review findings. Always commits via `git-commit`. |
+| Review | `impl-workflow.mjs:130-198` | `reviewCycle` fans out per-dimension reviewers (opus), challenges, decides, then `impl-execute --fix` loop capped at `MAX_FIX_ROUNDS = 2`. |
+| Concurrency | `impl/SKILL.md:49` | Orchestrator reads `impl.max-concurrent-units` from `$AUTOCODE_CONFIG_DIR/settings.json`, forwards `args: { homeDir, worktree, slug, base, dims }` to the workflow. |
+
+The fanout pattern already exists in this file (`reviewCycle` uses `parallel()` + per-leaf `agent()` calls with JSON schemas), because subagents cannot spawn subagents, so all fan-out lives in the workflow runtime. This epic applies the same shape to Execute.
+
+## Architecture
+
+No new dependencies. One new leaf skill (`impl-gapcheck`, real + shim), edits to two existing skills (`impl-plan`, `impl-execute`), one workflow rewrite of the Execute region (`impl-workflow.mjs`), one orchestrator edit (`impl/SKILL.md`), one settings row, one setup prompt.
+
+Execute-phase fork (the only behavioral change):
+
+```
+                    Plan (opus) -> .autocode/.impl-plan.md
+                                   (now carries ## Module partition)
+                                          |
+                              Partition assess (sonnet)
+                          reads plan -> { files_total, heavy,
+                            partitionable, foundation, modules[] }
+                                          |
+                    heavy = partition agent's judgment
+                    fanout = heavy && partitionable && mode != off
+                                          |
+            +-----------------------------+-----------------------------+
+            | fanout                       | heavy, not fanout           | light
+            v                              v                             v
+   Foundation (sonnet,             Execute (sonnet,               Execute (sonnet,
+   --module foundation             --auto, single agent,          --auto, single agent,
+   --no-commit)                    commits itself)                commits itself)
+            |                              |                             |
+   Modules (parallel sonnet,              |                             |
+   one per group,                         |                             |
+   --module <name> --no-commit)           |                             |
+            |                              |                             |
+   Commit (sonnet, sequential             |                             |
+   git-commit per group)                  |                             |
+            +--------------+---------------+                             |
+                           v                                            |
+                  GapCheck loop (heavy only)                            |
+                  gapcheck (opus, read-only) -> { complete, gaps[] }    |
+                  while gaps && round < GAP_MAX_ROUNDS:                  |
+                    impl-execute --fix (sonnet) -> recheck              |
+                           |                                            |
+                           +--------------------+-----------------------+
+                                                v
+                          reviewCycle / Push / Hygiene (unchanged)
+```
+
+## Design decisions
+
+1. **`impl-plan` owns the partition; a thin workflow agent only transcribes it.** The planner already resolves every signature and data shape and knows the file DAG, so it decides the foundation/module split and writes it into `## Module partition`. The workflow's Partition agent reads that section into JSON for `parallel()`; it does not re-infer groups from the file list. Rejected: a workflow-side prep agent that infers grouping from changed files. It would have to re-derive dependencies the planner already knows, and would split modules that secretly share an interface.
+
+2. **Modules write only; one sequential agent commits.** Parallel agents share one worktree and one `.git/index`; concurrent `git add`/`git commit` corrupt the index. So module agents run `impl-execute --no-commit` (working-tree writes only) and a dedicated Commit agent runs after the barrier, calling `git-commit` once per module group, foundation first then modules in listed order. Modules are file-disjoint and share nothing but foundation interfaces, so there is no inter-module dependency order to respect; listed order is deterministic and sufficient. A single agent committing serially is race-free and preserves logical per-module commits (and each commit still fires the Stop-hook progress logging). Rejected: each module commits itself (index race); one monolithic commit of the whole join (loses logical granularity and progress-log resolution).
+
+3. **Foundation pass runs before fanout.** A module may need a type or interface another module defines, but a parallel sibling cannot see uncommitted work. Modules build blind against the plan's resolved signatures; anything genuinely shared (types, contracts, interfaces) goes in an optional `### Foundation` group implemented sequentially first. This raises the bar on `impl-plan`: the partition is only emitted when interfaces are concrete enough that modules compile without seeing each other. Rejected: no foundation, rely solely on the plan spec. Works for leaf modules but breaks the moment two modules share a new type.
+
+4. **Heaviness gates both fanout and gapcheck; judged by the model from the plan, not a hardcoded threshold or per-unit config.** The Partition agent judges `heavy` from the whole plan (file count, total plan size, cross-file coupling, compaction risk) and returns it as a `heavy` boolean; there is no `HEAVY_FILES` constant. `files_total` is still returned as a plan-wide signal (count of all in-scope planned files, independent of the partition) so heaviness holds even when `partitionable: false`. Heavy + partitionable + mode-on -> fanout. Heavy + not partitionable -> single agent but still gapchecked (this is the user's exact pain case: a big unit that compacts, where the completeness net matters most). Light -> current path, no gapcheck overhead. Rejected: a fixed file-count threshold (a 7-file unit with deep coupling compacts harder than a 20-file unit of independent stubs; the model reads the plan and judges directly). Rejected: a per-unit fanout flag in the design folder (the planner's partition already encodes suitability; a separate flag would drift).
+
+5. **`impl.fanout-mode` setting: `auto` (default) | `off` | `on`.** `auto` fans out heavy partitionable units; `off` forces the single-agent path always; `on` fans out any partitionable unit regardless of the file threshold. The orchestrator reads it and forwards `fanout` in the workflow args, mirroring how `impl.max-concurrent-units` and `dims` already flow. Gapcheck is independent of this setting (it gates on heaviness, not fanout), so turning fanout off still protects heavy units. Rejected: a hardcoded always-on threshold with no override (users on constrained machines or with non-partitionable codebases need the escape hatch).
+
+6. **GapCheck is a new leaf, not part of `impl-critique`.** `impl-critique` answers "is this code correct/secure/fast"; gapcheck answers "is every plan item present". Different question, different prompt, different schema (`{ complete, gaps[] }`). It is read-only and run by the workflow exactly like the `impl-critique-*` leaves (path via `skill()`, `follow()`, a JSON schema). Rejected: adding a "completeness" dimension to `impl-critique-review` (conflates a spec-coverage check with a quality review and would run on every unit, not just heavy ones).
+
+7. **GapCheck runs opus, fix runs sonnet.** A fresh-context sonnet checker would share the blind spots of the sonnet that just compacted; the value is an independent reasoning pass over the spec, so gapcheck is opus (matching the review phase). The fix is mechanical, so it reuses `impl-execute --fix` on sonnet. The loop caps at `GAP_MAX_ROUNDS = 2`, mirroring `MAX_FIX_ROUNDS`; remaining gaps surface in the workflow result like `remaining_important`.
+
+## Runtime flow
+
+1. Plan (opus, unchanged trigger): `impl-plan --auto` writes `.autocode/.impl-plan.md` including the new `## Module partition` section.
+2. Partition assess (sonnet, new): an agent reads the plan and returns `{ files_total, heavy, partitionable, foundation, modules[] }`, judging `heavy` itself. The workflow computes `fanout` from `heavy`, `partitionable`, module count, and `fanout-mode`.
+3a. Fanout path: Foundation agent (`impl-execute --auto --no-commit --module foundation`) if a foundation group exists (on its failure, fall back to 3b over the whole plan); then `parallel()` over modules, each `impl-execute --auto --no-commit --module <name>`; then the Commit agent commits each group sequentially via `git-commit`, foundation first then modules in listed order.
+3b. Non-fanout path: the current single `impl-execute --auto` agent (commits itself).
+4. GapCheck loop (heavy only): gapcheck agent returns `{ complete, gaps[] }`; while gaps remain and `round < GAP_MAX_ROUNDS`, run `impl-execute --fix --auto` with the gaps as findings, then re-check.
+5. `reviewCycle`, Push, Hygiene proceed unchanged.
+
+## Edge cases and error handling
+
+- **Plan emits no partition / `partitionable: false`.** Single-agent Execute; gapcheck still runs if heavy. Backward compatible with plans written before this epic (no `## Module partition` -> Partition agent returns `partitionable: false`).
+- **Only one module.** Not worth fanout; treat as non-partitionable, single agent.
+- **No foundation group.** Skip the foundation pass; go straight to parallel modules.
+- **Foundation agent fails (returns null).** Abort fanout and fall back to the single-agent Execute path (one `impl-execute --auto` over the whole plan): modules building blind against missing shared types would cascade-fail, so a clean single-agent pass is safer than a partial fanout. Gapcheck still runs when heavy.
+- **A module named `foundation`.** The planner never emits one (`plan-module-partition` reserves the name) and `impl-execute --module foundation` resolves to the foundation group; the partition format forbids the collision at the source.
+- **A module agent fails (returns null).** The Commit agent commits whatever landed; gapcheck catches the missing files as gaps and the fix loop fills them. A persistent gap after `GAP_MAX_ROUNDS` is reported, not silently dropped.
+- **Gapcheck false-negative (reports complete but isn't).** `reviewCycle` (correctness dimension) is the backstop, unchanged.
+- **`args` delivered as a JSON string** (known issue, `[[project_workflow_args_string]]`): the workflow edit parses args defensively at the top so the new `fanout` field and existing fields read correctly.
+
+## Testing strategy
+
+These are prompt/skill artifacts and a JS workflow script, not unit-testable in isolation; verification is by shape-check and a live heavy-unit run.
+
+- `scripts/check-plugin-shape.sh` must pass for the new `impl-gapcheck` skill + shim (real file body-only, unique name, shim frontmatter + read line).
+- CI path globs and `.github/workflows/ci.yml` cover the new skill directory.
+- Manual: run `impl` on a heavy partitionable unit with `impl.fanout-mode: on`; confirm parallel module agents in the workflow view, one commit per group, gapcheck loop fires. Run a light unit; confirm the path and output are byte-identical to today.
+- `impl-plan` change verified by inspecting a generated `.impl-plan.md` for a well-formed `## Module partition`.
+
+## Alternatives considered
+
+- **Per-module worktrees instead of write-only + single commit.** Isolating each module in its own worktree removes the index race but explodes setup cost and needs a merge step back into the unit branch; the shared-worktree write-only approach is simpler and the sequential Commit agent already serializes safely.
+- **Make fanout the default (not opt-in).** Rejected per the original ask: opt-in via `impl.fanout-mode`, default `auto` so it only triggers on genuinely heavy, partitionable units.
+
+## Sources
+
+- `autocode/impl/skills/impl/scripts/impl-workflow.mjs:130-220`: `reviewCycle`, the Execute/Fix region, `MAX_FIX_ROUNDS`, per-phase models, schema pattern.
+- `autocode/impl/skills/impl-execute/SKILL.md:11-44`: default vs `--fix`, commit-via-`git-commit` contract, `--auto` output.
+- `autocode/impl/skills/impl-plan/SKILL.md:27-35`: current plan output format and `--auto` block.
+- `autocode/impl/skills/impl/SKILL.md:26,49,51`: arg assembly, settings read, capped-wave launch.
+- `autocode/_config/settings-schema.md:25`: `impl.max-concurrent-units` declaration pattern.
+- `autocode/impl/skills/impl-critique-{review,challenge,decide}/SKILL.md` and their shims: leaf-skill body + shim shape.
+- `scripts/check-plugin-shape.sh`: shim/real shape rules.
+- `autocode/design/design-folder.md`: `.impl-context`, progress lifecycle.
+- User statement (2026-06-09): heavy units compacted repeatedly under the single Execute agent; wants opt-in fanout + a spec-completeness check loop.
+
+## Units
+
+| unit | deliverable | depends-on |
+|---|---|---|
+| [plan-module-partition](units/plan-module-partition.md) | `impl-plan` emits a `## Module partition` section (foundation + file-disjoint modules) | none |
+| [execute-no-commit-scope](units/execute-no-commit-scope.md) | `impl-execute` gains `--no-commit` and `--module <name>` scoping | none |
+| [gapcheck-leaf-skill](units/gapcheck-leaf-skill.md) | new read-only `impl-gapcheck` leaf skill (real + shim + CLAUDE.md) | none |
+| [workflow-fanout-wiring](units/workflow-fanout-wiring.md) | wire fanout + commit + gapcheck loop into `impl-workflow.mjs`; `impl.fanout-mode` setting | plan-module-partition, execute-no-commit-scope, gapcheck-leaf-skill |
+
+## Critique log
+
+### Iteration 1
+
+- Q: `HEAVY_FILES` is referenced as the heaviness threshold but never given a value. What value? -> Resolved (user, 2026-06-09): no constant; the Partition agent judges `heavy` from the whole plan (compaction risk, coupling), returning a `heavy` boolean. Decision 4, architecture diagram, runtime flow, and `PARTITION_SCHEMA` (workflow-fanout-wiring) updated; `HEAVY_FILES` constant removed.
+- Q: Commit agent commits "in dependency order", but modules are file-disjoint with no inter-module edges in `PARTITION_SCHEMA`. Contradiction? -> Resolved (reasoning from design invariants): modules share nothing but foundation interfaces, so no inter-module order exists; commit order is foundation first then modules in listed order. Decision 2, architecture commit step, runtime flow, and workflow unit updated.
+- Q: `files_total` semantics, given `heavy` must hold when `partitionable: false` (no modules)? -> Resolved (reasoning): `files_total` is the count of all in-scope planned files (plan-wide, not partition-derived). Stated in decision 4 and `PARTITION_SCHEMA`.
+- Q: Foundation agent failure is unhandled; modules would build blind against missing shared types. -> Resolved (user, 2026-06-09): on Foundation `null`, abort fanout and fall back to the single-agent Execute path over the whole plan (gapcheck still runs if heavy). Added to edge cases, runtime flow, and workflow unit.
+- Q: `--module foundation` is reserved for the foundation group; a module named `foundation` would collide. -> Resolved (reasoning): planner must never name a module `foundation`; forbidden at the partition source. Added to plan-module-partition, execute-no-commit-scope, `PARTITION_SCHEMA`, and edge cases.
+
+### Iteration 2
+
+- No new questions. Cross-file consistency verified (`files_total` plan-wide, `foundation` reserved, foundation-fallback). The sonnet Partition agent judging `heavy` does not conflict with decision 7 (it runs fresh on a small plan doc, no compaction blind spot). Converged.
+</content>
+</invoke>

--- a/.autocode/design/0004-impl-fanout/PROGRESS.md
+++ b/.autocode/design/0004-impl-fanout/PROGRESS.md
@@ -1,0 +1,1 @@
+# Progress: impl-fanout

--- a/.autocode/design/0004-impl-fanout/units/execute-no-commit-scope.md
+++ b/.autocode/design/0004-impl-fanout/units/execute-no-commit-scope.md
@@ -1,0 +1,34 @@
+---
+depends-on: []
+type: task
+---
+
+# Add --no-commit and --module scoping to impl-execute
+
+## Summary
+
+`impl-execute` gains two composable flags so the fanout workflow can drive it as a write-only, scoped agent. `--no-commit` suppresses the `git-commit` delegation entirely: the agent implements and leaves changes in the working tree (unstaged, uncommitted), reporting the list of files written so the workflow's sequential Commit step can stage and commit per group. `--module <name>` scopes execution to one group of the plan's `## Module partition` (the literal group `foundation` is a valid name), implementing only that group's files and tasks. The two compose: `impl-execute --auto --no-commit --module <name>` is the per-module fanout invocation, and `--module foundation --no-commit` is the foundation pass. With neither flag, behavior is byte-identical to today (whole plan, commits via `git-commit`), so the change is backward compatible.
+
+## Implementation
+
+Deliverable: two new composable flags on `impl-execute`, `--no-commit` and `--module <name>`, leaving the default (no-flag) path unchanged.
+
+File to modify (only this file): `autocode/impl/skills/impl-execute/SKILL.md` (the real, body-only skill).
+
+Contract changes:
+
+- `--no-commit` (`## Args`, new entry): suppress the `git-commit` delegation entirely. Implement and leave all changes in the working tree, unstaged and uncommitted. Report the list of files written. Because nothing commits, the Stop-hook progress logging does not fire in this agent; that is intentional, since the workflow's separate Commit step owns commits and triggers logging.
+- `--module <name>` (`## Args`, new entry): read the plan's `## Module partition` section and implement ONLY the named group's files and tasks. `foundation` is a reserved name that resolves to the `### Foundation` group (the planner never emits a module called `foundation`; see `plan-module-partition`); any other `<name>` matches a `### Modules` entry. Without `--module`, execute the whole plan (current behavior, unchanged).
+- Composition: `--no-commit` and `--module` are independent and combine. `impl-execute --auto --no-commit --module <name>` is the fanout module-agent invocation; `--module foundation --no-commit` is the foundation pass. Both also compose with `--auto` (structured result block).
+- Backward compatibility: with neither flag, the default path is byte-identical to today (whole plan, commit at checkpoints via `git-commit`).
+
+Edits within `impl-execute/SKILL.md`:
+
+- `## Args`: add the two flags above with their contracts.
+- `## Workflow (default)`: scope step 3 to the named `## Module partition` group when `--module` is set (whole plan otherwise); make step 5 conditional on `--no-commit`. Under `--no-commit`, skip the `git-commit` delegation, leave changes in the working tree, and (under `--auto`) report the list of files written in the result block instead of commits. Note that without commits the Stop-hook progress logging does not fire here, by design.
+- `## Workflow (--fix)`: `--no-commit` applies here too if the workflow uses it during the gapcheck fix loop; under `--no-commit`, skip the `git-commit` in step 3 and report files written. `--module` is not used by `--fix` (findings already carry `file:line`).
+- `## Rules`: keep "Delegate commits to `git-commit`; never inline commit logic" but qualify it so `--no-commit` is the explicit exception (write-only, no commit, no inline commit logic either). Keep the rule that the skill does not own progress logging.
+
+What proves it: a generated `.autocode/.impl-plan.md` carrying a `## Module partition` plus a manual run of `impl-execute --no-commit --module <name>` that writes only that group's files and leaves them uncommitted in the working tree; and a no-flag run whose behavior and `--auto` output are byte-identical to today.
+
+Scope note: this unit edits `impl-execute/SKILL.md` only. The plan-side `## Module partition` format is owned by `plan-module-partition`; the workflow wiring that calls these flags is owned by `workflow-fanout-wiring`. This unit defines the contract those two consume.

--- a/.autocode/design/0004-impl-fanout/units/gapcheck-leaf-skill.md
+++ b/.autocode/design/0004-impl-fanout/units/gapcheck-leaf-skill.md
@@ -1,0 +1,46 @@
+---
+depends-on: []
+type: task
+---
+
+# Read-only impl-gapcheck leaf skill
+
+## Summary
+
+A new read-only leaf skill `impl-gapcheck` that checks whether every item in the implementation plan was actually implemented in the branch diff, returning a spec-completeness verdict. The caller (the `impl` workflow) supplies the plan (`.autocode/.impl-plan.md`) and the branch diff; for each in-scope plan item (per-file task and each module in the plan's `## Module partition`) the skill verifies the diff implements it, treating a missing or empty implementation as a gap and skipping items the plan marked out-of-scope. It returns `{ complete, gaps[] }` where `complete` is true only when every in-scope item is present. This is a spec-coverage check, distinct from `impl-critique` (which answers "is the code correct/secure/fast"): gapcheck answers only "is every plan item present". It is read-only and never edits, writes, or runs mutating commands. The deliverable is the real body-only skill file, its plugin shim, and a CLAUDE.md entry; the workflow wiring and the JSON schema live in the sibling `workflow-fanout-wiring` unit.
+
+## Implementation
+
+Per epic Design decision 6: gapcheck is a new leaf, not a dimension of `impl-critique` (different question, different prompt, different schema `{ complete, gaps[] }`); it is read-only and run by the workflow exactly like the `impl-critique-*` leaves. Model the body on the existing read-only leaves `impl-critique-{review,challenge,decide}`, whose structure is `## Input` -> `## Workflow` -> `## Output` -> `## Rules`, all body-only with no frontmatter (`autocode/impl/skills/impl-critique-review/SKILL.md:1-40`).
+
+Files to create:
+
+- `autocode/impl/skills/impl-gapcheck/SKILL.md` (real, body-only). Must NOT start with `---`; `scripts/check-plugin-shape.sh` rejects real files that open with a frontmatter block, requires exactly one real counterpart per shim, and requires `impl-gapcheck` to be a name unique across all feature-sets.
+- `plugins/autocode/skills/impl-gapcheck/SKILL.md` (shim). Copy the shape of `plugins/autocode/skills/impl-critique-review/SKILL.md:1-6`: frontmatter with ONLY `name:` and `description:` (no `model`, no `allowed-tools`), then one body line:
+  `Read through @~/.autocode/autocode/impl/skills/impl-gapcheck/SKILL.md and execute actions according to the instructions in the file. ` followed by `` `$ARGUMENTS` is forwarded. ``
+
+File to modify:
+
+- `autocode/impl/CLAUDE.md`. Lines 20-25 enumerate the `impl-critique-*` leaves (the report-only review front end). Add an entry describing `impl-gapcheck` as the read-only spec-completeness pass, distinct from the `impl-critique` quality leaves: `impl-critique` asks "is this code correct", gapcheck asks "is every plan item present". Do NOT touch the per-phase skill list at lines 13-18 (gapcheck is a leaf run by the workflow, not an individually-sequenced per-phase skill).
+
+Skill body shape (the four sections, modeled on `impl-critique-review/SKILL.md`):
+
+- `## Input` (caller always supplies these; the skill does not fish for files, matching `impl-critique-review/SKILL.md:5-9`): the plan at `.autocode/.impl-plan.md`, and the branch diff (or the changed-file list). The skill does not redesign or re-plan; it only checks coverage of the supplied plan against the supplied diff.
+- `## Workflow`: enumerate the in-scope plan items, where an item is a per-file task in the plan plus each module listed under the plan's `## Module partition` section (the section the sibling `plan-module-partition` unit adds to `impl-plan`). For each item verify the diff actually implements it; a missing or empty implementation is a gap. Skip any item the plan marked out-of-scope (`impl-plan/SKILL.md:33` writes an out-of-scope list).
+- `## Output`: the verdict object. `complete` is true only when every in-scope plan item is present in the diff; otherwise list each gap citing the plan item and the file with a one-line detail of what is missing. The format must match the schema the sibling `workflow-fanout-wiring` unit defines and consumes:
+  `GAPCHECK_SCHEMA = { complete: boolean, gaps: [{ file, plan_item, detail }] }`.
+  Each gap line carries a `file`, the `plan_item` it traces to, and a one-line `detail`. Return `complete: true` with an empty `gaps` list when coverage is full. (The schema itself is defined in the workflow unit, not here; this file only fixes the output shape to align with it.)
+- `## Rules`: read-only (no edits, no writes, no mutating commands), per Design decision 6 and matching `impl-critique-review/SKILL.md:37-40`. Every gap cites a concrete `file` and `plan_item`; no citation, no gap. Coverage only: do not stray into correctness/quality findings (that is `impl-critique`).
+
+What proves it (per epic Testing strategy, lines 99-104): `scripts/check-plugin-shape.sh` passes for the new skill + shim (real file body-only, unique name, shim = frontmatter + read line). CI path globs in `.github/workflows/ci.yml` cover the new skill directory. The skill is prompt-only, not unit-testable in isolation; live verification is via the gapcheck loop firing in a heavy-unit run, owned by the `workflow-fanout-wiring` unit.
+
+Boundary with the sibling unit:
+
+```
+gapcheck-leaf-skill (this unit)        workflow-fanout-wiring (sibling)
+  impl-gapcheck/SKILL.md  ----run by---->  skill()/follow() call in
+  (Input/Workflow/Output/Rules)            impl-workflow.mjs
+  Output shape: {complete, gaps[]}  ===  GAPCHECK_SCHEMA (defined there)
+```
+
+This unit owns the skill body, shim, and CLAUDE.md entry only. The `skill()` call, the schema constant, and the bounded fix loop (`GAP_MAX_ROUNDS`) are the sibling unit's; this file keeps the Output format aligned with `GAPCHECK_SCHEMA` but does not implement the wiring.

--- a/.autocode/design/0004-impl-fanout/units/plan-module-partition.md
+++ b/.autocode/design/0004-impl-fanout/units/plan-module-partition.md
@@ -1,0 +1,49 @@
+---
+depends-on: []
+type: task
+---
+
+# Emit a module partition section in the impl plan
+
+## Summary
+
+`impl-plan` writes a flat per-file plan to `.autocode/.impl-plan.md` with no module grouping, so the Execute phase has nothing to fan out across. This unit adds a new `## Module partition` section to that plan: an optional `### Foundation` group of shared types and interfaces to build first, and a `### Modules` group of file-disjoint module sets the workflow can run in parallel. The section is machine-readable and states explicitly whether the unit is partitionable at all, so the workflow's Partition agent can transcribe it into JSON without re-inferring the split. The planner already resolves every signature and data shape, so it owns the partition; this raises the bar that interfaces must be concrete enough for a module agent to implement its files without seeing sibling modules' uncommitted code.
+
+## Implementation
+
+Single file: `autocode/impl/skills/impl-plan/SKILL.md` (real, body-only skill). No other file changes; the workflow consumer and `impl-execute --module` flag are sibling units.
+
+### Deliverable
+
+`impl-plan` writes a `## Module partition` section into `.autocode/.impl-plan.md` alongside the existing per-file task list, test plan, implementation order, and out-of-scope list. The section partitions the planned files into a foundation set plus file-disjoint module groups (or declares the unit non-partitionable), formatted so the workflow's Partition agent can parse it into `{ files_total, partitionable, foundation, modules[] }` without re-deriving the grouping.
+
+### Files to modify
+
+`autocode/impl/skills/impl-plan/SKILL.md`:
+
+- Workflow step 3 ("Build the mechanical plan", SKILL.md:26-31): add a sub-bullet directing the planner to decide the partition as the final step of planning, once every file, signature, and data shape is resolved. The partition is derived from the already-resolved file DAG, not inferred separately.
+- Workflow step 4 ("Write the plan", SKILL.md:33): add `## Module partition` to the list of sections written to `.autocode/.impl-plan.md`.
+- Workflow step 5 (`--auto` block, SKILL.md:35): note that the structured result stays as-is here (file count, out-of-scope count); the partition is read from the plan file by the workflow, not surfaced in this block. Do not expand the `--auto` block.
+- Add a `## Module partition` subsection (or a Rules entry) defining the exact section shape and the partitionability bar, per below.
+
+### Exact section shape to add
+
+Specify in the skill that `## Module partition` is written to the plan with this structure:
+
+- An optional `### Foundation` subsection: the shared types, interfaces, and contracts plus the files that define them. Implemented sequentially BEFORE any module, so modules can build blind against the resolved interfaces. Omit the subsection entirely when nothing is shared. Each foundation file listed explicitly.
+- A `### Modules` subsection: one entry per module, each carrying a name, an explicit list of the files it owns, and a one-line scope. Files MUST be disjoint across modules and disjoint from the foundation set (every planned file belongs to at most one module, or to the foundation). A module MUST NOT be named `foundation`: that name is reserved for the `### Foundation` group, and `impl-execute --module foundation` (sibling `execute-no-commit-scope`) resolves to it, so a module called `foundation` would collide.
+- A partitionability statement: emit genuine file-disjoint modules only when the work truly splits into independent pieces sharing nothing but foundation-defined interfaces. Otherwise state the unit is not partitionable (single-module / no fanout) explicitly, so the consumer reads `partitionable: false` rather than guessing from an empty list. A single module is treated as non-partitionable.
+
+Keep the format simple and machine-readable: clear subsection headers (`### Foundation`, `### Modules`), explicit file lists, module names as headers or labeled entries. The skill instructs the planner on the format; it does not parse it.
+
+### The bar this raises on impl-plan
+
+State in the skill (per DESIGN Design decision 3): the partition is emitted with real modules only when the foundation and plan resolve interfaces concretely enough that a module agent implements its files without seeing sibling modules' uncommitted code. Anything two modules genuinely share goes in `### Foundation`; if the interfaces cannot be pinned down that precisely, the unit is not partitionable. This extends the existing "name signatures and data shapes concretely; do not leave them 'to be determined'" rule (SKILL.md:27) to cross-module contracts.
+
+### Consumer context (do not implement here)
+
+The workflow's Partition agent (sibling unit `workflow-fanout-wiring`) reads this section into `{ files_total, partitionable, foundation, modules[] }`; `impl-execute` gains `--module <name>` (sibling unit `execute-no-commit-scope`) to scope execution to one group. A plan written before this epic has no `## Module partition`, so the Partition agent returns `partitionable: false` and the single-agent path runs unchanged. This unit only emits the section; it wires nothing.
+
+### What proves it
+
+A generated `.autocode/.impl-plan.md` for a partitionable unit contains a well-formed `## Module partition` with a `### Modules` subsection whose file lists are disjoint and an optional `### Foundation` subsection, and a unit that does not split states `partitionable: false` (or equivalent non-partitionable wording). Verified by inspecting a generated plan, per DESIGN Testing strategy.

--- a/.autocode/design/0004-impl-fanout/units/workflow-fanout-wiring.md
+++ b/.autocode/design/0004-impl-fanout/units/workflow-fanout-wiring.md
@@ -1,0 +1,81 @@
+---
+depends-on: [plan-module-partition, execute-no-commit-scope, gapcheck-leaf-skill]
+type: task
+---
+
+# Wire fanout, sequential commit, and gapcheck into the impl workflow
+
+## Summary
+
+This is the integration unit for the fanout epic. It rewires the Execute region of `impl-workflow.mjs` (`impl-workflow.mjs:180-185`) into a fork: heavy, partitionable units run one fresh sonnet agent per module group in parallel (each `impl-execute --no-commit --module <name>`, small context), preceded by an optional sequential foundation pass, then a single sonnet Commit agent that stages and commits each group in dependency order; light or non-partitionable units keep today's single `impl-execute --auto` agent unchanged. A read-only opus GapCheck loop (via the `impl-gapcheck` leaf) then runs on every heavy unit, looping a bounded `impl-execute --fix` pass until every plan item is covered. The unit adds the `impl.fanout-mode` setting (`auto`|`off`|`on`), forwards it as `fanout` from the orchestrator into both workflow-launch arg objects, documents the new behavior, and adds a setup prompt. It depends on the plan partition format (`plan-module-partition`), the `--no-commit`/`--module` flags (`execute-no-commit-scope`), and the `impl-gapcheck` leaf (`gapcheck-leaf-skill`) all existing.
+
+## Implementation
+
+Integration only; the three siblings supply the plan section, the execute flags, and the leaf. This unit wires them into the workflow runtime and configures the setting.
+
+### Files to modify
+
+- `autocode/impl/skills/impl/scripts/impl-workflow.mjs` (the workflow rewrite; the bulk of this unit).
+- `autocode/impl/skills/impl/SKILL.md` (read the setting; forward `fanout` in both arg objects).
+- `autocode/_config/settings-schema.md` (declare `impl.fanout-mode`).
+- `plugins/autocode/skills/autocode-setup/SKILL.md` (collect `impl.fanout-mode`).
+- `autocode/impl/CLAUDE.md` (document fanout Execute + the gapcheck gate).
+
+### impl-workflow.mjs
+
+Defensive args parse, before reading fields (memory `project_workflow_args_string`: the Workflow tool may deliver `args` as a JSON string, so `args.homeDir` is `undefined`). At the top (currently `impl-workflow.mjs:17-23`), derive a parsed object, e.g. `const A = typeof args === 'string' ? JSON.parse(args) : args`, then read `homeDir`/`worktree`/`slug`/`base`/`dims` from `A`. Read the new mode: `const FANOUT = A.fanout || 'auto'` (values `auto`|`off`|`on`).
+
+New constant alongside `MAX_FIX_ROUNDS` (`impl-workflow.mjs:24`):
+- `GAP_MAX_ROUNDS = 2` (mirrors `MAX_FIX_ROUNDS`).
+
+Heaviness is a model judgment, not a hardcoded file-count threshold: the Partition agent decides `heavy` from the whole plan (file count, total plan size, cross-file coupling, compaction risk), so no `HEAVY_FILES` constant exists.
+
+New schemas, in the schema-const block (next to `PREP_SCHEMA` etc.), each `type: 'object'`, `additionalProperties: false`, with the listed `required`:
+- `PARTITION_SCHEMA`: `{ files_total: integer, heavy: boolean, partitionable: boolean, foundation: { files: string[], summary } | null, modules: [{ name, files: string[], summary }] }`. `files_total` is the count of all in-scope planned files (plan-wide, NOT partition-derived), so the `heavy` judgment and downstream gating hold even when `partitionable: false` (no modules). `heavy` is the agent's judgment of compaction risk for the whole plan. Module `name` MUST NOT be `foundation` (reserved for the foundation group; see `plan-module-partition`).
+- `GAPCHECK_SCHEMA`: `{ complete: boolean, gaps: [{ file, plan_item, detail }] }`.
+
+Partition assess (sonnet), inserted after the Plan agent (`impl-workflow.mjs:173-178`). One `agent()` that reads `.autocode/.impl-plan.md` (the `## Module partition` section from `plan-module-partition`) and returns `PARTITION_SCHEMA`, judging `heavy` itself. Then compute the gate:
+- `heavy = part.heavy` (the agent's judgment).
+- `fanout = FANOUT !== 'off' && part.partitionable && part.modules.length >= 2 && (FANOUT === 'on' || heavy)`.
+
+Edge cases this expression already covers (per epic Edge cases): no `## Module partition` -> Partition agent returns `partitionable: false` -> single agent; only one module -> `modules.length >= 2` is false -> single agent.
+
+Execute fork, replacing the single Execute agent at `impl-workflow.mjs:180-185`:
+- `if (fanout)`:
+  - Foundation agent (sonnet) only when `part.foundation` exists: `impl-execute --auto --no-commit --module foundation`. If the Foundation agent returns `null` (failed), abort fanout and fall through to the single-agent `else` path: modules cannot build blind against missing shared types without cascade-failing, so the whole plan runs through one `impl-execute --auto` agent instead (gapcheck still runs if `heavy`). Per epic Edge cases.
+  - `parallel()` over `part.modules`, each a fresh sonnet `impl-execute --auto --no-commit --module <name>` (mirroring the `reviewCycle` `parallel()` + per-leaf `agent()` shape at `impl-workflow.mjs:139-146`).
+  - One sequential Commit agent (sonnet) after the barrier that stages + commits each group via `git-commit`, foundation first then modules in listed order, one logical commit per group (epic Design decision 2: parallel agents share one `.git/index`, so only one agent commits). Modules are file-disjoint and share nothing but foundation interfaces, so there is no inter-module dependency order; listed order is deterministic and sufficient.
+- `else`: the current single `impl-execute --auto` agent, unchanged (commits itself).
+
+GapCheck loop, after the Execute fork and before `reviewCycle` (`impl-workflow.mjs:187-188`); runs when `heavy`, independent of `fanout` (epic Design decision 4):
+- A gapcheck `agent()` (opus, read-only) via the leaf, in the `impl-critique-*` shape: `agent(inWt + readOnly + follow(skill('impl-gapcheck'), '<context + plan + diff>'), { label, phase: 'GapCheck', model: 'opus', schema: GAPCHECK_SCHEMA })`.
+- `while (!gap.complete && gap.gaps.length && gapRound < GAP_MAX_ROUNDS)`: run `impl-execute --fix --auto` (sonnet) with the gaps reframed as findings (same shape as the existing fix call at `impl-workflow.mjs:192-196`), then re-run the gapcheck agent.
+- Light units skip GapCheck entirely.
+
+`meta.phases` (`impl-workflow.mjs:4-14`): add entries with models, titles matching each `phase()`/`agent()` call: Partition (sonnet), Foundation (sonnet), Modules (sonnet), Commit (sonnet), GapCheck (opus), GapFix (sonnet). Place them so the array reads in runtime order.
+
+Result object (`impl-workflow.mjs:214-220`): add `fanout_used` (the computed `fanout` boolean), `gap_rounds` (loop count), `remaining_gaps` (gap count after the loop), alongside the existing fields. `remaining_gaps` mirrors how `remaining_important` surfaces unresolved review findings (epic Design decision 7).
+
+### impl/SKILL.md
+
+Read `impl.fanout-mode` (default `auto`) from `$AUTOCODE_CONFIG_DIR/settings.json`, in the same place the capped-wave launch reads `impl.max-concurrent-units` (`impl/SKILL.md:49`). Add `fanout` to BOTH workflow-launch arg objects: the single-unit launch (`impl/SKILL.md:26`) and the capped-wave launch (`impl/SKILL.md:51`), so both become `args: { homeDir, worktree, slug, base, dims, fanout }`. Should also accept an optional `--fanout <auto|off|on>` orchestrator arg overriding the setting (alongside `--dims` at `impl/SKILL.md:9`); implementer's call on exact wording.
+
+### settings-schema.md
+
+Add a row to the shared-keys table (`settings-schema.md:25`, beside `impl.max-concurrent-units`): `impl.fanout-mode`, type enum `auto|off|on`, default `auto`, one-line description noting it is read by the `impl` orchestrator skill and forwarded to each workflow. `impl.*` is already shared scope, so no `write-settings.sh` change is needed.
+
+### autocode-setup/SKILL.md
+
+Add a prompt collecting `impl.fanout-mode` to the Step 3 settings collection (`autocode-setup/SKILL.md:43-48`), as an optional shared key defaulting to `auto`. The `impl.*` namespace already maps to `settings.json`, so no `write-settings.sh` change is required.
+
+### impl/CLAUDE.md
+
+Document the fanout Execute path and the gapcheck gate in the orchestrator's workflow-phases paragraph (the paragraph beginning "`impl` is the stateless, re-entrant epic orchestrator", which currently lists `plan -> execute -> review -> ...`). State that heavy partitionable units fan Execute into parallel per-module agents plus a sequential commit, and that heavy units run a bounded gapcheck loop, gated by `impl.fanout-mode`.
+
+### What proves it
+
+Per epic Testing strategy (these are prompt/JS artifacts, not unit-testable in isolation):
+- `node --check` (or equivalent) parses `impl-workflow.mjs` clean.
+- Run `impl` on a heavy partitionable unit with `impl.fanout-mode: on`: the workflow view shows parallel module agents, one commit per group, and the gapcheck loop firing.
+- Run a light unit: path and output are byte-identical to today (single Execute agent, no GapCheck).
+- `scripts/check-plugin-shape.sh` passes (no shim/real shape regression from the SKILL/schema edits).

--- a/.autocode/design/INDEX.md
+++ b/.autocode/design/INDEX.md
@@ -5,3 +5,4 @@
 | 0001 | auto-archive-epics | 2026-06-04 | archived |
 | 0002 | impl-epic-orchestrator | 2026-06-08 | archived |
 | 0003 | design-unit-workflow | 2026-06-08 | archived |
+| 0004 | impl-fanout | 2026-06-09 | active |


### PR DESCRIPTION
**Rendered design**

- [DESIGN.md](https://github.com/hhoikoo/autocode/blob/docs/impl-fanout/.autocode/design/0004-impl-fanout/DESIGN.md)
- [units/plan-module-partition.md](https://github.com/hhoikoo/autocode/blob/docs/impl-fanout/.autocode/design/0004-impl-fanout/units/plan-module-partition.md)
- [units/execute-no-commit-scope.md](https://github.com/hhoikoo/autocode/blob/docs/impl-fanout/.autocode/design/0004-impl-fanout/units/execute-no-commit-scope.md)
- [units/gapcheck-leaf-skill.md](https://github.com/hhoikoo/autocode/blob/docs/impl-fanout/.autocode/design/0004-impl-fanout/units/gapcheck-leaf-skill.md)
- [units/workflow-fanout-wiring.md](https://github.com/hhoikoo/autocode/blob/docs/impl-fanout/.autocode/design/0004-impl-fanout/units/workflow-fanout-wiring.md)

## Overview

The `impl` Execute phase runs one sonnet agent over a unit's entire plan; on a heavy unit that agent fills and compacts its context repeatedly, degrading quality. This epic adds an opt-in fanout mode: `impl-plan` partitions the plan into a foundation set plus file-disjoint module groups; the workflow runs one fresh sonnet agent per module in parallel (small context each), then a single sequential commit step; and a new read-only `impl-gapcheck` leaf verifies every plan item was implemented, looping a bounded fix pass until the spec is covered. Fanout and the gapcheck gate trigger on heaviness; light units keep the current single-agent path unchanged.

## Problem Statement

- A single Execute agent carrying a heavy unit's whole plan compacts its context repeatedly, degrading output quality.
- The flat plan has no module grouping, so Execute has nothing to fan out across.
- Nothing verifies that every plan item actually landed in the diff; silent gaps survive to review.
- Parallel agents in one worktree would race on `.git/index`, so a naive fanout corrupts commits.

## Architecture

```
                    Plan (opus) -> .autocode/.impl-plan.md
                                   (now carries ## Module partition)
                                          |
                              Partition assess (sonnet)
                          reads plan -> { files_total, heavy,
                            partitionable, foundation, modules[] }
                                          |
                    heavy = partition agent's judgment
                    fanout = heavy && partitionable && mode != off
                                          |
            +-----------------------------+-----------------------------+
            | fanout                       | heavy, not fanout           | light
            v                              v                             v
   Foundation (sonnet,             Execute (sonnet,               Execute (sonnet,
   --module foundation             --auto, single agent,          --auto, single agent,
   --no-commit)                    commits itself)                commits itself)
            |                              |                             |
   Modules (parallel sonnet,              |                             |
   one per group, --no-commit)            |                             |
            |                              |                             |
   Commit (sonnet, sequential             |                             |
   git-commit per group)                  |                             |
            +--------------+---------------+                             |
                           v                                            |
                  GapCheck loop (heavy only)                            |
                  gapcheck (opus, read-only) -> { complete, gaps[] }    |
                  while gaps && round < GAP_MAX_ROUNDS:                  |
                    impl-execute --fix (sonnet) -> recheck              |
                           |                                            |
                           +--------------------+-----------------------+
                                                v
                          reviewCycle / Push / Hygiene (unchanged)
```

Four units (DAG): `plan-module-partition`, `execute-no-commit-scope`, `gapcheck-leaf-skill` (all independent), then `workflow-fanout-wiring` (integration, depends on the other three).

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
    * n/a: text-only design doc, no code to test
* [x] Documentation added or modified appropriately
