### PR TITLE
fix: Guard design workflows against undelivered args

### DIFF
--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -9,10 +9,15 @@ export const meta = {
 }
 
 // args (from the design-plan-critique --auto launcher): { homeDir, repoRoot, folder }
-const HOME = args.homeDir
-const REPO = args.repoRoot
-const FOLDER = args.folder        // absolute path to the design folder
+// The runtime may deliver args as a JSON string rather than a parsed object (mirrors impl-workflow.mjs).
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const HOME = A.homeDir
+const REPO = A.repoRoot
+const FOLDER = A.folder        // absolute path to the design folder
 const MAX_ITERATIONS = 5
+
+// Fail fast before any fan-out: missing paths mean args was not delivered.
+if (!HOME || !REPO || !FOLDER) throw new Error('design-critique: args.homeDir/repoRoot/folder not delivered. Aborting before fan-out.')
 
 // Agents run skills by reading the canonical body by absolute path
 // (the skill catalog is not reliably visible to workflow agents).

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -13,10 +13,17 @@ export const meta = {
 //   { homeDir, repoRoot, seed, temp }
 // The workflow owns the entire heavy plan phase: research, synthesis, worktree creation,
 // unit-author fan-out, and the bounded retry. The launcher passes paths + seed + temp.
-const HOME = args.homeDir
-const REPO = args.repoRoot
-const SEED = String(args.seed || '')
-const TEMP = Boolean(args.temp)
+// The runtime may deliver args as a JSON string rather than a parsed object (mirrors impl-workflow.mjs).
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const HOME = A.homeDir
+const REPO = A.repoRoot
+const SEED = String(A.seed || '')
+const TEMP = Boolean(A.temp)
+
+// Fail fast before any fan-out: a missing seed/paths means args was not delivered.
+// Degrading to '' would bill a full 4-phase run that only reports "no seed supplied".
+if (!SEED.trim()) throw new Error('design-plan: empty seed; args.seed not delivered. Aborting before fan-out.')
+if (!HOME || !REPO) throw new Error('design-plan: args.homeDir/repoRoot not delivered. Aborting before fan-out.')
 
 // Path helpers — agents read canonical bodies by absolute path;
 // the skill/agent catalog is not reliably visible to workflow agents.

--- a/autocode/design/skills/design/SKILL.md
+++ b/autocode/design/skills/design/SKILL.md
@@ -41,8 +41,8 @@ Run every turn; never cache.
 Transition table:
 
 ```
-none       -> launch design-plan-workflow.mjs    (Workflow) -> { folder, id, units[], underspecified[], open_qs }
-planned    -> launch design-critique-workflow.mjs (Workflow) -> { iterations_run, files_modified, needs_human, needs_human_reasons[] }
+none       -> launch design-plan-workflow.mjs    (Workflow, args { homeDir, repoRoot, seed, temp })        -> { folder, id, units[], underspecified[], open_qs }
+planned    -> launch design-critique-workflow.mjs (Workflow, args { homeDir, repoRoot, folder })            -> { iterations_run, files_modified, needs_human, needs_human_reasons[] }
 planned    -> push           (design-plan-push; light, may stay in-session) -> { pr_url, branch }
 in-review  -> iterate        (design-plan-iterate --auto) -> { applied, replied, needs_human }
 =================== USER-GATED MERGE (orchestrator never merges) ===================
@@ -50,9 +50,9 @@ merged     -> fanout         (design-fanout --auto) -> { epic_key, sub_issues[] 
 fanned-out -> hand off: invoke `impl --from-design <id>` (the 0002 orchestrator)
 ```
 
-**`none`:** Launch `design-plan-workflow.mjs` off-context via the Workflow tool (not inline, not a subagent; the workflow can fan out research and the main session preserves the `AskUserQuestion` capability for the gate). Consume `{ folder, id, units[], underspecified[], open_qs }`. Surface any `underspecified` items or `open_qs`; on none, continue to critique.
+**`none`:** Launch `design-plan-workflow.mjs` off-context via the Workflow tool (not inline, not a subagent; the workflow can fan out research and the main session preserves the `AskUserQuestion` capability for the gate). Resolve `homeDir` (`echo "$HOME"`) and `repoRoot` (`git rev-parse --show-toplevel`); launch with `args: { homeDir, repoRoot, seed, temp }`. The script fails fast (throws, ~0 cost) if `seed`/`homeDir`/`repoRoot` arrive empty, so a dropped arg surfaces as a workflow error rather than a billed no-op run. Consume `{ folder, id, units[], underspecified[], open_qs }`. Surface any `underspecified` items or `open_qs`; on none, continue to critique.
 
-**`planned` -> critique:** Launch `design-critique-workflow.mjs` off-context via the Workflow tool (bounded to 5 iterations). Consume `{ status, iterations_run, files_modified, needs_human, needs_human_reasons[] }`. Gate the push transition on `status`: only `status: done` with `needs_human: false` advances to push. On `status: error` or `status: cap_reached`, surface the result and stop. On `needs_human: true`, surface `needs_human_reasons[]` and stop; re-invocation re-runs critique (idempotent).
+**`planned` -> critique:** Launch `design-critique-workflow.mjs` off-context via the Workflow tool (bounded to 5 iterations) with `args: { homeDir, repoRoot, folder }` (`folder` is the absolute design-folder path). The script fails fast if any arrive empty. Consume `{ status, iterations_run, files_modified, needs_human, needs_human_reasons[] }`. Gate the push transition on `status`: only `status: done` with `needs_human: false` advances to push. On `status: error` or `status: cap_reached`, surface the result and stop. On `needs_human: true`, surface `needs_human_reasons[]` and stop; re-invocation re-runs critique (idempotent).
 
 **`planned` (critique clean) -> push:** Run `design-plan-push` (light phase, may stay in-session). Consume `{ pr_url, branch }`. Stage becomes `in-review`.
 


### PR DESCRIPTION
## Overview

Fixes the `/design` plan and critique workflows silently running against undelivered args. Adds the JSON-string args guard and fail-fast throws so a dropped seed surfaces as a near-zero-cost error instead of a billed no-op fan-out.

## Problem Statement

- The Workflow tool delivers `args` as a JSON **string**, not a parsed object. `design-plan-workflow.mjs` and `design-critique-workflow.mjs` read `args.*` directly, so every field resolved to `undefined`.
- `const SEED = String(args.seed || '')` coerced the missing seed to `''`. The plan workflow then ran a full four-phase fan-out against an empty seed (~177.5k tokens) only to report the seed was missing.
- `impl-workflow.mjs` already carried this guard (#44); the design workflows never got it.
- `design/SKILL.md` documented the launch but never the `args` contract the scripts depend on, leaving the orchestrator to guess the wiring.

## Implementation Notes

- Both workflow scripts decode args with `typeof args === 'string' ? JSON.parse(args) : (args || {})` (mirrors `impl-workflow.mjs`) and read fields off the decoded object.
- `design-plan-workflow.mjs` throws before `phase('Research')` on empty `seed`/`homeDir`/`repoRoot`; `design-critique-workflow.mjs` throws on empty `homeDir`/`repoRoot`/`folder`.
- `design/SKILL.md` transition table and dispatch prose now name the `args` objects (`{ homeDir, repoRoot, seed, temp }` / `{ homeDir, repoRoot, folder }`) and how to resolve the paths.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
