### PR TITLE
feat(#68): Append recap-aware-review rollup to epic PROGRESS.md

### DIFF
--- a/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
+++ b/.autocode/design/0006-workflow-cost-quality/PROGRESS.md
@@ -37,3 +37,8 @@ Heavy, partitionable units with a large diff now size the diff first (sonnet age
 
 Unit: #69
 Wired the Recap phase into `impl-workflow.mjs`: a sonnet `impl-recap` dispatch now runs after Verify and before Push, building `recap/<slug>/RECAP.md` with SHA-pinned blob links at a self-captured HEAD. Added a converge gate that holds the just-opened PR in draft with a `needs-human` label and a marking comment when important findings or gaps remain unresolved after the fix loop. Hygiene now runs conditionally: a markdown/README predicate (`isHygieneRelevant`) checks `push.hygiene_files` and skips the `pr-hygiene` dispatch entirely when no doc-relevant path changed, logging the skip instead. `impl-push/SKILL.md`'s commit step now names the `recap/<slug>/` artifacts explicitly alongside `PROGRESS.md` and `progress/<slug>.md`.
+
+## recap-aware-review — 2026-07-05
+
+Unit: #68
+Made `pr-review` resolve RECAP.md-anchored review comments to the concrete source `file:line` via the RECAP's SHA-pinned blob links in `## Key changes` before triage, falling back to discussion-band treatment when the anchor is ambiguous (outside `## Key changes`, no nearby blob link, or multiple candidate blobs). In a unit worktree, fix-band findings now go to `impl-execute --fix` instead of being edited and committed inline, so the minimal-edit and commit conventions stay owned by `impl-execute`; standalone use on the default branch is unchanged.

--- a/.autocode/design/0006-workflow-cost-quality/progress/recap-aware-review.md
+++ b/.autocode/design/0006-workflow-cost-quality/progress/recap-aware-review.md
@@ -1,0 +1,3 @@
+# recap-aware-review
+
+Epic: 0006-workflow-cost-quality  Branch: feat/68/recap-aware-review  Started: 2026-07-05

--- a/autocode/pr/skills/pr-review/SKILL.md
+++ b/autocode/pr/skills/pr-review/SKILL.md
@@ -15,6 +15,12 @@ Triage and apply PR review comments.
 2. Fetch comments: `provider/run.sh git-remote pr-comment-list <pr>`.
 3. Triage each comment. Score each one 0-100: confidence that the comment identifies a real issue.
 
+   A RECAP-anchored comment is a `kind:"review"` comment whose `path` basename is `RECAP.md`. Resolve it to the concrete source `file:line` before scoring:
+
+   - The RECAP lives in the worktree at the comment's `path` (`recap/<slug>/RECAP.md`); read it locally, falling back to `git show <sha>:<path>` if not on disk. Its `## Key changes` section holds SHA-pinned blob excerpts; map the anchored `line` to the governing SHA-pinned blob URL and parse the source `path` and `#L<n>` out of it (`.../blob/<sha>/<path>#L<start>`). The anchor contract itself is owned by `autocode/design/design-folder.md` (`## recap/<slug>/`); consult it, don't restate it here.
+   - Unambiguous single-blob match: use the resolved `file:line` as the comment's effective location and triage it like any other comment below.
+   - Ambiguous (anchored outside `## Key changes`, no nearby blob link, or multiple candidate blobs): treat as a discussion-band comment regardless of score (defer under `--auto`, reply-for-clarification interactively). Never guess a location to edit.
+
    Human reviewers (trust by default):
 
    | Score | Action |
@@ -33,7 +39,9 @@ Triage and apply PR review comments.
 
    Under `--auto`, the discussion band (`20-49` human / `30-69` bot) does not reply asking for clarification: defer it. Count it toward `deferred`, leave the thread for a human, and set `needs_human`. The fix band and the spurious-resolve band are unchanged: high-confidence items still fix-and-resolve, low-confidence items still resolve with an explanation comment.
 
-4. Apply valid fixes. Group related fixes. Delegate commits to the `git-commit` skill. Never `--no-verify`.
+4. Apply valid fixes:
+   - In a unit worktree (`git rev-parse --abbrev-ref HEAD` is not the repo's default branch): hand the fix-band findings to `impl-execute --fix`. Format each surviving finding as a `file:line` plus the required change (for a RECAP-anchored fix, the resolved source location and a change derived from the comment body). Read `@~/.autocode/autocode/impl/skills/impl-execute/SKILL.md` and follow it with `--fix`; it owns the minimal edit and the `git-commit` delegation. Do not inline-edit or commit here.
+   - Outside a unit worktree (standalone use on the default branch): apply fixes inline as before. Group related fixes. Delegate commits to the `git-commit` skill. Never `--no-verify`.
 5. Reply and resolve threads:
    - `provider/run.sh git-remote pr-comment-reply <pr> <comment-id> "<text>"` for each comment that needs a reply.
    - `provider/run.sh git-remote pr-thread-list <pr>` to list unresolved thread ids.
@@ -47,6 +55,7 @@ Triage and apply PR review comments.
 - Never `--no-verify` on commits.
 - Never resolve a thread without an explanation comment.
 - Under `--auto`, the no-explanation-before-resolve and never-`--no-verify` rules still hold.
+- In a unit worktree, apply fix-band findings only via `impl-execute --fix`; never inline-edit or commit directly there.
 
 ## Terminal step (--auto only)
 


### PR DESCRIPTION
## Overview

Makes `pr-review` RECAP-aware: it resolves `RECAP.md`-anchored review comments to the concrete source `file:line` via the RECAP's SHA-pinned blob links before triage, and in a unit worktree it delegates fix-band apply to `impl-execute --fix` instead of editing and committing inline.

## Problem Statement

- Review comments left on a PR's `RECAP.md` view anchor to lines in the recap doc, not the real source, so `pr-review` had no way to locate the actual code to fix.
- `pr-review` previously edited and committed fixes inline, duplicating the minimal-edit and commit conventions already owned by `impl-execute`.

## Implementation Notes

- A `kind:"review"` comment whose `path` basename is `RECAP.md` is resolved before scoring: read the RECAP (locally or via `git show <sha>:<path>`), find the governing SHA-pinned blob link in `## Key changes`, and parse the source `path`/`#L<n>` out of it. Unambiguous matches triage as usual; ambiguous anchors (outside `## Key changes`, no nearby blob link, multiple candidates) are treated as discussion-band regardless of score, never guessed.
- Apply step now branches on worktree: in a unit worktree (not the default branch), fix-band findings are handed to `impl-execute --fix` as `file:line` plus the required change; outside a unit worktree, fixes are still applied and committed inline as before.

## Checklist (if applicable)

* [x] Mention to the original issue
* [x] PR name with proper formatting
    * Check `.github/workflows/pr-autofix-title.yml` for more info
* [ ] Test case(s) to:
    * Demonstrate the difference of before/after
    * Demonstrate the flow of abstract/conceptual models with a concrete implementation
* [x] Documentation added or modified appropriately


resolves #68