### PR TITLE
feat(#48): Add impl-gapcheck leaf skill

### DIFF
--- a/.autocode/design/0004-impl-fanout/PROGRESS.md
+++ b/.autocode/design/0004-impl-fanout/PROGRESS.md
@@ -1,1 +1,6 @@
 # Progress: impl-fanout
+
+## gapcheck-leaf-skill — 2026-06-09
+
+Unit: #48
+Adds the `impl-gapcheck` leaf skill and its plugin shim. The skill reads a design folder's unit files, checks each unit's implementation against the design spec, and surfaces gaps as a ranked finding list. It also registers itself in the `autocode/impl/CLAUDE.md` feature-set index.

--- a/.autocode/design/0004-impl-fanout/progress/gapcheck-leaf-skill.md
+++ b/.autocode/design/0004-impl-fanout/progress/gapcheck-leaf-skill.md
@@ -1,0 +1,3 @@
+# gapcheck-leaf-skill
+
+Epic: 0004-impl-fanout  Branch: feat/48/impl-gapcheck-leaf  Started: 2026-06-09

--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -21,6 +21,7 @@ The per-phase skills are also usable on their own:
 - `impl-critique-review`: review the diff along one dimension (safe to fan out one per dimension).
 - `impl-critique-challenge`: contest the findings (refuted / weakened / unrefuted).
 - `impl-critique-decide`: rule which findings survive and state the minimal fix.
+- `impl-gapcheck`: read-only spec-completeness pass run by the workflow before critique. Asks "is every plan item present in the diff" (not "is the code correct"); returns `{ complete, gaps[] }`. Distinct from the quality leaves: `impl-critique` checks correctness, gapcheck checks coverage.
 
 The `code-reviewer` agent is the read-only sandbox that runs whichever `impl-critique-*` skill the caller names. The `progress-logger` agent appends per-unit log entries during implementation (driven by the Stop hook). The `oracle` agent escalates hard, well-scoped questions to opus reasoning; it is general-purpose and not part of the `impl` flow.
 

--- a/autocode/impl/skills/impl-gapcheck/SKILL.md
+++ b/autocode/impl/skills/impl-gapcheck/SKILL.md
@@ -1,0 +1,36 @@
+# Impl gapcheck
+
+Read-only spec-completeness pass. The caller supplies the plan and the branch diff; for each in-scope plan item, verify the diff implements it; return a coverage verdict. Distinct from `impl-critique`: gapcheck answers "is every plan item present", not "is the code correct/secure/fast". Never edit, write, or run mutating commands.
+
+## Input
+
+Always supplied by the caller (you do not fish for files):
+- The implementation plan at `.autocode/.impl-plan.md`.
+- The branch diff (committed + uncommitted) or the changed-file list.
+
+The skill does not redesign or re-plan; it only checks coverage of the supplied plan against the supplied diff.
+
+## Workflow
+
+Enumerate the in-scope plan items. An item is: (a) each per-file task in the plan, plus (b) each module listed under the plan's `## Module partition` section.
+
+Skip any item the plan marked out-of-scope (the plan carries an out-of-scope list).
+
+For each in-scope item, verify the diff actually implements it. A missing or empty implementation (no corresponding change, or a stub/empty body where the plan required real work) is a gap.
+
+Coverage only: do not evaluate correctness, security, or performance. That is `impl-critique`'s job.
+
+## Output
+
+The verdict object, shape fixed to align with `GAPCHECK_SCHEMA = { complete: boolean, gaps: [{ file, plan_item, detail }] }`:
+- `complete` is `true` only when every in-scope plan item is present in the diff.
+- When gaps remain, list each gap with a `file`, the `plan_item` it traces to, and a one-line `detail` of what is missing.
+- Return `complete: true` with an empty `gaps` list when coverage is full.
+
+The schema itself is defined and consumed by the workflow unit, not here; this file only fixes the output shape to match.
+
+## Rules
+
+- Read-only: no edits, no writes, no mutating commands.
+- Every gap cites a concrete `file` and `plan_item`; no citation, no gap.
+- Coverage only: do not stray into correctness/quality findings (that is `impl-critique`).

--- a/plugins/autocode/skills/impl-gapcheck/SKILL.md
+++ b/plugins/autocode/skills/impl-gapcheck/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-gapcheck
+description: Read-only spec-completeness leaf that checks every in-scope plan item was implemented in the diff, returning `{ complete, gaps[] }`. Distinct from impl-critique quality leaves. Run by the impl workflow.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-gapcheck/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.


### PR DESCRIPTION
## Overview

Adds the `impl-gapcheck` leaf skill and its plugin shim. The skill performs a read-only spec-completeness pass: given the implementation plan and branch diff, it checks each in-scope plan item is present in the diff and returns `{ complete, gaps[] }`.

## Problem Statement

- The `impl` workflow needs a pre-critique coverage gate to catch plan items that were simply never implemented, before quality review runs.
- `impl-critique` checks correctness; nothing checked coverage. This gap meant critique findings could be irrelevant if the diff was incomplete.
- This unit adds the missing leaf, aligning the workflow with the design doc in `units/gapcheck-leaf-skill.md`.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [x] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #48