### PR TITLE
feat: Port leanness discipline across impl and design

### DIFF
--- a/autocode/_config/output-styles/CLAUDE.md
+++ b/autocode/_config/output-styles/CLAUDE.md
@@ -15,6 +15,7 @@ The root `CLAUDE.md` also `@`-imports `concise.md` directly from this directory 
 - Set `keep-coding-instructions: true` unless the style explicitly redefines the assistant's role away from coding. Without it, Claude Code's coding system prompt is dropped and the harness loses guidance for tests, file edits, etc.
 - Use `force-for-plugin: true` to apply the style automatically whenever the plugin is enabled. Overrides the user's `outputStyle` setting; if multiple enabled plugins set this, the first one loaded wins.
 - ASCII only in style body. Claude reads the style every session, so AI-tell vocabulary inside it shows up in output.
+- `concise.md` carries two axes: the prose voice and a `## Engineering minimalism` section (the leanness ladder). The ladder reaches plugin users only through this file (`force-for-plugin` for the main session, the per-agent read line for subagents), so `scripts/check-plugin-shape.sh` asserts its load-bearing invariants survive every edit. Keep those phrases intact when editing.
 
 ## Adding a new style
 

--- a/autocode/_config/output-styles/concise.md
+++ b/autocode/_config/output-styles/concise.md
@@ -9,6 +9,8 @@ force-for-plugin: true
 
 Applies to chat replies, code, comments, commits, PR bodies, docs.
 
+Two axes: prose voice (below) governs how you talk; `## Engineering minimalism` (bottom) governs how much you build. Both always active.
+
 ## Response shape
 
 ### Override harness defaults
@@ -147,3 +149,32 @@ Diagnostic, concise:
 - Multi-step sequences where fragment order risks misread.
 - User asks to clarify or repeats.
 - End-user docs, error messages.
+
+## Engineering minimalism
+
+Governs what you build, not how you talk. Always active. The best code is the code never written.
+
+### The ladder
+
+Before writing code, stop at the first rung that holds:
+
+1. Does this need to exist? Speculative need -> skip it, say so in one line. (YAGNI)
+2. Stdlib does it? Use it.
+3. Native platform feature covers it? `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+4. Already-installed dependency solves it? Use it. Never add a new dep for what a few lines cover.
+5. One line? One line.
+6. Only then: the minimum code that works.
+
+Two rungs work -> take the higher one and move on. The first lazy solution that works is the right one. No interface with one implementation, no factory for one product, no config for a value that never changes, no scaffolding "for later". Deletion over addition. Boring over clever. Fewest files, shortest working diff.
+
+### Lazy is not careless
+
+Never simplify away: input validation at trust boundaries, error handling that prevents data loss, security, accessibility basics, the calibration real hardware needs (a clock drifts, a sensor reads off), anything explicitly requested. Between two same-size stdlib options, take the one correct on edge cases; lazy means writing less code, not picking the flimsier algorithm. User insists on the full version -> build it, no re-arguing.
+
+### Ceiling comments
+
+Mark a deliberate simplification with a `leanness:` comment, so simple reads as intent. A shortcut with a known ceiling names the ceiling and the upgrade path: `# leanness: global lock, per-account locks if throughput matters`.
+
+### One check
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a loop, a parser, a money/security path) leaves ONE runnable check behind: the smallest thing that fails if the logic breaks, an assert-based self-check or one small test. No frameworks, no fixtures unless asked. Trivial one-liners need no test; YAGNI applies to tests too.

--- a/autocode/design/skills/design-plan-critique/SKILL.md
+++ b/autocode/design/skills/design-plan-critique/SKILL.md
@@ -49,7 +49,7 @@ Field semantics:
 The `--auto` path short-circuits to the launcher above; the following steps are the non-`--auto` in-session loop, preserved unchanged.
 
 1. Read the design: `DESIGN.md` and every `units/*.md` (multi-unit) or just `DESIGN.md` (flat).
-2. Generate follow-up questions per section and per unit. Bias toward: untested assumptions, interface shapes, error modes, concurrency, security, data shape, ordering invariants, and whether the unit decomposition and `depends-on` edges are right.
+2. Generate follow-up questions per section and per unit. Bias toward: untested assumptions, interface shapes, error modes, concurrency, security, data shape, ordering invariants, whether the unit decomposition and `depends-on` edges are right, and over-engineering (speculative scope, single-implementation abstractions, unneeded dependencies, dead flexibility).
 3. For each question, decide: ask the user, dispatch a researcher, or both (parallel where possible).
 4. Apply resolutions in place to the relevant file (`DESIGN.md` or the unit file). Preserve existing structure; add a `## Critique log` at the bottom of `DESIGN.md` that lists each iteration's questions and resolutions (one line each).
    - Make the decisions (questions, resolutions, sources) in the main session. The apply may fan out: when several units change in a pass, dispatch one generic Task subagent per affected unit in parallel, each handed the exact resolutions to write into its `units/<slug>.md`. Keep `DESIGN.md` edits and the `## Critique log` in the main session (shared file, serial). Use judgement: fan out when several units change, edit inline when only one does.

--- a/autocode/design/skills/design-plan/SKILL.md
+++ b/autocode/design/skills/design-plan/SKILL.md
@@ -30,6 +30,7 @@ Layout authority: `@~/.autocode/autocode/design/design-folder.md`. Read it; this
    - dispatch `web-researcher` in background,
    - ask the user.
    Launch researchers in parallel (single message, multiple Task tool calls). They return verbatim findings; fold them into the plan.
+   Run the leanness ladder over the whole shape before decomposing: does each proposed unit or component need to exist (YAGNI), does stdlib / a native feature / an existing dep cover it, is there a simpler decomposition. Cut speculative scope here, where it is cheapest to delete. Never cut validation at trust boundaries, security, data-loss handling, or accessibility.
 4. Compose the epic plan and decompose it into units once research returns.
    - Decide multi-unit vs flat. If the work is one PR's worth, produce a flat single-unit design: `DESIGN.md` only, no `units/` (see "Flat designs" below). Otherwise decompose into independent units of work, each one PR's worth with a single clear deliverable; identify dependencies between units and confirm the graph is acyclic. A unit that depends on nothing is immediately workable.
    - `DESIGN.md` sections (multi-unit): `design-folder.md` is the authority for the section set and when each conditional one applies. Do not restate or reorder it here. Writing guidance for the sections that carry the explanation:

--- a/autocode/impl/CLAUDE.md
+++ b/autocode/impl/CLAUDE.md
@@ -18,10 +18,12 @@ The per-phase skills are also usable on their own:
 - `impl-archive`: close out a completed epic.
 
 `impl-critique` is the standalone, report-only review front end. It composes three leaf skills, each run by a read-only `code-reviewer` subagent and reused by the `impl` workflow's review phase:
-- `impl-critique-review`: review the diff along one dimension (safe to fan out one per dimension).
+- `impl-critique-review`: review the diff along one dimension (safe to fan out one per dimension). Dimensions include a `leanness` over-engineering pass, run by default.
 - `impl-critique-challenge`: contest the findings (refuted / weakened / unrefuted).
 - `impl-critique-decide`: rule which findings survive and state the minimal fix.
 - `impl-gapcheck`: read-only spec-completeness pass run by the workflow before critique. Asks "is every plan item present in the diff" (not "is the code correct"); returns `{ complete, gaps[] }`. Distinct from the quality leaves: `impl-critique` checks correctness, gapcheck checks coverage.
+
+`impl-audit` is a standalone, report-only whole-repo over-engineering scan: the repo-wide counterpart of the `leanness` review dimension (which works on a diff). It ranks what to delete, shrink, or replace with stdlib/native equivalents and applies nothing. Not part of the per-unit workflow; invoked on demand.
 
 The `code-reviewer` agent is the read-only sandbox that runs whichever `impl-critique-*` skill the caller names. The `progress-logger` agent appends per-unit log entries during implementation (driven by the Stop hook). The `oracle` agent escalates hard, well-scoped questions to opus reasoning; it is general-purpose and not part of the `impl` flow.
 

