### PR TITLE
feat(#72): Log per-phase workflow progress under fan-out

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -4,3 +4,7 @@
 
 Unit: #64
 Downgraded the read-only `codebase-researcher` dispatches in the two design workflow runtimes from opus to sonnet: the `research:<label>` and `resolve-research:<slug>` fan-outs in `design-plan-workflow.mjs`, and the `resolve-i<n>-<id>` researcher wrapper in `design-critique-workflow.mjs`. Every judgment/generative dispatch (plan-gaps, synthesize, author, resolve-author, critique question) stays opus. Reworded the `meta.phases` descriptor strings to match; no schema or interface changes.
+## workflow-progress-logging — 2026-07-05
+
+Unit: #72
+Added a `logProgress` helper to the workflow runtime that spawns `progress-logger` directly after Plan, Execute, GapCheck (heavy units), and Fix (when a round ran), so progress is recorded even when a phase's Stop hook never fires under module fan-out. `progress-logger` gained a facts-provided fast path (phase + verbatim note) that skips git inspection and appends via Bash `>>`; the git-derived fallback used by standalone `impl-execute` is unchanged. `design-folder.md` documents the optional `[<phase>]` heading suffix.

--- a/.autocode/design/0006-workflow-cost-quality/progress/workflow-progress-logging.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/workflow-progress-logging.md
@@ -1,0 +1,3 @@
+# workflow-progress-logging
+
+Epic: 0006-workflow-cost-quality  Branch: feat/72/workflow-progress-logging  Started: 2026-07-05

--- a/autocode/design/design-folder.md
+++ b/autocode/design/design-folder.md
@@ -143,11 +143,11 @@ Per-unit detailed log, owned solely by that unit's worktree (no cross-file write
 
 Epic: <id>-<shortname>  Branch: <branch>  Started: <date>
 
-## <entry timestamp>
+## <entry timestamp> [<phase>]
 <what was attempted, what worked, what failed, troubleshooting steps>
 ```
 
-Entries capture lessons for any agent that later continues this unit or a sibling unit in the same epic. Written for both completed and abandoned units.
+Entries capture lessons for any agent that later continues this unit or a sibling unit in the same epic. Written for both completed and abandoned units. `[<phase>]` is the emitting milestone name (`Plan`, `Execute`, `GapCheck`, `Fix`) and is optional: the workflow-driven fast path emits it, the git-derived fallback (standalone `impl-execute` via the Stop hook) omits it.
 
 ## Lifecycle
 

--- a/autocode/impl/agents/progress-logger.md
+++ b/autocode/impl/agents/progress-logger.md
@@ -16,9 +16,13 @@ The spawning prompt provides:
 - `slug` and the unit's branch.
 - A short description of what was attempted this stretch, plus the new commit SHA(s).
 
-If any is missing, derive it: read `progress_log` for the last entry, then `git log` / `git diff` on the current branch for what changed since.
+When the spawn provides `phase` and a verbatim `note`, take the fast path (Workflow below); the SHA(s) are optional context. Absent those, derive it: read `progress_log` for the last entry, then `git log` / `git diff` on the current branch for what changed since.
 
 ## Workflow
+
+**Fast path (facts provided).** When the spawn supplies `phase` and a verbatim `note`, skip steps 1-2 (no `git log`/`git diff`): resolve `progress_log` (from the prompt or by reading `.autocode/.impl-context`), then append the note verbatim under a `## <UTC timestamp> [<phase>]` heading via Bash `>>`, and report. Do not inspect the diff or compose content; the note is authoritative. Bash `>>` is used instead of Edit because this path never Reads `progress_log` (an Edit would require a prior Read).
+
+Otherwise, the git-derived fallback:
 
 1. Read `progress_log` to see what is already recorded (and the last commit it covered).
 2. Inspect what changed since: `git log` and `git diff` for the new commits.
@@ -28,6 +32,8 @@ If any is missing, derive it: read `progress_log` for the last entry, then `git 
    ## <UTC timestamp>
    <what was attempted; what worked; what failed and why; troubleshooting steps and their outcome; anything a future implementer should know>
    ```
+
+   (The fast path's heading carries the optional `[<phase>]` suffix; the git-derived heading above omits it.)
 
 4. Report a one-line confirmation of what you logged, or that you skipped.
 

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -33,13 +33,31 @@ const FANOUT = A.fanout || 'auto' // 'auto' | 'off' | 'on'
 const MAX_FIX_ROUNDS = 2
 const GAP_MAX_ROUNDS = 2
 
-// Subagents cannot spawn subagents, so all fan-out lives here in the workflow
-// runtime. Agents run skills by reading the canonical body by absolute path
-// (the skill catalog is not reliably visible to workflow agents).
+// Fan-out lives here in the workflow runtime to keep heavy work off the
+// launching context, not because nesting is impossible (nested subagents are
+// supported as of CC v2.1.172). Agents run skills by reading the canonical body
+// by absolute path (the skill catalog is not reliably visible to workflow agents).
 const skill = (name) => `${HOME}/.autocode/autocode/impl/skills/${name}/SKILL.md`
 const inWt = `Work in the git worktree at ${WT}: cd into it before doing anything. `
 const follow = (path, extra) => `Read the skill at ${path} and follow it exactly. ${extra}`
 const readOnly = 'You are a read-only reviewer: never edit, write, or run mutating commands. '
+
+// leanness: the spawned agent reads .impl-context for progress_log because the
+// workflow runtime does no file/git I/O (every agent() delegates it). Same
+// source the Stop hook reads. Facts (phase + verbatim note) fire the agent's
+// fast path, skipping git inspection.
+const progressLoggerAgent = `${HOME}/.autocode/autocode/impl/agents/progress-logger.md`
+const logProgress = (phase, note) =>
+  agent(
+    inWt + follow(progressLoggerAgent,
+      'Facts-provided fast path: skip the git-inspection steps. ' +
+      'Read `.autocode/.impl-context` (jq `.progress_log`) for the progress log path; ' +
+      `the unit slug is "${SLUG}". ` +
+      `Append the note below verbatim under a \`## <UTC timestamp> [${phase}]\` heading ` +
+      '(generate the UTC timestamp with `date -u`), appending via Bash `>>` and touching only that file. ' +
+      `Note: ${note}`),
+    { label: `log:${phase}`, phase, model: 'sonnet' },
+  )
 
 const PREP_SCHEMA = {
   type: 'object',
@@ -241,6 +259,7 @@ await agent(
     `Run it in --auto mode for unit ${SLUG}. It writes the mechanical plan to .autocode/.impl-plan.md. Return the plan path and a one-line summary.`),
   { label: 'plan', phase: 'Plan', model: 'opus' },
 )
+await logProgress('Plan', 'Plan phase: mechanical plan written to .autocode/.impl-plan.md.')
 
 phase('Partition')
 const part = await agent(
@@ -306,6 +325,7 @@ if (fanout) {
     { label: 'execute', phase: 'Execute', model: 'sonnet' },
   )
 }
+await logProgress('Execute', `Execute phase: plan implemented and committed${fanout ? ' (module fanout)' : ''}.`)
 
 let gapRoundsUsed = 0
 let remainingGaps = 0
@@ -332,6 +352,7 @@ if (heavy) {
   }
   gapRoundsUsed = gapRound
   remainingGaps = gap && gap.gaps ? gap.gaps.length : 0
+  await logProgress('GapCheck', `GapCheck phase: ${gapRoundsUsed} gap round(s); ${remainingGaps} gap(s) remaining.`)
 }
 
 let round = 0
@@ -346,6 +367,7 @@ while (importantOf(decided).length && round < MAX_FIX_ROUNDS) {
   )
   decided = await reviewCycle(`-r${round}`)
 }
