### PR TITLE
feat(#66): Fan out round-0 gapcheck per module for heavy units

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -27,3 +27,8 @@ Added `impl-critique-verify` (opus, read-only): after a `--fix` round it confirm
 Unit: #65
 Added the `impl-recap` skill (sonnet): builds a per-unit `recap/<slug>/RECAP.md` from the branch diff and `progress/<slug>.md` (Headline + Narrative model-authored, Data/contract + File tree + Key changes + Remaining mechanical), plus `autocode/impl/impl-pr-body.md`, the canonical recipe for a unit code PR body that both `pr-create` and the `pr-hygiene` refresh agent `@`-import so the body never diverges. Extended `design-folder.md` with the living `recap/<slug>/` layout. Fixed `pr-hygiene`'s unit-PR detection to key solely on a committed `recap/<slug>/RECAP.md`, dropping the `progress/<slug>.md` fallback that matched every unit PR and recomposed bodies from a link to a RECAP.md that doesn't exist yet.
 Notes: the Recap-phase invocation itself (wiring it into `impl-workflow.mjs`) is out of scope here; tracked as `recap-phase-wiring`.
+
+## per-module-gapcheck — 2026-07-05
+
+Unit: #66
+Heavy, partitionable units with a large diff now size the diff first (sonnet agent), then run one `impl-gapcheck` agent per module plus a residual integration bucket in parallel, union and de-dupe the gaps, and feed the result into the existing gapfix + recheck loop unchanged. Small-heavy and non-partitionable units keep the single whole-diff agent. `impl-gapcheck/SKILL.md` documents the caller-supplied bounded scope this relies on.

--- a/.autocode/design/0006-workflow-cost-quality/progress/per-module-gapcheck.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/per-module-gapcheck.md
@@ -1,0 +1,3 @@
+# per-module-gapcheck
+
+Epic: 0006-workflow-cost-quality  Branch: feat/66/per-module-gapcheck  Started: 2026-07-05

--- a/autocode/impl/skills/impl-gapcheck/SKILL.md
+++ b/autocode/impl/skills/impl-gapcheck/SKILL.md
@@ -12,6 +12,8 @@ The skill does not redesign or re-plan; it only checks coverage of the supplied 
 
 Enumerate the in-scope plan items. An item is: (a) each per-file task in the plan, plus (b) each module listed under the plan's `## Module partition` section.
 
+A caller may instead supply a bounded scope: a single module's file list plus its module plan item, or a foundation-plus-residual file list (optionally with a checksum to assert). When a bounded scope is supplied, enumerate and check coverage of exactly that scope rather than the whole plan; the output shape is unchanged.
+
 Skip any item the plan marked out-of-scope (the plan carries an out-of-scope list).
 
 For each in-scope item, verify the diff actually implements it. A missing or empty implementation (no corresponding change, or a stub/empty body where the plan required real work) is a gap.

--- a/autocode/impl/skills/impl/scripts/impl-workflow.mjs
+++ b/autocode/impl/skills/impl/scripts/impl-workflow.mjs
@@ -32,6 +32,7 @@ const DIMS = A.dims ? String(A.dims).split(',').map((d) => d.trim()).filter(Bool
 const FANOUT = A.fanout || 'auto' // 'auto' | 'off' | 'on'
 const MAX_FIX_ROUNDS = 2
 const GAP_MAX_ROUNDS = 2
+const GAP_FANOUT_MIN_LINES = 400 // leanness: bump if fan-out fires on small heavy units, drop if large ones slip through
 
 // Fan-out lives here in the workflow runtime to keep heavy work off the
 // launching context, not because nesting is impossible (nested subagents are
@@ -208,6 +209,13 @@ const GAPCHECK_SCHEMA = {
   required: ['complete', 'gaps'],
 }
 
+const DIFF_SIZE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { diff_lines: { type: 'integer' } },
+  required: ['diff_lines'],
+}
+
 const importantOf = (decided) => decided.actionable.filter((a) => a.severity === 'Important')
 
 async function reviewCycle(tag) {
@@ -327,12 +335,66 @@ await logProgress('Execute', `Execute phase: plan implemented and committed${fan
 let gapRoundsUsed = 0
 let remainingGaps = 0
 if (heavy) {
+  // Round-0 coverage sweep. Fan out per module for large, partitionable heavy
+  // units; else one whole-diff agent (small-heavy or non-partitionable fallback).
+  const gapPartitionable = plan.partitionable && plan.modules.length >= 2
+  let diffLines = 0
+  if (gapPartitionable) {
+    // No diff_lines exists at gapcheck time (prep.diff_lines is produced later,
+    // inside reviewCycle). The runtime never shells out, so a sonnet agent sizes.
+    const sized = await agent(
+      inWt + readOnly +
+        `Count changed lines across \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`. Return { diff_lines }.`,
+      { label: 'gap-size', phase: 'GapCheck', model: 'sonnet', schema: DIFF_SIZE_SCHEMA },
+    )
+    diffLines = sized ? sized.diff_lines : 0
+  }
+  const gapFanout = gapPartitionable && diffLines > GAP_FANOUT_MIN_LINES
+
+  let gap
+  if (gapFanout) {
+    const moduleFiles = new Set(plan.modules.flatMap((m) => m.files))
+    const foundationFiles = plan.foundation ? plan.foundation.files : []
+    const residualCount = plan.files_total - new Set([...foundationFiles, ...moduleFiles]).size
+    // Skip integration only when the bucket is provably empty (no foundation and
+    // zero residual). residualCount === 0 here proves union covers files_total
+    // exactly, so the module checksum is asserted by arithmetic, not assumed.
+    const runIntegration = residualCount !== 0 || foundationFiles.length > 0
+    if (!runIntegration) log('gapcheck: empty integration bucket proven (residual 0, no foundation)')
+
+    const moduleChecks = plan.modules.map((m) => () =>
+      agent(
+        inWt + readOnly + follow(skill('impl-gapcheck'),
+          `Check spec completeness for the "${m.name}" module only. Bounded scope: the files ${JSON.stringify(m.files)} plus the "${m.name}" module plan item under \`## Module partition\`. Plan: .autocode/.impl-plan.md. Base ref: ${BASE}. Compute the diff yourself (\`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, untracked via \`git status --porcelain\`) but check coverage of ONLY that scope. Return { complete, gaps }.`),
+        { label: `gapcheck-r0:${m.name}`, phase: 'GapCheck', model: 'opus', schema: GAPCHECK_SCHEMA },
+      ))
+    const integrationCheck = runIntegration ? [() =>
+      agent(
+        inWt + readOnly + follow(skill('impl-gapcheck'),
+          `Check spec completeness for the integration bucket only. Plan: .autocode/.impl-plan.md. Base ref: ${BASE}. Read the plan's per-file task list; the full in-scope planned-file count is ${plan.files_total}. Foundation files: ${JSON.stringify(foundationFiles)}. Union of all module files (checked elsewhere, EXCLUDE them): ${JSON.stringify([...moduleFiles])}. Compute residual = (all in-scope planned files) \\ (foundation U module files). Bounded scope: foundation files U residual files, plus any foundation/residual plan item. Compute the diff yourself (\`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, untracked via \`git status --porcelain\`). Assert the checksum |foundation| + sum(|module files|) + |residual| == ${plan.files_total}; on mismatch (a module file absent from the plan, or a cross-group overlap) surface it as a gap citing the file and plan_item. Return { complete, gaps }.`),
+        { label: 'gapcheck-r0:integration', phase: 'GapCheck', model: 'opus', schema: GAPCHECK_SCHEMA },
+      )] : []
+
+    const results = await parallel(moduleChecks.concat(integrationCheck))
+    // Union gaps, de-dupe on file+plan_item (mirrors the finding de-dupe above).
+    const seenGap = new Set()
+    const gaps = []
+    for (const g of results.filter(Boolean).flatMap((r) => r.gaps || [])) {
+      const key = `${g.file}|${g.plan_item}`
+      if (seenGap.has(key)) continue
+      seenGap.add(key)
+      gaps.push(g)
+    }
+    gap = { complete: gaps.length === 0, gaps }
+  } else {
+    gap = await agent(
+      inWt + readOnly + follow(skill('impl-gapcheck'),
+        `Check spec completeness. Plan: .autocode/.impl-plan.md. Diff: compute it yourself via \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`. Return { complete, gaps }.`),
+      { label: 'gapcheck-r0', phase: 'GapCheck', model: 'opus', schema: GAPCHECK_SCHEMA },
+    )
+  }
+
   let gapRound = 0
-  let gap = await agent(
-    inWt + readOnly + follow(skill('impl-gapcheck'),
-      `Check spec completeness. Plan: .autocode/.impl-plan.md. Diff: compute it yourself via \`git diff ${BASE}...HEAD\`, \`git diff HEAD\`, and untracked files from \`git status --porcelain\`. Return { complete, gaps }.`),
-    { label: 'gapcheck-r0', phase: 'GapCheck', model: 'opus', schema: GAPCHECK_SCHEMA },
-  )
   while (gap && !gap.complete && gap.gaps.length && gapRound < GAP_MAX_ROUNDS) {
     gapRound += 1
     log(`gap round ${gapRound}: ${gap.gaps.length} gap(s)`)


### PR DESCRIPTION
## Overview

Fans out the round-0 GapCheck for heavy, partitionable units with a large diff: one `impl-gapcheck` agent per module plus a residual integration bucket, run in parallel, unioned and de-duped, instead of one agent reading the whole diff.

## Problem Statement

- A single agent re-reading a large multi-module diff for round-0 gap coverage burns context and cost proportional to the whole diff, even though each module's coverage check only needs that module's slice.
- Small-heavy and non-partitionable units do not have enough surface area to justify fan-out overhead.

## Implementation Notes

- `impl-workflow.mjs`: added `GAP_FANOUT_MIN_LINES` (400). For partitionable heavy units (`plan.partitionable && plan.modules.length >= 2`), a sonnet `gap-size` agent counts changed lines first; fan-out triggers only when `diff_lines > GAP_FANOUT_MIN_LINES`.
- Fan-out path: one opus `impl-gapcheck` per module (bounded to that module's files + plan item) plus one integration-bucket check (foundation files + residual, with a files-total checksum assertion), run via `parallel`. The residual-only-when-nonempty check (`runIntegration`) skips the integration agent when the module/foundation union provably covers `files_total`.
- Gaps from all agents are unioned and de-duped on `file+plan_item`, then fed into the existing `gapRound`/`GAP_MAX_ROUNDS` fix loop unchanged.
- Small-heavy and non-partitionable units keep the single whole-diff `impl-gapcheck` call (else branch), so behavior there is unchanged.
- `impl-gapcheck/SKILL.md` documents the caller-supplied bounded scope (single module's files + module plan item, or foundation+residual) that the fan-out callers rely on.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately

Closes #66
