### PR TITLE
fix(design): restore args JSON.parse guard in design workflows

### DIFF
--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -9,9 +9,12 @@ export const meta = {
 }
 
 // args (from the design-plan-critique --auto launcher): { homeDir, repoRoot, folder }
-const HOME = args.homeDir
-const REPO = args.repoRoot
-const FOLDER = args.folder        // absolute path to the design folder
+// The runtime may deliver args as a JSON string rather than a parsed object (mirrors impl-workflow.mjs).
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const HOME = A.homeDir
+const REPO = A.repoRoot
+const FOLDER = A.folder        // absolute path to the design folder
+if (!HOME || !REPO || !FOLDER) throw new Error('design-critique-workflow: missing homeDir/repoRoot/folder (args not delivered; see #57)')
 const MAX_ITERATIONS = 5
 
 // Agents run skills by reading the canonical body by absolute path

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -13,10 +13,14 @@ export const meta = {
 //   { homeDir, repoRoot, seed, temp }
 // The workflow owns the entire heavy plan phase: research, synthesis, worktree creation,
 // unit-author fan-out, and the bounded retry. The launcher passes paths + seed + temp.
-const HOME = args.homeDir
-const REPO = args.repoRoot
-const SEED = String(args.seed || '')
-const TEMP = Boolean(args.temp)
+// The runtime may deliver args as a JSON string rather than a parsed object (mirrors impl-workflow.mjs).
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const HOME = A.homeDir
+const REPO = A.repoRoot
+const SEED = String(A.seed || '')
+const TEMP = Boolean(A.temp)
+if (!HOME || !REPO) throw new Error('design-plan-workflow: missing homeDir/repoRoot (args not delivered)')
+if (!SEED) throw new Error('design-plan-workflow: empty seed (args not delivered; see #57)')
 
 // Path helpers — agents read canonical bodies by absolute path;
 // the skill/agent catalog is not reliably visible to workflow agents.


### PR DESCRIPTION
## Overview

Restores the `args` JSON-string guard in `design-plan-workflow.mjs` and `design-critique-workflow.mjs` so the design plan/critique workflows receive their seed and paths again.

## Problem Statement

- The Workflow runtime delivers `args` as a JSON string, but both design workflow scripts read `args.homeDir` / `args.seed` / `args.folder` directly, so every field resolved to `undefined` and the seed coerced to `""`.
- The plan workflow then ran a full four-phase opus fan-out against an empty seed, latched onto an unrelated in-flight design, and billed the tokens to report only that the seed was missing.
- This is a regression of #57 (`c5ffded`), whose guard was later dropped from these two files. `impl-workflow.mjs:26` still carries the equivalent guard.

## Implementation Notes

- Add `const A = typeof args === 'string' ? JSON.parse(args) : (args || {})` at the top of both scripts and read fields from `A` (mirrors `impl-workflow.mjs`).
- Add fail-fast throws on empty seed / missing `homeDir`/`repoRoot`/`folder`, so a dropped arg surfaces as a near-zero-cost error instead of an expensive no-op run.

## Checklist (if applicable)

* [x] Mention to the original issue (regression of #57)
* [x] PR name with proper formatting
* [ ] Test case(s): workflow scripts have no unit-test harness; verified by driving `design-plan` via the Workflow tool with a JSON-string `args` payload (seed now delivered; a subsequent empty-arg call throws immediately instead of fanning out)
* [x] Documentation added or modified appropriately (n/a; inline comment references the mirrored guard)