--- a/autocode/impl/skills/impl-audit/SKILL.md
+++ b/autocode/impl/skills/impl-audit/SKILL.md
@@ -1,0 +1,44 @@
+# Impl audit
+
+Whole-repo over-engineering audit. Scan the tree (not a diff) for what to delete, simplify, or replace with stdlib / native equivalents. Ranked report, biggest cut first. Report-only: lists findings, applies nothing. The repo-wide counterpart of `impl-critique`'s `leanness` dimension, which reviews a diff.
+
+## Args
+
+All optional:
+- `<path>`: limit the scan to a subtree. Default: the repo root (`git rev-parse --show-toplevel`).
+- Freeform note: extra focus (e.g. "the auth module"). Context, not a scope expander.
+
+## Scope
+
+Read the working tree. Hunt:
+- Dependencies the stdlib or platform already ships.
+- Single-implementation interfaces, factories with one product, wrappers that only delegate.
+- Files exporting one thing, dead flags, config nobody sets.
+- Hand-rolled stdlib, code that shrinks with no behavior change.
+
+Bound findings to the repo's own standards: read `CLAUDE.md` and `.claude/rules/` so each is over-engineering by this repo's conventions, not generic taste.
+
+## Tags
+
+- `delete`: dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib`: hand-rolled thing the standard library ships. Name the function.
+- `native`: dependency or code doing what the platform already does. Name the feature.
+- `yagni`: abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink`: same logic, fewer lines. Show the shorter form.
+
+## Output
+
+One line per finding, ranked biggest cut first:
+
+`<tag>: <what to cut>. <replacement>. [path:line]`
+
+End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+
+## Rules
+
+- Read-only. List findings, apply nothing. Acting on them is the user's call.
+- Leanness only. Correctness bugs, security holes, and performance go to `impl-critique`, not here.
+- Never flag input validation at trust boundaries, security, data-loss handling, accessibility, or a single smoke test / assert-based self-check; those are the leanness minimum, not bloat.
+- Every finding cites a concrete path; no citation, no finding.
+
+$ARGUMENTS

--- a/autocode/impl/skills/impl-critique-review/SKILL.md
+++ b/autocode/impl/skills/impl-critique-review/SKILL.md
@@ -15,6 +15,7 @@ Always supplied by the caller (you do not fish for files):
 - `performance`: hot-path allocations, N+1 queries, resource leaks, accidental quadratic behavior.
 - `observability`: missing or misleading logging, metrics, tracing on new paths.
 - `standards`: violations of the supplied repo conventions only (not generic style).
+- `leanness`: over-engineering. Reinvented stdlib, deps doing what the platform ships, abstractions with one implementation, dead flexibility, code that shrinks with no behavior change. Lead the claim with a tag: `delete` / `stdlib` / `native` / `yagni` / `shrink`. Never flag validation at trust boundaries, security, data-loss handling, accessibility, or the single smoke test; those are the minimum, not bloat.
 
 ## Workflow
 

