### PR TITLE
refactor(#67): Fold Partition phase into Plan agent's structured output

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -8,3 +8,8 @@ Downgraded the read-only `codebase-researcher` dispatches in the two design work
 
 Unit: #72
 Added a `logProgress` helper to the workflow runtime that spawns `progress-logger` directly after Plan, Execute, GapCheck (heavy units), and Fix (when a round ran), so progress is recorded even when a phase's Stop hook never fires under module fan-out. `progress-logger` gained a facts-provided fast path (phase + verbatim note) that skips git inspection and appends via Bash `>>`; the git-derived fallback used by standalone `impl-execute` is unchanged. `design-folder.md` documents the optional `[<phase>]` heading suffix.
+
+## plan-partition-schema — 2026-07-05
+
+Unit: #67
+Deleted the redundant sonnet Partition phase from `impl-workflow.mjs`: renamed `PARTITION_SCHEMA` to `PLAN_SCHEMA` and attached it to the existing Plan call, so the opus planner returns `files_total`/`heavy`/`partitionable`/`foundation`/`modules` directly instead of a second agent re-reading `.autocode/.impl-plan.md` to transcribe the same fields. Downstream `heavy`/fanout/foundation/modules logic now reads `plan.*` instead of `part.*`; the `## Module partition` section still lands on disk unchanged for `impl-execute --module` to consume. `impl-plan/SKILL.md`'s `--auto` result and Module partition intro updated to match.

--- a/.autocode/design/0006-workflow-cost-quality/progress/plan-partition-schema.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/plan-partition-schema.md
@@ -1,0 +1,3 @@
+# plan-partition-schema
+
+Epic: 0006-workflow-cost-quality  Branch: refactor/67/plan-partition-schema  Started: 2026-07-05

--- a/autocode/impl/skills/impl-plan/SKILL.md
+++ b/autocode/impl/skills/impl-plan/SKILL.md
@@ -34,11 +34,11 @@ Design-folder layout, `.impl-context` keys, unit DAG, and the progress lifecycle
 
 4. Write the plan to `.autocode/.impl-plan.md` in the worktree: the per-file task list, the test plan, the implementation order, the `## Module partition` section, and the out-of-scope list. This file is the spec `impl-execute` consumes. Ensure `.autocode/.gitignore` ignores it (create if missing, append if absent); it is a transient artifact, not committed.
 
-5. Report. Default: the plan path and a short summary of the task list. With `--auto`: emit a structured result block (plan path, file count, out-of-scope count). The `## Module partition` section is read from the plan file by the workflow's Partition agent, not surfaced in this block; leave the `--auto` fields unchanged. Next step: `/impl-execute`.
+5. Report. Default: the plan path and a short summary of the task list. With `--auto`: emit a structured result block (plan path, file count, out-of-scope count, `files_total`, `partitionable`, `foundation` `{files,summary}` or null, `modules` `[{name,files,summary}]`). These partition fields mirror the plan's own `## Module partition` section: the planner emits the partition directly in this structured result, and the workflow's Plan phase consumes it from there rather than a separate agent re-reading the plan file. Next step: `/impl-execute`.
 
 ## Module partition
 
-`## Module partition` is written into `.autocode/.impl-plan.md` so the workflow's Partition agent can read it into `{ files_total, partitionable, foundation, modules[] }` without re-deriving the grouping. The planner owns the split; the agent only transcribes.
+`## Module partition` is written into `.autocode/.impl-plan.md` so `impl-execute --module <name>` can scope execution to one group. The same partition is also returned in the `--auto` structured result, consumed by the workflow's Plan phase.
 
 ### Foundation
 

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -3,7 +3,6 @@ export const meta = {
   description: 'Implement one design unit: plan, execute, review (challenge/decide), fix, push, hygiene',
   phases: [
     { title: 'Plan', detail: 'opus: resolve all unknowns into a mechanical plan', model: 'opus' },
-    { title: 'Partition', detail: 'sonnet: transcribe the plan partition and judge heaviness', model: 'sonnet' },
     { title: 'Execute', detail: 'sonnet: carry out the plan and commit', model: 'sonnet' },
     { title: 'Foundation', detail: 'sonnet: implement the shared foundation group (no commit)', model: 'sonnet' },
     { title: 'Modules', detail: 'sonnet: implement each module group in parallel (no commit)', model: 'sonnet' },
@@ -153,7 +152,7 @@ const PUSH_SCHEMA = {
   required: ['pr_url', 'branch', 'hygiene_shas', 'hygiene_files'],
 }
 
-const PARTITION_SCHEMA = {
+const PLAN_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
@@ -254,35 +253,32 @@ async function reviewCycle(tag) {
 }
 
 phase('Plan')
-await agent(
+const plan = await agent(
   inWt + follow(skill('impl-plan'),
-    `Run it in --auto mode for unit ${SLUG}. It writes the mechanical plan to .autocode/.impl-plan.md. Return the plan path and a one-line summary.`),
-  { label: 'plan', phase: 'Plan', model: 'opus' },
+    `Run it in --auto mode for unit ${SLUG}. It writes the mechanical plan to .autocode/.impl-plan.md. Return the plan path and a one-line summary. ` +
+    'Also return the module partition and a self-assessed heaviness, from the `## Module partition` section you write into the plan: ' +
+    'set `partitionable`/`foundation`/`modules`/`files_total` from that section (do NOT re-infer the grouping from the file list). ' +
+    'Set `files_total` to the count of ALL in-scope planned files across the whole per-file task list, independent of the partition. ' +
+    'Set `partitionable` true only when the section declares genuine file-disjoint modules (>=2); a missing section, a non-partitionable declaration, or a single module means `partitionable: false` with `modules: []`. ' +
+    'Set `foundation` to the `### Foundation` group ({ files, summary }) when present, else null. ' +
+    'Self-assess `heavy`: compaction risk over a single Execute agent (file count, total plan size, cross-file coupling); a small, loosely-coupled plan is not heavy.'),
+  { label: 'plan', phase: 'Plan', model: 'opus', schema: PLAN_SCHEMA },
 )
 await logProgress('Plan', 'Plan phase: mechanical plan written to .autocode/.impl-plan.md.')
 
-phase('Partition')
-const part = await agent(
-  inWt +
-    'Read .autocode/.impl-plan.md, specifically its `## Module partition` section (the planner writes a `### Foundation` group and a `### Modules` list, or declares the unit non-partitionable). ' +
-    'Transcribe that section into the schema; do NOT re-infer the grouping from the file list. ' +
-    'Set `files_total` to the count of ALL in-scope planned files across the whole plan (the per-file task list), independent of the partition. ' +
-    'Set `partitionable` true only when the section declares genuine file-disjoint modules (>=2); a missing section, a non-partitionable declaration, or a single module means `partitionable: false` with `modules: []`. ' +
-    'Set `foundation` to the `### Foundation` group ({ files, summary }) when present, else null. ' +
-    'Judge `heavy` yourself from the whole plan: compaction risk over a single Execute agent (file count, total plan size, cross-file coupling). A small, loosely-coupled plan is not heavy.',
-  { label: 'partition', phase: 'Partition', model: 'sonnet', schema: PARTITION_SCHEMA },
-)
-const heavy = !!part && part.heavy
-const fanout = !!part &&
+// files_total rides the plan output unread here; it exists for the downstream
+// per-module-gapcheck sibling's contract, not for this workflow's own logic.
+const heavy = !!plan && plan.heavy
+const fanout = !!plan &&
   FANOUT !== 'off' &&
-  part.partitionable &&
-  part.modules.length >= 2 &&
+  plan.partitionable &&
+  plan.modules.length >= 2 &&
   (FANOUT === 'on' || heavy)
 
 phase('Execute')
 if (fanout) {
   let foundationOk = true
-  if (part.foundation) {
+  if (plan.foundation) {
     phase('Foundation')
     const found = await agent(
       inWt + follow(skill('impl-execute'),
@@ -293,14 +289,14 @@ if (fanout) {
   }
   if (foundationOk) {
     phase('Modules')
-    await parallel(part.modules.map((m) => () =>
+    await parallel(plan.modules.map((m) => () =>
       agent(
         inWt + follow(skill('impl-execute'),
           `Run it in --auto --no-commit --module ${m.name} mode. Implement ONLY the "${m.name}" module group of the plan's \`## Module partition\`, leave all changes uncommitted in the working tree, and report the files written.`),
         { label: `module:${m.name}`, phase: 'Modules', model: 'sonnet' },
       )))
     phase('Commit')
-    const commitOrder = (part.foundation ? ['foundation'] : []).concat(part.modules.map((m) => m.name))
+    const commitOrder = (plan.foundation ? ['foundation'] : []).concat(plan.modules.map((m) => m.name))
     await agent(
       inWt + follow(`${HOME}/.autocode/autocode/git/skills/git-commit/SKILL.md`,
         'Parallel module agents wrote changes to the working tree without committing. ' +


### PR DESCRIPTION
## Overview

Deletes the redundant sonnet Partition phase from the impl workflow: `PARTITION_SCHEMA` is renamed to `PLAN_SCHEMA` and attached to the existing opus Plan call, so the planner returns `files_total`/`heavy`/`partitionable`/`foundation`/`modules` directly instead of a second agent re-reading `.autocode/.impl-plan.md` just to transcribe the same fields.

## Problem Statement

- The opus Plan agent already wrote the `## Module partition` section into `.autocode/.impl-plan.md`.
- A separate sonnet Partition agent then re-read that file only to transcribe it into a schema, an extra model call for zero new information.
- `heavy` was an independent downstream judgment instead of something the planner, which already has full context, could self-assess in the same call.

## Architecture

_n/a_

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately


resolves #67