### PR TITLE
chore: remove version from plugin manifest

### DIFF
--- a/.autocode/conventions/commit.md
+++ b/.autocode/conventions/commit.md
@@ -22,5 +22,5 @@ Conventional Commits with an optional issue scope. The shape mirrors the PR titl
 
 - `feat(#12): Add clone-step idempotency check`
 - `fix(#47): Refuse to clobber differing AUTOCODE_CONFIG_DIR`
-- `chore: Bump plugin version to 0.2.0`
+- `chore: Remove version from plugin manifest`
 - `refactor(#103): Split provider dispatcher into resolver and runner`

--- a/.claude/skills/autocode-feature/SKILL.md
+++ b/.claude/skills/autocode-feature/SKILL.md
@@ -36,7 +36,7 @@ The shim contains:
 
 The real file contains only the body that the model executes: workflow, format, rules, examples. No frontmatter at the top.
 
-Skill and agent names must be unique across feature-sets (the shim layer is flat). The shape check (`scripts/check-plugin-shape.sh`) enforces this, rejects real files that start with `---`, and pairs shims with real files in both directions: every shim needs a real counterpart, and every real skill/agent needs a shim. It also validates each shim's `@~/.autocode/` read line resolves, gates the `.github/actions/design-fanout/` copy as byte-identical to the canonical plugin template, asserts a `plugin.json` version, and shellchecks scripts under `autocode/` and `.github/`.
+Skill and agent names must be unique across feature-sets (the shim layer is flat). The shape check (`scripts/check-plugin-shape.sh`) enforces this, rejects real files that start with `---`, and pairs shims with real files in both directions: every shim needs a real counterpart, and every real skill/agent needs a shim. It also validates each shim's `@~/.autocode/` read line resolves, gates the `.github/actions/design-fanout/` copy as byte-identical to the canonical plugin template, and shellchecks scripts under `autocode/` and `.github/`.
 
 ## Bootstrap exceptions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,6 @@ Reference the canonical source at runtime. Don't duplicate structure: two files 
 | Settings schema | `autocode/_config/settings-schema.md` |
 | Per-convention instructions | `autocode/_config/conventions/<name>.md` |
 | Output styles | `autocode/_config/output-styles/<name>.md` (plugin path is a symlink) |
-| Plugin version | `plugins/autocode/.claude-plugin/plugin.json` (`version`) |
 | CI pipeline | `.github/workflows/*.yml` |
 
 Anti-patterns: shims that restate the real definition; agents that copy a skill's workflow instead of invoking the skill; local config that duplicates a definition (derived convention instances under `$AUTOCODE_CONFIG_DIR` / `.autocode/` are expected outputs of `autocode/_config/conventions/`, not duplication).

--- a/plugins/autocode/.claude-plugin/plugin.json
+++ b/plugins/autocode/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "autocode",
-  "version": "0.1.0",
   "description": "Skills, agents, hooks, and provider scripts for the autocode SDLC workflow.",
   "author": { "name": "autocode" },
   "license": "Apache-2.0",

--- a/scripts/check-plugin-shape.sh
+++ b/scripts/check-plugin-shape.sh
@@ -168,16 +168,7 @@ else
   done
 fi
 
-# 7. Plugin manifest carries a version (the CLAUDE.md SSOT row points here).
-note "checking plugin.json version field"
-plugin_manifest="plugins/autocode/.claude-plugin/plugin.json"
-if [[ ! -f "${plugin_manifest}" ]]; then
-  err "missing ${plugin_manifest}"
-elif ! grep -Eq '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "${plugin_manifest}"; then
-  err "missing non-empty \"version\" in ${plugin_manifest}"
-fi
-
-# 8. Shellcheck all shell scripts under tracked locations.
+# 7. Shellcheck all shell scripts under tracked locations.
 note "shellchecking shell scripts"
 scripts=()
 while IFS= read -r f; do


### PR DESCRIPTION
## Overview

Remove the `version` field from the plugin manifest. Plugins are not versioned in autocode.

## Problem Statement

- `plugins/autocode/.claude-plugin/plugin.json` carried a `version` that had no meaning for this plugin.
- `scripts/check-plugin-shape.sh` asserted the field, and `CLAUDE.md` listed it as a single-source-of-truth row, propagating the false invariant.

## Checklist (if applicable)

* [ ] Mention to the original issue
* [x] PR name with proper formatting
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