--- a/autocode/impl/skills/impl-critique/SKILL.md
+++ b/autocode/impl/skills/impl-critique/SKILL.md
@@ -7,7 +7,7 @@ Composer of three leaf skills (`impl-critique-review`, `impl-critique-challenge`
 ## Args
 
 All optional:
-- `--dims <list>`: comma-separated dimensions to run. `correctness` is always included. Default set: `correctness,security,performance`. Known: `correctness`, `security`, `performance`, `observability`, `standards`.
+- `--dims <list>`: comma-separated dimensions to run. `correctness` is always included. Default set: `correctness,security,performance,leanness`. Known: `correctness`, `security`, `performance`, `leanness`, `observability`, `standards`.
 - `--base <ref>`: base to diff against. Default: the repo's default branch (the same base `impl-start` worktrees from).
 
 ## Scope

--- a/autocode/impl/skills/impl-execute/SKILL.md
+++ b/autocode/impl/skills/impl-execute/SKILL.md
@@ -41,6 +41,7 @@ Design-folder layout, `.impl-context` keys, and the progress lifecycle: `@~/.aut
 ## Rules
 
 - Mechanical. Execute the plan or the findings; do not redesign. Surface plan gaps instead of widening scope silently.
+- Build minimal per the plan: emit the `leanness:` ceiling comments the plan named, and leave the plan's ONE runnable check for non-trivial logic. Do not add abstractions, scaffolding, or tests the plan did not call for.
 - Delegate commits to `git-commit`; never inline commit logic. Exception: under `--no-commit`, write changes to the working tree without committing and without inlining commit logic; the workflow's Commit step owns commits and triggers progress logging.
 - Do not own progress logging (the Stop hook + `progress-logger`) or the epic rollup (`impl-push`).
 - `--fix` applies only the supplied findings, minimally; it is not a second implementation pass.

--- a/autocode/impl/skills/impl-plan/SKILL.md
+++ b/autocode/impl/skills/impl-plan/SKILL.md
@@ -24,6 +24,7 @@ Design-folder layout, `.impl-context` keys, unit DAG, and the progress lifecycle
    - Never pull spec content from the issue body: it carries only `## Summary`, a permalink, and a marker, not the full plan. The authoritative spec is the file on disk in the worktree.
 
 3. Build the mechanical plan. Decide everything now so execution is pure mechanics:
+   - Run the engineering-minimalism ladder (active style) over each planned piece before committing to it: does it need to exist (YAGNI), does stdlib / a native feature / an already-installed dep cover it, can it be one line. Plan the minimum that works. Record each deliberate simplification with its ceiling and upgrade path so execution emits the matching `leanness:` comment. Speculative scope stays on the out-of-scope list, never folded in. Never trade away validation at trust boundaries, data-loss handling, security, or accessibility for brevity.
    - Per file to create or modify: the exact changes and why, keyed to the spec. Name functions, types, signatures, and data shapes concretely; do not leave them "to be determined".
    - The test plan: which tests prove the unit, where they live, what they assert.
    - The implementation order, respecting within-unit dependencies.

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -193,7 +193,7 @@ const GAPCHECK_SCHEMA = {
 const importantOf = (decided) => decided.actionable.filter((a) => a.severity === 'Important')
 
 async function reviewCycle(tag) {
-  const defaultDims = DIMS ? JSON.stringify(DIMS) : '["correctness","security","performance"]'
+  const defaultDims = DIMS ? JSON.stringify(DIMS) : '["correctness","security","performance","leanness"]'
   const prep = await agent(
     inWt +
       `Build the review context for the branch diff against ${BASE}. Count changed lines across \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`; list the changed files; choose dimensions: under ~50 changed lines use ["correctness"], otherwise use ${defaultDims}. Set empty=true only when there is no diff at all.`,

--- a/plugins/autocode/skills/impl-audit/SKILL.md
+++ b/plugins/autocode/skills/impl-audit/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-audit
+description: Whole-repo over-engineering audit: scan the tree for dead code, reinvented stdlib, needless deps, and single-use abstractions; ranked report ending in `net: -N lines possible`. Report-only. The repo-wide counterpart of impl-critique's leanness dimension. Use when the user says "audit for over-engineering", "find bloat", "what can I delete", or "/impl-audit".
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-audit/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/scripts/check-plugin-shape.sh
+++ b/scripts/check-plugin-shape.sh
@@ -108,7 +108,29 @@ for dir in autocode/*/; do
   fi
 done
 
-# 4. Shellcheck all shell scripts under tracked locations.
+# 4. Engineering-minimalism invariants survive in the forced output style.
+# The ladder reaches plugin users only through concise.md (force-for-plugin +
+# the per-agent read line); a careless edit must not silently gut it.
+note "checking leanness invariants in concise.md"
+style="autocode/_config/output-styles/concise.md"
+if [[ ! -f "${style}" ]]; then
+  err "missing ${style}"
+else
+  leanness_invariants=(
+    "## Engineering minimalism"
+    "Does this need to exist"
+    "input validation at trust boundaries"
+    "leanness:"
+    "ONE runnable check"
+  )
+  for phrase in "${leanness_invariants[@]}"; do
+    if ! grep -qF "${phrase}" "${style}"; then
+      err "concise.md missing leanness invariant: \"${phrase}\""
+    fi
+  done
+fi
+
+# 5. Shellcheck all shell scripts under tracked locations.
 note "shellchecking shell scripts"
 scripts=()
 while IFS= read -r f; do


### PR DESCRIPTION
## Overview

Ports ponytail's leanness reflex into autocode as a new build axis (how much code to write), distinct from the existing concise prose voice. Adds an always-on engineering-minimalism ladder, wires it into the impl and design phases, adds a `leanness` review dimension and a standalone `impl-audit` skill, and guards the ladder with a drift canary.

## Problem Statement

- autocode enforced *how you talk* (the `concise.md` output style) but had no rule for *how much you build*.
- The impl/design workflows verified correctness, security, coverage, and performance, never over-engineering.
- Over-engineering had no home in either the always-on guidance or the review gates.

## Architecture

The ladder reaches plugin users only through `concise.md` (`force-for-plugin` for the main session, the per-agent read line for subagents); autocode's own `CLAUDE.md` / `.claude/rules/` govern only developing autocode itself. Because one `force-for-plugin` style wins per plugin, the ladder lives inside `concise.md` rather than a sibling style, reinforced in the skills:

- `concise.md`: new `## Engineering minimalism` section (ladder, lazy-is-not-careless exceptions, `leanness:` ceiling comments, one-check rule).
- Gates in `impl-plan`, `impl-execute`, `design-plan`, `design-plan-critique`.
- `leanness` review dimension in `impl-critique-review`, added to `impl-critique` defaults and the per-unit `impl-workflow.mjs` review set.
- New `impl-audit` skill: repo-wide over-engineering scan, report-only.
- `check-plugin-shape.sh` canary asserting the ladder invariants survive in `concise.md`.

Single always-on posture (no lite/full/ultra modes), matching the stateless orchestrator design.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [x] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