+if (round > 0) await logProgress('Fix', `Fix phase: ${round} fix round(s); ${importantOf(decided).length} important finding(s) remaining.`)
 
 phase('Push')
 const push = await agent(


### PR DESCRIPTION
## Overview

Adds a `logProgress` helper to the workflow runtime so per-phase progress is logged directly after Plan, Execute, GapCheck (heavy units), and Fix (when a round ran), instead of relying solely on the Stop hook. `progress-logger` gains a facts-provided fast path that skips git inspection when a phase and verbatim note are supplied.

## Problem Statement

- The workflow runtime's Stop hook fires only in the spawned subagent, so progress goes unlogged whenever a phase spawns via module fan-out.
- `progress-logger` had only a git-derived path (`git log` / `git diff`), which is unnecessary work when the caller already knows what happened.
- A stale comment in `impl-workflow.mjs` claimed subagents cannot spawn subagents, which is no longer true as of CC v2.1.172.

## Architecture

No new components. `impl-workflow.mjs` gains a `logProgress(phase, note)` helper that spawns the `progress-logger` agent directly (not via the Stop hook) after each heavy phase. `progress-logger.md` gains a fast path: when `phase` + a verbatim `note` are supplied, it skips steps 1-2 (no `git log`/`git diff`) and appends via Bash `>>` instead of Edit, since it never reads `progress_log` first. `design-folder.md` documents the optional `[<phase>]` heading suffix so the spec and the agent stay in sync.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately
<!-- /required-checklist -->

<!-- Issue linking (auto-added by tooling): -->


resolves #72