### PR TITLE
feat(#70): Replace fix-round re-review with scoped verify gate

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -17,3 +17,8 @@ Deleted the redundant sonnet Partition phase from `impl-workflow.mjs`: renamed `
 
 Unit: #71
 Added `autocode/_config/guides/svg-diagram.md`: a fixed copy-and-edit SVG skeleton (explicit viewBox, one reusable `<marker>` arrowhead, four named style classes, rounded-rect boxes, manual grid coordinates) plus a python3 well-formedness check with a dependency-free Node tag-balance fallback, no `xmllint`. `design-folder.md`'s Architecture diagram bullet now points at the guide as an SVG alternative to ASCII, and `guides/CLAUDE.md` lists it.
+
+## scoped-verify-gate — 2026-07-05
+
+Unit: #70
+Added `impl-critique-verify` (opus, read-only): after a `--fix` round it confirms the just-applied findings are resolved and diff-scans for regressions, replacing the full `reviewCycle` re-run that previously followed every fix round. `impl-workflow.mjs` wires the new phase in and falls back to the full `reviewCycle` on a low-confidence decline; a `needs_human` flag now threads out of the workflow return for the caller to act on. Added `provider/git-remote/github/pr-draft.sh` (`gh pr ready --undo`) plus its `git-remote` contract entry for a future consumer to convert a PR to draft, then fixed it to stop swallowing genuine `gh` failures (e.g. a closed PR) that its stderr-grep special case had been masking as idempotent no-ops.

--- a/.autocode/design/0006-workflow-cost-quality/progress/scoped-verify-gate.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/scoped-verify-gate.md
@@ -1,0 +1,3 @@
+# scoped-verify-gate
+
+Epic: 0006-workflow-cost-quality  Branch: feat/70/scoped-verify-gate  Started: 2026-07-05

--- a/autocode/impl/skills/impl-critique-verify/SKILL.md
+++ b/autocode/impl/skills/impl-critique-verify/SKILL.md
@@ -1,0 +1,40 @@
+# Impl critique verify
+
+Scoped verification that the decided findings applied this fix round are resolved and that the fix commits introduced no new regressions. Read-only.
+
+## Input
+
+Always supplied by the caller:
+- The decided findings applied this round, each with `file:line`, `severity`, `claim`, `fix`.
+- The base ref.
+
+The skill computes the fix-commit diff itself; the caller does not supply it.
+
+## Workflow
+
+1. Compute the fix-commit diff against the base ref (`git diff <base>...HEAD`, `git diff HEAD`, untracked via `git status --porcelain`).
+2. For each supplied finding, confirm it is resolved in the current working tree at its `file:line`. Still open -> actionable.
+3. Diff-scan the fix commits for NEW regressions outside the supplied set. A regression -> actionable.
+
+## Output
+
+A `DECIDE_SCHEMA`-compatible object, no preamble:
+
+```
+- file:line | <severity> | <claim> | <minimal fix>
+```
+
+Then a one-line tally: `kept N (important M, nit K), dropped D`.
+
+`severity` MUST be exactly `Important` or `Nit`. `fix` MUST be populated for every `Important` survivor (it feeds `impl-execute --fix`). `dropped` is the count of supplied findings confirmed resolved. `tally` is the one-line summary above.
+
+Low confidence: decline. Emit no structured object at all, so the workflow falls back to the full `reviewCycle`.
+
+## Rules
+
+- Read-only: never edit, write, or run mutating commands.
+- Every supplied finding is accounted for: resolved -> counted in `dropped`; still-open -> `actionable`.
+- Regressions found outside the supplied set are added to `actionable` too.
+- Decline (no structured object) rather than guess on low confidence.
+
+$ARGUMENTS

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -14,6 +14,7 @@ export const meta = {
     { title: 'Challenge', detail: 'opus: contest the findings', model: 'opus' },
     { title: 'Decide', detail: 'opus: rule which findings survive', model: 'opus' },
     { title: 'Fix', detail: 'sonnet: apply the decided findings', model: 'sonnet' },
+    { title: 'Verify', detail: 'opus: scoped check that decided findings are resolved and no new regressions', model: 'opus' },
     { title: 'Push', detail: 'sonnet: commit the rollup and open the PR', model: 'sonnet' },
     { title: 'Hygiene', detail: 'sonnet: doc/PR-description hygiene', model: 'sonnet' },
   ],
@@ -361,9 +362,21 @@ while (importantOf(decided).length && round < MAX_FIX_ROUNDS) {
       `Run it in --fix --auto mode. Apply these decided findings minimally and commit:\n${JSON.stringify(importantOf(decided))}`),
     { label: `fix-r${round}`, phase: 'Fix', model: 'sonnet' },
   )
-  decided = await reviewCycle(`-r${round}`)
+  const verify = await agent(
+    inWt + readOnly + follow(skill('impl-critique-verify'),
+      'Verify the fixes just applied this round. The decided findings applied this round ' +
+      `(each file:line, severity, claim, fix):\n${JSON.stringify(importantOf(decided))}\n` +
+      `Base ref: ${BASE}. Compute the fix-commit diff yourself. Confirm each finding is resolved; ` +
+      'diff-scan the fix commits for NEW regressions outside the decided set. ' +
+      'Return a DECIDE_SCHEMA object (actionable[] keyed on severity Important|Nit, dropped, tally); ' +
+      'decline by returning no structured object on low confidence.'),
+    { label: `verify-r${round}`, phase: 'Verify', model: 'opus', schema: DECIDE_SCHEMA },
+  )
+  decided = verify || await reviewCycle(`-r${round}`)
 }
 if (round > 0) await logProgress('Fix', `Fix phase: ${round} fix round(s); ${importantOf(decided).length} important finding(s) remaining.`)
+
+const needsHuman = importantOf(decided).length > 0 || remainingGaps > 0
 
 phase('Push')
 const push = await agent(
@@ -388,4 +401,5 @@ return {
   fanout_used: fanout,
   gap_rounds: gapRoundsUsed,
   remaining_gaps: remainingGaps,
+  needs_human: needsHuman,
 }

--- a/plugins/autocode/skills/impl-critique-verify/SKILL.md
+++ b/plugins/autocode/skills/impl-critique-verify/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: impl-critique-verify
+description: Read-only scoped verifier that confirms each decided review finding was resolved in the fix commits and diff-scans them for new regressions, emitting a decide-shaped result. Use when verifying a fix round in the impl workflow before falling back to a full re-review. Leaf skill of the impl-critique review flow.
+---
+
+Read through @~/.autocode/autocode/impl/skills/impl-critique-verify/SKILL.md and execute actions according to the instructions in the file. `$ARGUMENTS` is forwarded.

--- a/provider/git-remote/contract.md
+++ b/provider/git-remote/contract.md
@@ -13,7 +13,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 - Exit codes: `0` success, `1` expected failure (bad input, missing resource), `2` unexpected failure (network, crash).
 - JSON: `snake_case` keys, `[]` for empty arrays, `""` for empty strings, never `null` (except where the shape explicitly allows it, e.g. `line: <integer|null>` for PR comments without a line).
 - PR identifier is provider-native as a string (GitHub PR number).
-- Idempotency: `pr-issue-link.sh` is a no-op when the link is already present. `pr-review-request.sh` tolerates already-requested reviewers. `pr-thread-resolve.sh` tolerates already-resolved threads. `pr-merge.sh` is a no-op on an already-merged PR.
+- Idempotency: `pr-issue-link.sh` is a no-op when the link is already present. `pr-review-request.sh` tolerates already-requested reviewers. `pr-thread-resolve.sh` tolerates already-resolved threads. `pr-merge.sh` is a no-op on an already-merged PR. `pr-draft.sh` is a no-op on an already-draft PR.
 
 ## Shared types
 
@@ -82,6 +82,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 | `pr-create.sh` | `--title <t> --body-file <p> [--base <b>] [--assignee <a>] [--no-review]` | PR URL on a single line |
 | `pr-body-edit.sh` | `<pr> <body-file>` | none |
 | `pr-merge.sh` | `<pr> [--admin] [--squash\|--merge\|--rebase]` | none |
+| `pr-draft.sh` | `<pr> [-g <owner/repo>]` | none |
 | `pr-issue-link.sh` | `<pr> <issue-id>` | none |
 | `issue-ref.sh` | `<tracker-key>` | git-remote issue number to close, or empty |
 | `pr-review-request.sh` | `<pr> <reviewer>...` | none |
@@ -100,6 +101,7 @@ PR lifecycle on the git hosting side: create, view, edit body, link to issue, re
 - `pr-issue-link.sh` is idempotent. It detects existing `close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved #N` references (case-insensitive, word-boundary anchored) and skips when present. When missing, it appends a canonical `Closes #N` line.
 - `issue-ref.sh` bridges the issue-tracker key to a git-remote-native close target. A close reference only auto-closes when it names a git-remote issue number, which differs from the tracker key when the tracker is not the git remote. The GitHub implementation echoes a numeric key as-is (GitHub Issues is the tracker), and for a non-numeric key (e.g. Jira `PROJ-123`) searches for a mirrored GitHub issue, emitting its number or empty. Empty stdout with exit `0` means "nothing on this remote to close" and is not a failure; callers skip the link step.
 - `pr-merge.sh` default method is `--squash`; `--admin` bypasses required reviews and checks. Idempotent: an already-merged PR exits `0` as a no-op.
+- `pr-draft.sh` converts an already-opened PR to draft via `gh pr ready <pr> --undo`. Side-effect only, no stdout. Idempotent: an already-draft PR is a no-op with exit `0`. `-g <owner/repo>` overrides repo detection. Deliberately separate from `pr-create.sh` (which has no `--draft` and rejects unknown args, `pr-create.sh:37`); the `needs-human` label is applied by the caller, not this script.
 - `pr-review-request.sh` tolerates reviewers already on the PR without error.
 - `pr-comment-list.sh` returns all comments (review-line + issue-style) merged into one array; callers discriminate via `.kind`. Rejects any extra argument with exit `1`.
 - `pr-comment-reply.sh` posts a threaded reply to a review comment. Falls back to a regular issue-style PR comment if the threaded-reply API rejects the target id.

--- a/provider/git-remote/github/pr-draft.sh
+++ b/provider/git-remote/github/pr-draft.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert an already-opened PR to draft (wraps `gh pr ready <pr> --undo`).
+# Usage: pr-draft.sh <pr> [-g <owner/repo>]
+# Side-effect only, no stdout. Idempotent: an already-draft PR is a no-op (exit 0).
+# Depends on: gh.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "pr-draft.sh: gh CLI not on PATH; install GitHub CLI and run 'gh auth login'" >&2
+  exit 2
+fi
+
+pr_number=""
+repo_override=""
+repo_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -g) repo_override="${2:?Usage: pr-draft.sh <pr> [-g <owner/repo>]}"; shift 2 ;;
+    -*)
+      echo "pr-draft.sh: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "${pr_number}" ]]; then
+        pr_number="$1"
+      else
+        echo "pr-draft.sh: unexpected argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+: "${pr_number:?Usage: pr-draft.sh <pr> [-g <owner/repo>]}"
+
+if [[ -n "${repo_override}" ]]; then
+  repo_args=(--repo "${repo_override}")
+fi
+
+# `gh pr ready <pr> --undo` converts open -> draft. An already-draft PR makes gh
+# exit non-zero with an "already a draft" message; swallow that one case so the
+# script stays idempotent, and re-raise any other failure.
+err=$(gh pr ready "${pr_number}" ${repo_args[@]+"${repo_args[@]}"} --undo 2>&1) || {
+  if printf '%s' "${err}" | grep -qi 'draft'; then
+    exit 0
+  fi
+  printf '%s\n' "${err}" >&2
+  exit 1
+}

