### PR TITLE
docs(#71): Add SVG diagram authoring guide

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -13,3 +13,7 @@ Added a `logProgress` helper to the workflow runtime that spawns `progress-logge
 
 Unit: #67
 Deleted the redundant sonnet Partition phase from `impl-workflow.mjs`: renamed `PARTITION_SCHEMA` to `PLAN_SCHEMA` and attached it to the existing Plan call, so the opus planner returns `files_total`/`heavy`/`partitionable`/`foundation`/`modules` directly instead of a second agent re-reading `.autocode/.impl-plan.md` to transcribe the same fields. Downstream `heavy`/fanout/foundation/modules logic now reads `plan.*` instead of `part.*`; the `## Module partition` section still lands on disk unchanged for `impl-execute --module` to consume. `impl-plan/SKILL.md`'s `--auto` result and Module partition intro updated to match.
+## svg-diagram-guide — 2026-07-05
+
+Unit: #71
+Added `autocode/_config/guides/svg-diagram.md`: a fixed copy-and-edit SVG skeleton (explicit viewBox, one reusable `<marker>` arrowhead, four named style classes, rounded-rect boxes, manual grid coordinates) plus a python3 well-formedness check with a dependency-free Node tag-balance fallback, no `xmllint`. `design-folder.md`'s Architecture diagram bullet now points at the guide as an SVG alternative to ASCII, and `guides/CLAUDE.md` lists it.

--- a/.autocode/design/0006-workflow-cost-quality/progress/svg-diagram-guide.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/svg-diagram-guide.md
@@ -1,0 +1,3 @@
+# svg-diagram-guide
+
+Epic: 0006-workflow-cost-quality  Branch: feat/71/svg-diagram-guide  Started: 2026-07-05

--- a/autocode/_config/guides/CLAUDE.md
+++ b/autocode/_config/guides/CLAUDE.md
@@ -3,3 +3,4 @@
 Fixed, cross-cutting procedural specs that skills `@`-import (like `design-folder.md` does from `design/`). Plugin-internal: unlike `conventions/`, nothing here is scaffolded into target repos, and unlike `output-styles/`, nothing is symlinked into the plugin tree. A guide is a single source of truth for a procedure shared by skills across feature-sets.
 
 - `worktree.md`: how skills enter and tear down a git worktree to isolate repo changes. Imported by the design, impl, and git skills that mutate the repo.
+- `svg-diagram.md`: a copy-and-edit SVG diagram template plus a `python3`/Node well-formedness check. Imported by design and impl skills that author a diagram where SVG reads better than ASCII.

--- a/autocode/_config/guides/svg-diagram.md
+++ b/autocode/_config/guides/svg-diagram.md
@@ -1,0 +1,62 @@
+# SVG diagram
+
+A fixed, copy-and-edit SVG diagram template plus a well-formedness check, for a skill that authors a diagram where SVG reads better than ASCII art (currently `design-plan`; later `impl-recap`). This guide is the sole locus of the SVG procedure: an importing skill copies the skeleton below and issues the validation Bash call itself, rather than restating these steps.
+
+## Template
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200" role="img" aria-label="Two-component data flow">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="edge-arrow" d="M0 0 L10 5 L0 10 z"/>
+    </marker>
+  </defs>
+  <style>
+    .box   { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.5; }
+    .label { font: 13px sans-serif; fill: #1e1b4b; text-anchor: middle; }
+    .edge  { stroke: #4f46e5; stroke-width: 1.5; fill: none; }
+    .edge-arrow { fill: #4f46e5; }
+  </style>
+  <rect class="box" x="20"  y="70" width="120" height="50" rx="8"/>
+  <text class="label" x="80"  y="100">Source component</text>
+  <rect class="box" x="260" y="70" width="120" height="50" rx="8"/>
+  <text class="label" x="320" y="100">Target component</text>
+  <line class="edge" x1="140" y1="95" x2="260" y2="95" marker-end="url(#arrow)"/>
+  <text class="label" x="200" y="86">payload</text>
+</svg>
+```
+
+Explicit `viewBox`; exactly one reusable `<marker>` arrowhead in `<defs>`; four named `<style>` classes (`box`, `label`, `edge`, `edge-arrow`); rounded-rect (`<rect rx>`) boxes with 2-4 word labels; connectors on manually chosen grid coordinates. Copy the skeleton, add or remove `<rect>`/`<text>`/`<line>` groups, and adjust coordinates by hand: no auto-layout, no renderer binary.
+
+## Validation
+
+After writing the `<svg>` to a file, check well-formedness as a Bash call:
+
+- Primary: `python3 -c 'import sys, xml.dom.minidom; xml.dom.minidom.parse(sys.argv[1])' <path>` (exit 0 = well-formed).
+- Fallback when `python3` is absent, a tag-balance check in Node:
+
+```
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync(process.argv[1], "utf8");
+const stack = [];
+const tagRe = /<\/?([a-zA-Z][\w:-]*)[^>]*?(\/?)>/g;
+let m;
+while ((m = tagRe.exec(src))) {
+  const [full, name, selfClose] = m;
+  if (full.startsWith("<?") || full.startsWith("<!")) continue;
+  if (selfClose === "/") continue;
+  if (full.startsWith("</")) {
+    if (stack.pop() !== name) { console.error("mismatched close: " + name); process.exit(1); }
+  } else {
+    stack.push(name);
+  }
+}
+if (stack.length) { console.error("unclosed: " + stack.join(",")); process.exit(1); }
+console.log("ok");
+' <path>
+```
+
+Never use `xmllint`: it is absent on a minimal Linux box and reintroduces the dependency this procedure avoids.
+
+`leanness:` manual grid coordinates, no auto-layout, is the deliberate ceiling; upgrade to a layout tool only if diagrams outgrow hand-placement.

--- a/autocode/design/design-folder.md
+++ b/autocode/design/design-folder.md
@@ -58,7 +58,7 @@ The epic plan. Opens with a single `# <Title>` H1: a natural-language title for 
 
 - `## Summary`: one paragraph. Verbatim source for the epic issue body at fan-out, so it must stand alone.
 - `## Background` (conditional): brief current-state context. A table (component / file / current behavior) when several pieces interact; a sentence or two otherwise. It frames the change; it does not re-document the codebase.
-- `## Architecture`: the proposed design. Packages, interfaces, new deps (or "no architecture impact" explicitly). Include an ASCII diagram when components interact or data crosses a boundary; omit the diagram for a single-file change.
+- `## Architecture`: the proposed design. Packages, interfaces, new deps (or "no architecture impact" explicitly). Include a diagram, ASCII or an SVG authored per `@~/.autocode/autocode/_config/guides/svg-diagram.md`, when components interact or data crosses a boundary; omit the diagram for a single-file change.
 - `## Design decisions`: numbered. Each names the choice, the rationale, and the rejected alternative. One entry per non-obvious decision; obvious choices need none.
 - `## Runtime flow` (conditional): numbered end-to-end walk of the behavior at runtime. Include for behavior changes; omit for pure refactors or static config.
 - `## Edge cases and error handling`.


### PR DESCRIPTION
## Overview

Adds `autocode/_config/guides/svg-diagram.md`: a fixed copy-and-edit SVG skeleton (explicit `viewBox`, one reusable `<marker>` arrowhead, four named style classes, rounded-rect boxes, manual grid coordinates) plus a `python3` well-formedness check with a dependency-free Node tag-balance fallback.

## Problem Statement

- Design plans sometimes need a diagram where SVG reads better than ASCII art, but there was no shared authoring procedure, so each skill would reinvent layout and validation.
- No `xmllint` dependency should be introduced (absent on a minimal Linux box).
- `design-folder.md`'s Architecture diagram bullet needed a pointer to an SVG alternative.

## Implementation Notes

- `svg-diagram.md` is the sole locus of the SVG procedure: an importing skill (currently `design-plan`; later `impl-recap`) copies the skeleton and issues the validation Bash call itself, rather than restating the steps.
- Validation primary path uses `python3 -c 'import sys, xml.dom.minidom; xml.dom.minidom.parse(sys.argv[1])'`; falls back to a Node tag-balance check when `python3` is absent.
- `design-folder.md`'s Architecture diagram bullet now references the guide as an SVG alternative to ASCII; `guides/CLAUDE.md` lists it.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately


resolves #71