### PR TITLE
feat(#49): Add ## Module partition section to impl-plan skill

### DIFF
--- a/.autocode/design/0004-impl-fanout/PROGRESS.md
+++ b/.autocode/design/0004-impl-fanout/PROGRESS.md
@@ -9,3 +9,7 @@ Adds the `impl-gapcheck` leaf skill and its plugin shim. The skill reads a desig
 Unit: #47
 
 Added `--no-commit` flag to `impl-execute` and `--module <name>` flag for per-module fanout. The two flags are independent and compose with `--auto`. Under `--no-commit`, the `git-commit` delegation is suppressed entirely; all changes land in the working tree unstaged. Under `--module`, execution is scoped to the named group in the plan's `## Module partition` section (`foundation` resolves to `### Foundation`; any other name matches a `### Modules` entry). Both flags are described in the workflow steps and the rules section.
+## plan-module-partition — 2026-06-09
+
+Unit: #49
+Added a `## Module partition` section to the `impl-plan` skill (`autocode/impl/skills/impl-plan/SKILL.md`). The section directs the planner to emit a foundation set plus file-disjoint module groups (or an explicit non-partitionable statement) as the final planning step, so the workflow's Partition agent can transcribe the split from the plan file without re-deriving it. 23 lines added, 2 changed.

--- a/.autocode/design/0004-impl-fanout/progress/plan-module-partition.md
+++ b/.autocode/design/0004-impl-fanout/progress/plan-module-partition.md
@@ -1,0 +1,3 @@
+# plan-module-partition
+
+Epic: 0004-impl-fanout  Branch: feat/49/module-partition-section  Started: 2026-06-09

--- a/autocode/impl/skills/impl-plan/SKILL.md
+++ b/autocode/impl/skills/impl-plan/SKILL.md
@@ -28,11 +28,32 @@ Design-folder layout, `.impl-context` keys, unit DAG, and the progress lifecycle
    - The test plan: which tests prove the unit, where they live, what they assert.
    - The implementation order, respecting within-unit dependencies.
    - Read the `CLAUDE.md` and `.claude/rules/` globs covering each changed path and bake their constraints into the plan, so execution just follows the plan rather than re-deriving conventions.
+   - The module partition: as the final planning step, once every file, signature, and data shape above is resolved, partition the planned files into a foundation set plus file-disjoint module groups (or declare the unit non-partitionable). Derive it from the file DAG you just resolved, not from a separate inference pass. Shape and partitionability bar: see `## Module partition` below.
    Bound it strictly to the unit's `## Implementation` scope plus the DESIGN cross-cutting constraints. Anything the spec does not cover is out of scope: list it as such, do not fold it in. Fold the freeform note here.
 
-4. Write the plan to `.autocode/.impl-plan.md` in the worktree: the per-file task list, the test plan, the implementation order, and the out-of-scope list. This file is the spec `impl-execute` consumes. Ensure `.autocode/.gitignore` ignores it (create if missing, append if absent); it is a transient artifact, not committed.
+4. Write the plan to `.autocode/.impl-plan.md` in the worktree: the per-file task list, the test plan, the implementation order, the `## Module partition` section, and the out-of-scope list. This file is the spec `impl-execute` consumes. Ensure `.autocode/.gitignore` ignores it (create if missing, append if absent); it is a transient artifact, not committed.
 
-5. Report. Default: the plan path and a short summary of the task list. With `--auto`: emit a structured result block (plan path, file count, out-of-scope count). Next step: `/impl-execute`.
+5. Report. Default: the plan path and a short summary of the task list. With `--auto`: emit a structured result block (plan path, file count, out-of-scope count). The `## Module partition` section is read from the plan file by the workflow's Partition agent, not surfaced in this block; leave the `--auto` fields unchanged. Next step: `/impl-execute`.
+
+## Module partition
+
+`## Module partition` is written into `.autocode/.impl-plan.md` so the workflow's Partition agent can read it into `{ files_total, partitionable, foundation, modules[] }` without re-deriving the grouping. The planner owns the split; the agent only transcribes.
+
+### Foundation
+
+Optional subsection. List the shared types, interfaces, and contracts, with every defining file named explicitly. Implemented sequentially before any module so modules build against resolved interfaces without seeing each other's uncommitted code. Omit the `### Foundation` subsection entirely when nothing is shared.
+
+### Modules
+
+Required subsection when partitionable. One entry per module: a name, an explicit list of files it owns, and a one-line scope. Files must be disjoint across modules and disjoint from the foundation set; every planned file belongs to at most one module or to the foundation. A module must not be named `foundation` (reserved for the `### Foundation` group; `impl-execute --module foundation` resolves to it, so the name would collide).
+
+### Partitionability bar
+
+Emit genuine file-disjoint modules only when the work truly splits into independent pieces sharing nothing but foundation-defined interfaces. The bar (per DESIGN Design decision 3): emit real modules only when the foundation and plan resolve interfaces concretely enough that a module agent implements its files without seeing sibling modules' uncommitted code. Anything two modules genuinely share goes in `### Foundation`; if interfaces cannot be pinned that precisely, the unit is not partitionable. A single module is treated as non-partitionable.
+
+When not partitionable, state so explicitly (e.g., `partitionable: false`) so the consumer reads the flag rather than guessing from an empty list.
+
+Format: keep it machine-readable. Use clear subsection headers (`### Foundation`, `### Modules`), explicit file lists, and module names as headers or labeled entries. The skill instructs on format; it does not parse.
 
 ## Rules
 


### PR DESCRIPTION
## Overview

Adds a `## Module partition` section to the `impl-plan` skill. The section directs the planner to produce a foundation set plus file-disjoint module groups (or an explicit `partitionable: false` flag) as the final step of planning, so the workflow's Partition agent can transcribe the split from the plan file without re-deriving it.

## Problem Statement

- The impl-fanout workflow needs a Partition agent that reads module groupings from the plan rather than re-inferring them from scratch.
- `impl-plan` had no instructions for emitting a module partition, so the workflow had no structured artifact to consume.
- Without an explicit partitionability flag, the Partition agent would have to guess from an absent or empty section.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #49