### PR TITLE
refactor(#64): Downgrade design-workflow researcher dispatches to sonnet

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -1,1 +1,6 @@
 # Progress: workflow-cost-quality
+
+## design-researchers-sonnet — 2026-07-05
+
+Unit: #64
+Downgraded the read-only `codebase-researcher` dispatches in the two design workflow runtimes from opus to sonnet: the `research:<label>` and `resolve-research:<slug>` fan-outs in `design-plan-workflow.mjs`, and the `resolve-i<n>-<id>` researcher wrapper in `design-critique-workflow.mjs`. Every judgment/generative dispatch (plan-gaps, synthesize, author, resolve-author, critique question) stays opus. Reworded the `meta.phases` descriptor strings to match; no schema or interface changes.

--- a/.autocode/design/0006-workflow-cost-quality/progress/design-researchers-sonnet.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/design-researchers-sonnet.md
@@ -1,0 +1,3 @@
+# design-researchers-sonnet
+
+Epic: 0006-workflow-cost-quality  Branch: refactor/64/design-researchers-sonnet  Started: 2026-07-05

--- a/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
+++ b/autocode/design/skills/design-plan-critique/scripts/design-critique-workflow.mjs
@@ -3,7 +3,7 @@ export const meta = {
   description: 'Critique loop: generate questions, resolve via research, apply in place, cap 5',
   phases: [
     { title: 'Question', detail: "opus: generate this pass's follow-up questions", model: 'opus' },
-    { title: 'Resolve', detail: 'opus: research each question (researcher-only)', model: 'opus' },
+    { title: 'Resolve', detail: 'sonnet: research each question (researcher-only)', model: 'sonnet' },
     { title: 'Apply', detail: 'sonnet: write resolutions into units + DESIGN + critique log', model: 'sonnet' },
   ],
 }
@@ -96,7 +96,7 @@ while (iterations < MAX_ITERATIONS) {
           'Apply its resolution + source-citation rules (SKILL step 3 and Rules: every resolution cites its source). ' +
           'If research cannot close the question, set unresolved=true and explain why in `why`; do not abort.') +
         `\nQuestion JSON:\n${JSON.stringify(item)}`,
-      { label: `resolve-i${iterations}-${item.id}`, phase: 'Resolve', model: 'opus', schema: RESOLVE_SCHEMA },
+      { label: `resolve-i${iterations}-${item.id}`, phase: 'Resolve', model: 'sonnet', schema: RESOLVE_SCHEMA },
     )))
 
   const usable = resolved.filter(Boolean)

--- a/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
+++ b/autocode/design/skills/design-plan/scripts/design-plan-workflow.mjs
@@ -2,7 +2,7 @@ export const meta = {
   name: 'design-plan',
   description: 'Plan phase off-context: research, DESIGN.md synthesis, worktree/branch/id/INDEX.md, unit-author fan-out with structured contract and bounded retry',
   phases: [
-    { title: 'Research', detail: 'opus: interpret seed, fan-out codebase researchers for each gap', model: 'opus' },
+    { title: 'Research', detail: 'opus: interpret seed + decompose gaps; sonnet: fan-out codebase researchers', model: 'opus+sonnet' },
     { title: 'Synthesize', detail: 'opus: compose DESIGN.md, derive shortname, create worktree/branch/id/INDEX.md, assign units', model: 'opus' },
     { title: 'Author', detail: 'opus: unit-author fan-out (one per unit)', model: 'opus' },
     { title: 'Resolve', detail: 'opus: bounded research-backed retry for underspecified units (cap one per unit)', model: 'opus' },
@@ -136,7 +136,7 @@ const researched = await parallel(
       `Read ${designAgent('codebase-researcher')} and follow it. ` +
       `Research question: "${gap.question}". Label: "${gap.label}". ` +
       `Return label, verbatim findings, and any remaining gaps you could not resolve.`,
-      { label: `research:${gap.label}`, phase: 'Research', model: 'opus', schema: RESEARCH_SCHEMA },
+      { label: `research:${gap.label}`, phase: 'Research', model: 'sonnet', schema: RESEARCH_SCHEMA },
     )
   )
 )
@@ -244,7 +244,7 @@ if (underspecifiedIdxs.length > 0) {
         `Research the specific gap that makes unit "${unit.slug}" underspecified. ` +
         `Deliverable: "${unit.deliverable}". ` +
         `Focus on which concrete files exist and what interfaces they expose.`,
-        { label: `resolve-research:${unit.slug}`, phase: 'Resolve', model: 'opus', schema: RESEARCH_SCHEMA },
+        { label: `resolve-research:${unit.slug}`, phase: 'Resolve', model: 'sonnet', schema: RESEARCH_SCHEMA },
       )
       // Then: re-author with additional findings
       return agent(


### PR DESCRIPTION
## Overview

Downgrades the read-only `codebase-researcher` dispatches in the two design workflow runtimes (`design-plan-workflow.mjs`, `design-critique-workflow.mjs`) from `opus` to `sonnet`.

## Problem Statement

- Both design workflows dispatched read-and-report `codebase-researcher` work on `opus`, which is overkill for research and inflates plan/critique cost.
- Every judgment/generative dispatch (plan-gaps, synthesize, author, resolve-author, critique question) must stay on `opus`; only the pure research fan-outs should move.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [ ] Documentation added or modified appropriately

<!-- Issue linking (auto-added by tooling): -->


resolves #64