--- a/provider/git-remote/github/pr-draft.sh
+++ b/provider/git-remote/github/pr-draft.sh
@@ -40,13 +40,9 @@ if [[ -n "${repo_override}" ]]; then
   repo_args=(--repo "${repo_override}")
 fi
 
-# `gh pr ready <pr> --undo` converts open -> draft. An already-draft PR makes gh
-# exit non-zero with an "already a draft" message; swallow that one case so the
-# script stays idempotent, and re-raise any other failure.
+# `gh pr ready <pr> --undo` converts open -> draft. gh already exits 0 for an
+# already-draft PR, so idempotency needs no special-casing here.
 err=$(gh pr ready "${pr_number}" ${repo_args[@]+"${repo_args[@]}"} --undo 2>&1) || {
-  if printf '%s' "${err}" | grep -qi 'draft'; then
-    exit 0
-  fi
   printf '%s\n' "${err}" >&2
   exit 1
 }


### PR DESCRIPTION
## Overview

Adds `impl-critique-verify` (opus, read-only): after a `--fix` round it confirms the just-applied findings are resolved and diff-scans for regressions, replacing the full `reviewCycle` re-run that previously followed every fix round. Also adds `pr-draft.sh` (`gh pr ready --undo`) to `git-remote` for a future consumer to convert a PR to draft.

## Problem Statement

- Re-running the full multi-dimension `reviewCycle` after every `--fix` round re-reviews the whole diff even when only a handful of findings were just fixed, inflating cost per round.
- `impl-workflow.mjs` had no cheap way to confirm a fix round actually resolved what it targeted, or to catch a regression it introduced, without paying for a full review cycle again.
- No `git-remote` primitive existed to flip an opened PR back to draft, which a future `needs_human` consumer needs.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

Closes #70
